### PR TITLE
fix(alpha): publish vehicle events from pos-vehicle-inventory

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -231,6 +231,14 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-vehicle-inventory:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # This service owns the vehicle aggregate and is the only publisher of
+    # vehicle.vehicle.updated on vehicle.events.v1. With the flag off nothing is
+    # written to its outbox, so every ext_vehicle replica downstream stays empty:
+    # pos-shop-manager rejects appointments with VEHICLE_NOT_FOUND, and
+    # pos-customer's own vehicle reads return an empty list for a vehicle that
+    # exists.
+    environment:
+      POS_VEHICLE_INVENTORY_KAFKA_ENABLED: "true"
 
   pos-warranty:
     image: ${ECR_REGISTRY}/durion/pos-warranty:${BACKEND_TAG}

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleRegistryController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleRegistryController.java
@@ -4,17 +4,21 @@ import com.positivity.events.EmitEvent;
 import com.positivity.shared.dto.CreateVehicleRequest;
 import com.positivity.shared.dto.UpdateVehicleRequest;
 import com.positivity.shared.dto.VehicleResponse;
+import com.positivity.vehicle.internal.dto.VehicleFactReplayResultDto;
+import com.positivity.vehicle.service.VehicleFactReplayService;
 import com.positivity.vehicle.service.VehicleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,6 +32,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -67,6 +72,7 @@ public class VehicleRegistryController {
             """;
 
     private final VehicleService vehicleService;
+    private final VehicleFactReplayService vehicleFactReplayService;
 
     @Operation(operationId = "createVehicle", summary = "Create vehicle", description = """
                     Creates an active vehicle registry record after validating and normalizing the VIN, which must \
@@ -222,5 +228,48 @@ public class VehicleRegistryController {
             @Parameter(description = "Vehicle UUID", required = true) @PathVariable @NotNull UUID vehicleId) {
         vehicleService.deleteVehicle(vehicleId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN"})
+    @PostMapping("/facts/replay")
+    @EmitEvent(id = "VEHICLE_FACT_REPLAY", apiVersion = "1")
+    @Operation(
+            operationId = "replayVehicleFacts",
+            summary = "Re-emit Vehicle Facts for Replica Consumers",
+            description = """
+                    Re-publishes vehicle.vehicle.updated facts for one bounded page of vehicles so that \
+                    event-fed replicas in other modules can be seeded or repaired, returning what it emitted \
+                    and a cursor for the next page.
+                    Use this tool to fill a consumer's replica after publication was enabled on an environment \
+                    that already held vehicles, or after a consumer outage longer than broker retention; do not \
+                    use the outbox replay for that, which re-queues only rows already written and therefore \
+                    cannot reach vehicles whose facts were never produced.
+                    Preconditions: Kafka publication must be enabled, or the facts queue in the outbox and reach \
+                    nobody; replayed facts are indistinguishable from live ones, so consumers apply them through \
+                    their normal path and their stale guard prevents an older fact regressing newer state.
+                    Required inputs: none; afterVehicleId resumes a previous page, updatedSince restricts to \
+                    vehicles changed at or after an instant, and limit bounds the page at 1000.
+                    Emits a VEHICLE_FACT_REPLAY event and queues one vehicle fact per vehicle in the page; no \
+                    vehicle state changes.
+                    Returns 200 with complete=true and a null cursor once the last vehicle is reached, and 400 \
+                    when a parameter is malformed.
+                    """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "What this page emitted and where to resume.",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = VehicleFactReplayResultDto.class)))
+    public ResponseEntity<VehicleFactReplayResultDto> replayVehicleFacts(
+            @Parameter(description = "Resume after this vehicle id.") @RequestParam(required = false)
+                    UUID afterVehicleId,
+            @Parameter(description = "Only vehicles updated at or after this instant.") @RequestParam(required = false)
+                    Instant updatedSince,
+            @Parameter(description = "Page size, 1-1000.") @RequestParam(defaultValue = "500") int limit) {
+        return ResponseEntity.ok(vehicleFactReplayService.replayPage(afterVehicleId, updatedSince, limit));
     }
 }

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/VehicleFactReplayResultDto.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/VehicleFactReplayResultDto.java
@@ -1,0 +1,28 @@
+package com.positivity.vehicle.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Outcome of one page of a vehicle-fact replay. */
+@Schema(description = "Outcome of one page of a vehicle-fact replay.")
+public record VehicleFactReplayResultDto(
+        @Schema(description = "Facts published by this call.", example = "500")
+        int emitted,
+
+        @Schema(
+                description = "Cursor for the next page; null when the last vehicle was reached.",
+                example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+        @Nullable
+        UUID nextAfterId,
+
+        @Schema(description = "True when no further pages remain for this filter.", example = "false")
+        boolean complete,
+
+        @Schema(description = "The updatedSince filter this page ran under, echoed back.") @Nullable
+        Instant updatedSince,
+
+        @Schema(description = "When this page began.") @NonNull
+        Instant startedAt) {}

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/repository/VehicleRecordRepository.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/repository/VehicleRecordRepository.java
@@ -1,10 +1,12 @@
 package com.positivity.vehicle.internal.repository;
 
 import com.positivity.vehicle.internal.entity.VehicleRecord;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +25,20 @@ public interface VehicleRecordRepository extends JpaRepository<VehicleRecord, UU
     List<VehicleRecord> findByAccountId(@NonNull UUID accountId);
 
     boolean existsByVinNormalizedAndIsActiveTrue(@NonNull String vinNormalized);
+
+    /**
+     * One page of vehicles for a fact replay, ordered by id so a cursor can resume.
+     *
+     * <p>Reads the vehicles themselves rather than the outbox: a replay exists precisely for the
+     * rows whose facts were never written, so replaying the outbox would re-emit only what already
+     * reached consumers. Mirrors {@code ProductRepository.findForReplay} in pos-catalog.
+     */
+    @Query("""
+      SELECT v FROM VehicleRecord v
+      WHERE (:afterId IS NULL OR v.vehicleId > :afterId)
+        AND (:updatedSince IS NULL OR v.updatedAt >= :updatedSince)
+      ORDER BY v.vehicleId ASC
+      """)
+    List<VehicleRecord> findForReplay(
+            @Param("afterId") UUID afterId, @Param("updatedSince") Instant updatedSince, Pageable pageable);
 }

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehicleFactReplayServiceImpl.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehicleFactReplayServiceImpl.java
@@ -1,0 +1,71 @@
+package com.positivity.vehicle.internal.service;
+
+import com.positivity.vehicle.internal.config.VehicleEventPublisher;
+import com.positivity.vehicle.internal.dto.VehicleFactReplayResultDto;
+import com.positivity.vehicle.internal.entity.VehicleRecord;
+import com.positivity.vehicle.internal.repository.VehicleRecordRepository;
+import com.positivity.vehicle.service.VehicleFactReplayService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Re-publishes {@code vehicle.vehicle.updated} for one bounded page of vehicles.
+ *
+ * <p>Exists because enabling publication only covers what changes afterwards. Vehicles written while
+ * {@code POS_VEHICLE_INVENTORY_KAFKA_ENABLED} was false have no outbox rows at all, so the existing
+ * outbox replay - which re-queues rows already in that table - cannot reach them, and every
+ * ext_vehicle replica downstream stays missing them until someone happens to edit each vehicle.
+ * This reads the vehicles themselves instead. Mirrors pos-catalog's product-fact replay.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VehicleFactReplayServiceImpl implements VehicleFactReplayService {
+
+    /** Bound on one call, so a mistyped limit cannot turn a replay into a broker flood. */
+    public static final int MAX_LIMIT = 1000;
+
+    private final VehicleRecordRepository vehicleRecordRepository;
+    private final VehicleEventPublisher vehicleEventPublisher;
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    @Transactional
+    public VehicleFactReplayResultDto replayPage(
+            @Nullable UUID afterVehicleId, @Nullable Instant updatedSince, int limit) {
+        int pageSize = Math.min(Math.max(limit, 1), MAX_LIMIT);
+        Instant startedAt = Instant.now(clock);
+
+        List<VehicleRecord> vehicles =
+                vehicleRecordRepository.findForReplay(afterVehicleId, updatedSince, PageRequest.of(0, pageSize));
+
+        for (VehicleRecord vehicle : vehicles) {
+            vehicleEventPublisher.publishVehicleUpdated(vehicle);
+        }
+
+        // A short page means the end was reached: the query is ordered by id and bounded by the
+        // cursor, so there is nothing after it for this filter.
+        boolean complete = vehicles.size() < pageSize;
+        UUID nextAfterId =
+                complete || vehicles.isEmpty() ? null : vehicles.getLast().getVehicleId();
+
+        log.info(
+                "Replayed {} vehicle facts (after={}, updatedSince={}, complete={})",
+                vehicles.size(),
+                afterVehicleId,
+                updatedSince,
+                complete);
+
+        return new VehicleFactReplayResultDto(vehicles.size(), nextAfterId, complete, updatedSince, startedAt);
+    }
+}

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/service/VehicleFactReplayService.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/service/VehicleFactReplayService.java
@@ -1,0 +1,14 @@
+package com.positivity.vehicle.service;
+
+import com.positivity.vehicle.internal.dto.VehicleFactReplayResultDto;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Re-emits vehicle facts so event-fed replicas can be seeded or repaired. */
+public interface VehicleFactReplayService {
+
+    @NonNull
+    VehicleFactReplayResultDto replayPage(@Nullable UUID afterVehicleId, @Nullable Instant updatedSince, int limit);
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleRegistryControllerWebMvcTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleRegistryControllerWebMvcTest.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.positivity.shared.dto.VehicleResponse;
 import com.positivity.vehicle.config.WebMvcTestSecurityConfig;
+import com.positivity.vehicle.service.VehicleFactReplayService;
 import com.positivity.vehicle.service.VehicleService;
 import jakarta.persistence.EntityNotFoundException;
 import java.net.URI;
@@ -71,6 +72,9 @@ class VehicleRegistryControllerWebMvcTest {
 
     @MockitoBean
     VehicleService vehicleService;
+
+    @MockitoBean
+    VehicleFactReplayService vehicleFactReplayService;
 
     private static VehicleResponse vehicle() {
         return VehicleResponse.builder()

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehicleFactReplayServiceImplTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehicleFactReplayServiceImplTest.java
@@ -1,0 +1,104 @@
+package com.positivity.vehicle.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.vehicle.internal.config.VehicleEventPublisher;
+import com.positivity.vehicle.internal.dto.VehicleFactReplayResultDto;
+import com.positivity.vehicle.internal.entity.VehicleRecord;
+import com.positivity.vehicle.internal.repository.VehicleRecordRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * The replay reads vehicles, not the outbox.
+ *
+ * <p>That distinction is the whole point: the rows this exists to repair are the ones whose facts
+ * were never written, so an outbox-sourced replay would emit nothing for them however often it ran.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Vehicle fact replay re-emits from the vehicles themselves")
+class VehicleFactReplayServiceImplTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-23T12:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private VehicleRecordRepository vehicleRecordRepository;
+
+    @Mock
+    private VehicleEventPublisher vehicleEventPublisher;
+
+    private VehicleFactReplayServiceImpl service() {
+        return new VehicleFactReplayServiceImpl(vehicleRecordRepository, vehicleEventPublisher, CLOCK);
+    }
+
+    private static VehicleRecord vehicle(UUID id) {
+        VehicleRecord record = new VehicleRecord();
+        record.setVehicleId(id);
+        return record;
+    }
+
+    @Test
+    @DisplayName("publishes one fact per vehicle and reports completion on a short page")
+    void publishesOneFactPerVehicle() {
+        UUID first = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+        UUID second = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+        when(vehicleRecordRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(List.of(vehicle(first), vehicle(second)));
+
+        VehicleFactReplayResultDto result = service().replayPage(null, null, 500);
+
+        verify(vehicleEventPublisher).publishVehicleUpdated(argThatHasId(first));
+        verify(vehicleEventPublisher).publishVehicleUpdated(argThatHasId(second));
+        assertThat(result.emitted()).isEqualTo(2);
+        assertThat(result.complete())
+                .as("a page shorter than the limit is the end")
+                .isTrue();
+        assertThat(result.nextAfterId()).isNull();
+    }
+
+    @Test
+    @DisplayName("hands back a cursor when the page is full")
+    void returnsCursorOnFullPage() {
+        UUID first = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+        UUID last = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+        when(vehicleRecordRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(List.of(vehicle(first), vehicle(last)));
+
+        VehicleFactReplayResultDto result = service().replayPage(null, null, 2);
+
+        assertThat(result.complete()).isFalse();
+        assertThat(result.nextAfterId())
+                .as("resume after the last vehicle of the page")
+                .isEqualTo(last);
+    }
+
+    @Test
+    @DisplayName("clamps the page size so a mistyped limit cannot flood the broker")
+    void clampsLimit() {
+        when(vehicleRecordRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        service().replayPage(null, null, 10_000);
+
+        verify(vehicleRecordRepository)
+                .findForReplay(isNull(), isNull(), eq(Pageable.ofSize(VehicleFactReplayServiceImpl.MAX_LIMIT)));
+    }
+
+    private static VehicleRecord argThatHasId(UUID id) {
+        return org.mockito.ArgumentMatchers.argThat(record -> record != null && id.equals(record.getVehicleId()));
+    }
+}


### PR DESCRIPTION
## Symptom

With #1467 deployed, appointment creation moved past `CUSTOMER_NOT_FOUND` and failed one step later:

```
POST /shop-manager/v1/appointments
404 {"code":"VEHICLE_NOT_FOUND","message":"CRM vehicle not found: 01a02ee7-2573-7467-9b0e-bad211366e51"}
```

The vehicle exists — the registry returned that id seconds earlier.

## Cause

pos-shop-manager validates `crmVehicleId` against `ext_vehicle`, fed by `VehicleEventsListener` from `vehicle.events.v1`. pos-vehicle-inventory owns the aggregate and is the only publisher of `vehicle.vehicle.updated`, but:

```yaml
kafka:
  enabled: ${POS_VEHICLE_INVENTORY_KAFKA_ENABLED:false}
```

The default is `false` and the alpha override never set it, so nothing has ever been written to that outbox and every `ext_vehicle` replica downstream is empty. That also explains a symptom I had been treating as unrelated: `listVehiclesForCustomer` and the party snapshot return an empty list for a vehicle that demonstrably exists — pos-customer serves vehicle reads from the same replica.

## What this changes

**1. The flag, for alpha** — matching the twelve services already flipped there. #1467 turned on the consumer side for customer facts; this turns on the producer the vehicle half needs.

**2. A replay that can actually reach the existing rows.** Enabling publication only covers what changes afterwards. Vehicles written while the flag was false have no `event_outbox` rows at all, and `OutboxReplayService` re-queues rows already in that table — so it cannot reach them, and they would stay invisible until somebody happened to edit each one.

`POST /v1/vehicle-registry/facts/replay` reads the **vehicles** and publishes `vehicle.vehicle.updated` for a bounded page, with a cursor to resume. Same shape pos-catalog already uses for product facts (`ProductFactReplayService`, `POST /v1/products/facts/replay`), including the 1000-row ceiling so a mistyped limit cannot turn a repair into a broker flood. ADMIN only — an operational repair, not an ordinary write.

Replayed facts are indistinguishable from live ones, so consumers apply them through their normal path and their stale guard prevents an older fact regressing newer state.

## Deployment order

1. Deploy with `POS_VEHICLE_INVENTORY_KAFKA_ENABLED=true`, so new mutations publish.
2. Run the replay once to seed what already exists:

```bash
curl -X POST "$GATEWAY/vehicle-inventory/v1/vehicle-registry/facts/replay?limit=1000" \
  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'X-API-Version: 1'
# repeat with ?afterVehicleId=<nextAfterId> until complete=true
```

3. Confirm: `GET /customer/v1/crm/{partyId}/vehicles` returns a vehicle registered before the flag was on.

## Contract

This adds one endpoint, `POST /v1/vehicle-registry/facts/replay`, and one response DTO. Per `BACKEND_CONTRACT_GUIDE.md` (domain: vehicle), it follows the shape already established for the equivalent catalog operation: an operationId (`replayVehicleFacts`), a full tool-style description covering preconditions, inputs, emitted events and status codes, and a documented 200 body. It emits `VEHICLE_FACT_REPLAY` and changes no vehicle state, so it is additive for every existing consumer.

## Verification

- `docker compose config -q` clean for the base file and the alpha merge
- pos-vehicle-inventory suite: **151 tests, 0 failures, 0 errors** — new tests cover one fact per vehicle with completion on a short page, a cursor on a full page, and the clamped limit
- Found by the appointments suite, whose A1 books an appointment for a vehicle it registers moments earlier. I'll re-run A–D against alpha once this deploys.

## Related

The shape of these two is worth noting: a replica-backed validator whose feed is switched off rejects everything, and the rejection names the *caller's* data rather than the disabled consumer. #1458 tracks the green-health half. A startup warning when a service registers a replica listener whose feed is disabled would have made both a one-minute diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
