### PR TITLE
Platform global exception handling: ApiError envelope + correlation id on every unmapped exception (issue #1471)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ pos-api-gateway  (JWT validation, path rewrite /{domain}/vN/.., permission bitse
 |---|---|
 | `pos-events` | `@EmitEvent` AOP annotation + event publishing to `pos-event-receiver` |
 | `pos-shared-dtos` | Shared request/response/error DTOs (`ApiError`, etc.) |
-| `pos-security-common` | Shared security utilities |
+| `pos-web-common` | Auto-configured global exception handler (`ApiError` envelope + correlation id fallback) |
+| `pos-security-common` | Shared security utilities (re-exports `pos-web-common`) |
 | `pos-tax-common` | Shared tax DTOs/enums |
 | `pos-bulk-ingest-lib` / `pos-document-helper` | Bulk import / document generation helpers |
 | `pos-dependencies` | Internal BOM for internal artifact versions |

--- a/docs/ERROR_ENVELOPE.md
+++ b/docs/ERROR_ENVELOPE.md
@@ -142,6 +142,27 @@ All Durion backend REST APIs return a consistent `ApiError` JSON object for non-
 
 ---
 
+## Platform Fallback Codes (pos-web-common)
+
+Emitted by the shared `GlobalApiExceptionHandler` (auto-configured from `pos-web-common`, see
+`docs/adr-0056-global-exception-handling.md`) when no service-specific advice mapped the exception.
+Any service may therefore return these in addition to its module codes below.
+
+| Code | Status | Description |
+|------|--------|-------------|
+| `DUPLICATE_RESOURCE` | 409 | Unique-constraint violation (SQLSTATE 23505); message names the constraint |
+| `REFERENCE_CONFLICT` | 409 | Foreign-key constraint violation |
+| `DATA_INTEGRITY_VIOLATION` | 409 | Other database integrity violation |
+| `MISSING_REQUIRED_VALUE` | 422 | Not-null violation on a client-supplied column; message names the column |
+| `CONSTRAINT_VIOLATION` | 422 | Check-constraint violation; message names the constraint |
+| `VALIDATION_ERROR` | 400 | Bean-validation failure (with `fieldErrors`) or malformed request |
+| `NOT_FOUND` | 404 | No endpoint for the requested path |
+| `METHOD_NOT_ALLOWED` | 405 | HTTP method not supported for this path |
+| `NOT_ACCEPTABLE` / `PAYLOAD_TOO_LARGE` / `UNSUPPORTED_MEDIA_TYPE` / `REQUEST_REJECTED` | 406/413/415/other 4xx | Framework-rejected request |
+| `INTERNAL_ERROR` | 500 | Unhandled exception, or a not-null violation on a server-populated audit column; stack trace logged at ERROR against the `correlationId` |
+
+---
+
 ## Common Error Codes by Module
 
 ### pos-order

--- a/docs/adr-0056-global-exception-handling.md
+++ b/docs/adr-0056-global-exception-handling.md
@@ -2,9 +2,9 @@
 
 **Status:** PROPOSED **Date:** 2026-08-23 **Deciders:** Architecture, Backend Lead, API Lead **Affected Issues:** durion-positivity-backend#1471
 
-> **Canonical home:** `durion/docs/adr/0056-global-exception-handling.adr.md`. This copy lives in
-> durion-positivity-backend because it was authored alongside the implementing change; move it into the
-> durion ADR directory (with the `.adr.md` suffix) on acceptance.
+> **Canonical home:** `durion/docs/adr/0056-platform-global-exception-handling.adr.md`, proposed in
+> louisburroughs/durion#403. This copy lives in durion-positivity-backend because it was authored
+> alongside the implementing change, mirroring the existing local copies of ADR-0042/0044.
 
 ---
 

--- a/docs/adr-0056-global-exception-handling.md
+++ b/docs/adr-0056-global-exception-handling.md
@@ -1,0 +1,168 @@
+# ADR-0056: Platform Global Exception Handling and Persistence Error Mapping
+
+**Status:** PROPOSED **Date:** 2026-08-23 **Deciders:** Architecture, Backend Lead, API Lead **Affected Issues:** durion-positivity-backend#1471
+
+> **Canonical home:** `durion/docs/adr/0056-global-exception-handling.adr.md`. This copy lives in
+> durion-positivity-backend because it was authored alongside the implementing change; move it into the
+> durion ADR directory (with the `.adr.md` suffix) on acceptance.
+
+---
+
+## Context
+
+ADR-0017 requires every non-2xx response to carry the `ApiError` envelope (`code`, `message`, `status`,
+`timestamp`, `correlationId`) and to echo/generate `X-Correlation-Id`. In practice the requirement only
+held for exceptions someone had explicitly mapped: when an exception reached a controller without a
+matching `@ExceptionHandler`, Spring's default error page answered instead — a bare 500 with none of the
+envelope. Issue durion-positivity-backend#1471 documented three production bugs in two days that all
+presented as this indistinguishable bare 500 (a `@Lob` read outside a transaction, a NOT NULL violation
+from a missing `AuditorAware`, and a UNIQUE violation on customer numbers), each costing hours that a
+mapped status plus a correlation id would have collapsed into minutes.
+
+Two structural gaps produced this:
+
+1. No service mapped `DataIntegrityViolationException`, so every unique/not-null/check violation became
+   an unmapped 500 despite ADR-0017 §2 already classifying duplicate-unique constraints as `409`.
+2. Only a minority of services had a catch-all `@ExceptionHandler(Exception.class)`. ADR-0017's
+   implementation notes said to centralize mapping in "global handlers" but mandated no mechanism, so
+   seven-plus services hand-rolled advices that each covered a different subset.
+
+---
+
+## Decision
+
+### 1. Platform catch-all is mandatory and shared
+
+**Decision:** ✅ **Resolved** — Every controller-bearing `pos-*` servlet module MUST have a catch-all
+exception handler that returns the ADR-0017 envelope with a correlation id and logs the stack trace at
+ERROR keyed by that correlation id (ADR-0046 §6 structured logging carries the same id).
+
+The platform implementation is `GlobalApiExceptionHandler` in the shared **pos-web-common** module,
+registered via Spring Boot auto-configuration at `Ordered.LOWEST_PRECEDENCE`:
+
+- Service-specific `@ControllerAdvice` classes keep precedence for every exception type they map;
+  the shared advice only sees what nothing else handled.
+- Spring Security exceptions (`AccessDeniedException`, `AuthenticationException`) are rethrown so the
+  security filter chain renders its 401/403 — the advice never converts them to 500s.
+- Spring MVC's own `ErrorResponse` exceptions (unknown path, unsupported method/media type, malformed
+  request) keep their framework status and gain the envelope, rather than collapsing to 500.
+- 500 bodies stay generic (`INTERNAL_ERROR` / "Unexpected error occurred"); the correlation id is the
+  diagnostic handle. Rejected data values are never echoed; only constraint/column identifiers may be
+  named on 409/422.
+- Opt-out for tests or special cases: `pos.web.global-exception-handler.enabled=false`, or define a
+  module-local `GlobalApiExceptionHandler` bean (the auto-configuration backs off).
+
+### 2. Central `DataIntegrityViolationException` mapping
+
+**Decision:** ✅ **Resolved** — The shared advice classifies integrity violations by the SQLSTATE of the
+underlying `SQLException` (class 23 is standardized across PostgreSQL and H2) and maps:
+
+| Violation | SQLSTATE | Status | Code |
+| --- | --- | --- | --- |
+| Unique | `23505` | **409** | `DUPLICATE_RESOURCE` |
+| Not-null, client-supplied column | `23502` | **422** | `MISSING_REQUIRED_VALUE` |
+| Not-null, server-populated audit column | `23502` | **500** (enveloped, ERROR-logged) | `INTERNAL_ERROR` |
+| Check | `23514`/`23513` | **422** | `CONSTRAINT_VIOLATION` |
+| Foreign key | `23503`/`23506` | **409** | `REFERENCE_CONFLICT` |
+| Other class-23 | `23xxx` | **409** | `DATA_INTEGRITY_VIOLATION` |
+| Unclassifiable | — | **500** (enveloped, ERROR-logged) | `INTERNAL_ERROR` |
+
+The 409-for-unique row restates ADR-0017 §2 (duplicate-unique constraints are stateful collisions). The
+not-null split is the new decision this ADR adds: a NOT NULL violation on a server-populated audit column
+(`created_by`, `updated_at`, …) means the *server* failed to populate it (e.g. a missing `AuditorAware`,
+the #1464 bug) — telling the client `422` would misdirect the retry, so it stays a 500, but an enveloped,
+correlated, ERROR-logged one. Client-supplied columns get `422`, consistent with ADR-0017's boundary
+(the payload was structurally valid; the domain data policy rejected it). Constraint and column names are
+extracted best-effort from the driver message; data values are never included.
+
+### 3. Shared advice lives in pos-web-common; pos-security-common re-exports it
+
+**Decision:** ✅ **Resolved** — The advice lives in a new shared library **pos-web-common**
+(`com.positivity.web.common`), not pos-security-common, because services without Spring Security
+(pos-event-receiver, the vehicle-reference proxies) must be able to consume it without inheriting
+Spring Boot's security auto-configuration lockdown. pos-security-common declares a compile dependency on
+pos-web-common, so all gateway-secured services (the overwhelming majority) receive the catch-all with no
+pom change; the few non-secured servlet services depend on pos-web-common directly.
+
+### 4. Enforced rather than remembered
+
+**Decision:** ✅ **Resolved** — pos-archunit's `GlobalExceptionHandlerEnforcementTest` fails the build for
+any module that declares `@RestController` endpoints but neither depends on pos-web-common (directly or
+via pos-security-common) nor declares its own `@ExceptionHandler(Exception.class)` advice.
+**pos-api-gateway is exempt**: it is a WebFlux application where the servlet advice does not apply, and
+gateway error rendering remains its own concern (ADR-0011).
+
+---
+
+## Alternatives Considered
+
+1. **Copy a catch-all advice into every service**: Rejected — seven independent copies are how the
+   current drift happened; the copies already disagree on envelope shape (ProblemDetail vs ApiError).
+2. **Advice in pos-security-common directly**: Rejected — pulls `spring-boot-starter-security`
+   transitively into services that have no security configuration, activating Boot's default lockdown.
+3. **Advice in pos-shared-dtos**: Rejected — that module is deliberately dependency-light DTOs; web MVC
+   machinery does not belong there.
+4. **Map all not-null violations to 422**: Rejected — a NOT NULL failure on a server-populated audit
+   column is a server defect; a 4xx would tell the client to fix a request that was correct.
+5. **Enforce via Spring context tests per service**: Rejected — heavier and slower than a single
+   reactor-level source/pom scan, with no additional guarantee.
+
+---
+
+## Consequences
+
+### Positive ✅
+
+- ✅ No exception can leave a servlet service as Spring's bare default page: worst case is an enveloped,
+  correlated, ERROR-logged 500
+- ✅ Unique-constraint collisions surface as retryable 409s; not-null/check violations as 422s — SDK
+  integration suites can assert exact statuses on negative paths
+- ✅ One implementation to evolve; service advices keep full precedence for domain-specific mapping
+- ✅ The requirement is build-enforced, not convention-enforced
+
+### Negative ⚠️
+
+- ⚠️ Services relying on Spring's default 500 body shape (none should, per ADR-0017) see a body change
+- ⚠️ The audit-column list for the 422/500 not-null split is maintained centrally and must track any new
+  server-populated columns
+- ⚠️ SQLSTATE-based classification is driver-dependent for identifier extraction (best-effort names in
+  messages), though status mapping itself relies only on standardized class-23 codes
+
+### Neutral
+
+- pos-api-gateway (WebFlux) is out of scope; its error rendering is governed by ADR-0011
+- Existing per-service advices continue to work unchanged; migrating them onto shared codes is
+  incremental cleanup, not part of this decision
+
+---
+
+## Implementation Notes
+
+- Module: `pos-web-common` (`GlobalApiExceptionHandler`, `DataIntegrityViolations`,
+  `WebCommonErrorAutoConfiguration`), auto-configured for servlet web applications only.
+- Enforcement: `pos-archunit/src/test/java/com/positivity/archunit/GlobalExceptionHandlerEnforcementTest.java`.
+- Envelope codes are documented in `docs/ERROR_ENVELOPE.md` ("Platform fallback codes").
+- ADR-0017 remains the status-matrix authority; on acceptance, add a changelog line there
+  cross-referencing this ADR for the not-null/check mapping.
+
+---
+
+## Sign-Off
+
+| Role         | Name | Date | Notes |
+| ------------ | ---- | ---- | ----- |
+| Architecture |      |      |       |
+| Backend Lead |      |      |       |
+| API Lead     |      |      |       |
+
+---
+
+## Timeline
+
+- **Proposed**: 2026-08-23
+
+---
+
+## Changelog
+
+- **2026-08-23**: Initial draft, authored with the implementing change for issue #1471

--- a/docs/compliance/issue-1471-adr-exception-handling-review.md
+++ b/docs/compliance/issue-1471-adr-exception-handling-review.md
@@ -1,0 +1,119 @@
+# ADR Review: Exception Handling vs Issue #1471
+
+**Scope:** Assessment of the platform ADR set (durion repo, `docs/adr/`) against
+[issue #1471](https://github.com/louisburroughs/durion-positivity-backend/issues/1471)
+("Unhandled exceptions escape as bare 500s with no error code or correlation id").
+
+**Date:** 2026-08-23
+
+---
+
+## Relevant ADRs
+
+| ADR | Relevance |
+| --- | --- |
+| [ADR-0017: API Controller HTTP Response Codes Standard](https://github.com/louisburroughs/durion/blob/main/docs/adr/0017-api-controller-http-response-codes.adr.md) | The core exception-handling ADR: canonical status matrix, error envelope contract, correlation-id propagation |
+| [ADR-0046: Environment Log Level Policy](https://github.com/louisburroughs/durion/blob/main/docs/adr/0046-environment-log-level-policy.adr.md) (§6) | Structured JSON logs must carry the `correlationId` already propagated in the `ApiError` envelope |
+| `docs/ERROR_ENVELOPE.md` (this repo, non-ADR) | Concrete `ApiError` schema the envelope decisions refer to |
+
+No other ADR (0001–0055) addresses exception mapping, catch-all handlers, or
+`DataIntegrityViolationException`. There is no dedicated "global exception handling" ADR.
+
+---
+
+## Verdict per issue point
+
+### 1. `DataIntegrityViolationException` → 409 / 422
+
+**Partially covered; one open decision.**
+
+- **409 for unique-constraint violations: already decided.** ADR-0017 §2 explicitly lists
+  "duplicate-unique constraints" as a `409` case. The issue's proposal is *consistent with the
+  existing ADR* — the failure is purely an implementation gap. Verified in code: **no controller
+  advice in any module handles `DataIntegrityViolationException`** (all 38 references to it are
+  service-layer `try/catch` blocks, e.g. `PartyTagServiceImpl`), so uncaught unique violations fall
+  through to Spring's default 500 page — a direct violation of ADR-0017 §2/§3.
+- **422 for not-null / check violations: NOT decided, and in tension with the ADR.** ADR-0017 §1
+  maps field-validation failures to `400`, and §2 restricts `422` to domain-policy violations
+  "explicitly documented in the endpoint contract". A NOT NULL violation reaching the database fits
+  neither bucket cleanly. Note that the motivating bug (#1464, `created_by` NOT NULL with no
+  `AuditorAware`) was a *server-side* defect the client could not have fixed — for
+  server-populated columns, an enveloped `500` is arguably the honest answer, with `422` reserved
+  for client-supplied fields. **This needs an ADR decision (amend ADR-0017 or supersede), not just
+  code.**
+
+### 2. Catch-all `@ExceptionHandler(Exception.class)` in every service
+
+**Requirement already implied by ADR-0017; mechanism and mandate missing.**
+
+ADR-0017 §3 standardizes **all** non-2xx bodies to the envelope (`code`, `message`, `status`,
+`timestamp`, `correlationId`) and §4 requires every error response to carry `X-Correlation-Id`.
+A bare Spring whitelabel 500 therefore already violates the accepted ADR — the issue describes an
+ADR-compliance failure, not a policy vacuum. However, the ADR's Implementation Notes ("centralize
+status-code mapping in ... global handlers") are advisory and name no concrete mechanism, which is
+how the gap arose. Verified in code: only 7 modules have an `Exception.class` handler
+(pos-inventory, pos-people, pos-people-contact, pos-security-service, pos-supplier, pos-warranty,
+pos-mcp-server); at least 14 controller-bearing modules with advices have none (pos-accounting,
+pos-bulk-loader, pos-catalog, pos-customer, pos-documents, pos-image, pos-invoice, pos-location,
+pos-marketing, pos-order, pos-price, pos-shop-manager, pos-vehicle-inventory, pos-workorder).
+The issue's count (2 of 7 services checked) is confirmed for the services it names.
+
+### 3. Shared `@ControllerAdvice` in a common module
+
+**No ADR covers this.** ADR-0017's Implementation Notes say to apply the standard "for each `pos-*`
+service" — per-service duplication is the (implicit) status quo, and seven copies is how the drift
+happened. No ADR governs where cross-cutting web concerns live (ADR-0026, the service-contract
+boundary policy, is silent on shared libraries). The issue's suggestion (pos-security-common, with
+service-specific advices keeping `@Order` precedence) is unopposed by any ADR but also unbacked by
+one. **Needs a decision** — including whether the shared advice lives in pos-security-common or a
+new/existing web-commons module, since pos-shared-dtos (home of `ApiError`) currently ships DTOs
+only.
+
+### 4. Enforcement (ArchUnit rule requiring a catch-all)
+
+**No ADR and no existing rule.** pos-archunit contains no rule about exception handlers or
+controller advices (verified). Precedent for enforcing ADRs via ArchUnit exists (package layout,
+ADR-0013 identifier rules), so the issue's "enforced rather than remembered" acceptance criterion
+fits the house style but requires a new decision and a new rule.
+
+### 5. Identical envelope across services
+
+**Fully covered.** ADR-0017 §3 + the shared `ApiError` record
+(`pos-shared-dtos/src/main/java/com/positivity/shared/error/ApiError.java`) already give one
+canonical shape, including `fieldErrors[]` as the field-level collection. Existing advices that do
+handle a type comply (e.g. `CrmExceptionHandler` resolves/echoes `X-Correlation-Id` per §4). The
+gap is only the unmapped-exception path.
+
+---
+
+## Summary
+
+| Issue #1471 ask | ADR status |
+| --- | --- |
+| 409 for unique-constraint violation | ✅ Decided (ADR-0017 §2) — implementation gap only |
+| 422 for not-null / check violation | ❌ Undecided; conflicts with ADR-0017 §1/§2 boundary — needs ADR change |
+| Catch-all with envelope + correlation id | ⚠️ Implied by ADR-0017 §3/§4 but mechanism never mandated |
+| Shared advice in a common module | ❌ No ADR; location undecided |
+| ArchUnit-enforced catch-all | ❌ No ADR, no rule |
+| One envelope shape for all services | ✅ Decided (ADR-0017 §3 + `ApiError`) |
+
+## Recommendation
+
+Author a new platform ADR (next free number, "Platform Global Exception Handling and Persistence
+Error Mapping") rather than growing ADR-0017 further. It should decide:
+
+1. Every controller-bearing `pos-*` module MUST register a catch-all `@ExceptionHandler(Exception.class)`
+   returning the ADR-0017 envelope, logging the stack trace at ERROR keyed by the `correlationId`
+   (ties into ADR-0046 §6 structured logging).
+2. Central `DataIntegrityViolationException` mapping: `409` for unique violations (restating
+   ADR-0017 §2); an explicit choice for not-null/check violations — recommended: `422` when the
+   violated column is client-supplied, enveloped `500` when it is server-populated (audit columns),
+   distinguished by constraint name from the nested `ConstraintViolationException`.
+3. The shared-advice home (e.g. `@AutoConfiguration` in pos-security-common or a new
+   pos-web-common), with service advices taking `@Order` precedence.
+4. An ArchUnit rule in pos-archunit requiring the catch-all (or the shared advice import) for every
+   module containing `@RestController`s, satisfying the issue's "enforced rather than remembered"
+   criterion.
+
+ADR-0017 then needs only a small changelog amendment cross-referencing the new ADR for the
+not-null/check mapping.

--- a/docs/compliance/issue-1471-adr-exception-handling-review.md
+++ b/docs/compliance/issue-1471-adr-exception-handling-review.md
@@ -6,6 +6,13 @@
 
 **Date:** 2026-08-23
 
+> **Status: executed.** The recommendation below has been implemented:
+> `docs/adr-0056-global-exception-handling.md` (draft ADR, pending relocation to durion/docs/adr and
+> sign-off), the `pos-web-common` module (auto-configured `GlobalApiExceptionHandler` +
+> SQLSTATE-based `DataIntegrityViolationException` mapping), pos-security-common re-export,
+> direct dependencies for pos-event-receiver and the vehicle-reference services, and the
+> `GlobalExceptionHandlerEnforcementTest` build gate in pos-archunit.
+
 ---
 
 ## Relevant ADRs

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
 			</dependency>
 			<dependency>
 				<groupId>com.positivity</groupId>
+				<artifactId>pos-web-common</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.positivity</groupId>
 				<artifactId>pos-tax-common</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -248,6 +253,7 @@
 		<module>pos-dependencies</module>
 		<module>pos-shared-dtos</module>
 		<module>pos-domain-events</module>
+		<module>pos-web-common</module>
 		<module>pos-security-common</module>
 		<module>pos-tax-common</module>
 		<module>pos-archunit</module>

--- a/pos-archunit/src/test/java/com/positivity/archunit/GlobalExceptionHandlerEnforcementTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/GlobalExceptionHandlerEnforcementTest.java
@@ -1,0 +1,125 @@
+package com.positivity.archunit;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Enforces issue #1471's acceptance criterion: every module with REST controllers has a
+ * catch-all exception handler — enforced rather than remembered.
+ *
+ * <p>Without one, any unmapped exception escapes as Spring's bare default 500 page with no
+ * {@code code}, no {@code message} and no {@code correlationId}, violating ADR-0017 §3/§4
+ * (every non-2xx body carries the ApiError envelope and a correlation id). A module
+ * satisfies the rule by either:
+ *
+ * <ul>
+ *   <li>depending (directly, or transitively via pos-security-common) on pos-web-common,
+ *       whose auto-configured {@code GlobalApiExceptionHandler} provides the platform
+ *       catch-all at lowest precedence, or</li>
+ *   <li>declaring its own {@code @ExceptionHandler(Exception.class)} advice (for example
+ *       pos-security-service, which cannot depend on pos-security-common).</li>
+ * </ul>
+ *
+ * <p>This test scans module source trees and poms on disk rather than the ArchUnit classpath
+ * import: pos-archunit's classpath only covers the modules declared in its pom, and this rule
+ * must hold for every module in the reactor.
+ */
+class GlobalExceptionHandlerEnforcementTest {
+
+    /**
+     * Modules whose controllers are exempt from the servlet-MVC catch-all requirement.
+     * pos-api-gateway is a WebFlux application: the servlet {@code @ControllerAdvice} in
+     * pos-web-common does not apply, and gateway error rendering is its own concern
+     * (ADR-0011 security boundary).
+     */
+    private static final Set<String> EXEMPT_MODULES = Set.of("pos-api-gateway");
+
+    /**
+     * Modules that provide the shared catch-all transitively when depended upon.
+     * pos-security-common deliberately re-exports pos-web-common (see its pom).
+     */
+    private static final Set<String> CATCH_ALL_PROVIDERS = Set.of("pos-web-common", "pos-security-common");
+
+    private static final Path REPO_ROOT = Path.of("..").toAbsolutePath().normalize();
+
+    @Test
+    void everyModuleWithRestControllersHasACatchAllExceptionHandler() throws IOException {
+        List<Path> controllerModules;
+        try (Stream<Path> modules = Files.list(REPO_ROOT)) {
+            controllerModules = modules.filter(
+                            module -> module.getFileName().toString().startsWith("pos-"))
+                    .filter(module -> Files.isDirectory(module.resolve("src/main/java")))
+                    .filter(module ->
+                            !EXEMPT_MODULES.contains(module.getFileName().toString()))
+                    .filter(GlobalExceptionHandlerEnforcementTest::hasRestControllers)
+                    .toList();
+        }
+
+        // Guard against a vacuous pass from scanning the wrong directory: the reactor has
+        // dozens of controller-bearing modules, so finding none means this test looked in
+        // the wrong place, not that the rule holds.
+        Assertions.assertFalse(
+                controllerModules.isEmpty(),
+                () -> "No modules with @RestController endpoints found under " + REPO_ROOT
+                        + " — this test must run with the repository root as its parent directory"
+                        + " (Maven surefire runs it from pos-archunit/).");
+
+        List<String> violations = controllerModules.stream()
+                .filter(module -> !hasOwnCatchAll(module) && !dependsOnCatchAllProvider(module))
+                .map(module -> module.getFileName().toString())
+                .sorted()
+                .toList();
+
+        Assertions.assertTrue(
+                violations.isEmpty(),
+                () -> "Modules with @RestController endpoints but no catch-all exception handler: " + violations
+                        + ". Unmapped exceptions there escape as Spring's bare default 500 page without the"
+                        + " ApiError envelope or a correlation id (issue #1471, ADR-0017 §3/§4). Fix: add a"
+                        + " dependency on pos-web-common (or pos-security-common, which re-exports it) so the"
+                        + " auto-configured GlobalApiExceptionHandler applies, or declare a module-local"
+                        + " @ExceptionHandler(Exception.class) advice that returns the ApiError envelope.");
+    }
+
+    private static boolean hasRestControllers(Path module) {
+        return anyMainSourceContains(module, "@RestController");
+    }
+
+    private static boolean hasOwnCatchAll(Path module) {
+        return anyMainSourceContains(module, "@ExceptionHandler(Exception.class)");
+    }
+
+    private static boolean dependsOnCatchAllProvider(Path module) {
+        Path pom = module.resolve("pom.xml");
+        if (!Files.isRegularFile(pom)) {
+            return false;
+        }
+        try {
+            String content = Files.readString(pom);
+            return CATCH_ALL_PROVIDERS.stream()
+                    .anyMatch(provider -> content.contains("<artifactId>" + provider + "</artifactId>"));
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read " + pom, e);
+        }
+    }
+
+    private static boolean anyMainSourceContains(Path module, String needle) {
+        Path sourceRoot = module.resolve("src/main/java");
+        try (Stream<Path> sources = Files.walk(sourceRoot)) {
+            return sources.filter(path -> path.toString().endsWith(".java")).anyMatch(path -> {
+                try {
+                    return Files.readString(path).contains(needle);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Cannot read " + path, e);
+                }
+            });
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot walk " + sourceRoot, e);
+        }
+    }
+}

--- a/pos-coverage-aggregate/pom.xml
+++ b/pos-coverage-aggregate/pom.xml
@@ -23,6 +23,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.positivity</groupId>
+			<artifactId>pos-web-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.positivity</groupId>
 			<artifactId>pos-domain-events</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/pos-dependencies/pom.xml
+++ b/pos-dependencies/pom.xml
@@ -29,6 +29,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- Shared Web MVC Concerns (Global Exception Handling) -->
+            <dependency>
+                <groupId>com.positivity</groupId>
+                <artifactId>pos-web-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- Shared Event Library -->
             <dependency>
                 <groupId>com.positivity</groupId>

--- a/pos-event-receiver/pom.xml
+++ b/pos-event-receiver/pom.xml
@@ -91,6 +91,12 @@
             <artifactId>pos-shared-dtos</artifactId>
         </dependency>
 
+        <!-- Shared global exception handling: ApiError envelope + correlation id (issue #1471) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-web-common</artifactId>
+        </dependency>
+
 
 
         <!-- OpenAPI/Swagger documentation -->

--- a/pos-security-common/pom.xml
+++ b/pos-security-common/pom.xml
@@ -24,6 +24,15 @@
     <packaging>jar</packaging>
 
     <dependencies>
+        <!-- Shared web MVC concerns (issue #1471): deliberately a compile dependency so every
+             service that uses gateway security transitively gets the auto-configured
+             GlobalApiExceptionHandler (ApiError envelope + correlation id on unmapped exceptions). -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-web-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Spring Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pos-vehicle-reference-carapi/pom.xml
+++ b/pos-vehicle-reference-carapi/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>pos-shared-dtos</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Shared global exception handling: ApiError envelope + correlation id (issue #1471) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-web-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.positivity</groupId>
             <artifactId>pos-events</artifactId>

--- a/pos-vehicle-reference-nhtsa/pom.xml
+++ b/pos-vehicle-reference-nhtsa/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>pos-shared-dtos</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Shared global exception handling: ApiError envelope + correlation id (issue #1471) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-web-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.positivity</groupId>
             <artifactId>pos-events</artifactId>

--- a/pos-web-common/pom.xml
+++ b/pos-web-common/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.positivity</groupId>
+        <artifactId>positivity</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pos-web-common</artifactId>
+    <name>pos-web-common</name>
+    <description>Shared web MVC concerns: global exception handling with the canonical ApiError envelope</description>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Spring Web MVC (advice, servlet API) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Auto-configuration support -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <!-- DataAccessException hierarchy (DataIntegrityViolationException) -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
+
+        <!-- Canonical ApiError envelope + UUIDv7 correlation ids -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-shared-dtos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- SLF4J for logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- JSpecify for null safety annotations -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Bean validation, to exercise the MethodArgumentNotValidException handler -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spring Security types, to verify the advice rethrows them for the filter chain -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This is a library, not a bootable application -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pos-web-common/src/main/java/com/positivity/web/common/DataIntegrityViolations.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/DataIntegrityViolations.java
@@ -1,0 +1,141 @@
+package com.positivity.web.common;
+
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Classifies a persistence-layer integrity failure by the SQLSTATE of the underlying
+ * {@link SQLException}, so {@link GlobalApiExceptionHandler} can map it to the HTTP status
+ * required by ADR-0017 (409 for stateful collisions such as unique/foreign-key violations,
+ * 422 for semantic violations such as not-null/check failures on client-supplied values).
+ *
+ * <p>SQLSTATE class 23 (integrity constraint violation) is standardized, so the codes below
+ * cover both PostgreSQL (docker/alpha/prod) and H2 (dev):
+ *
+ * <ul>
+ *   <li>{@code 23505} — unique violation</li>
+ *   <li>{@code 23502} — not-null violation</li>
+ *   <li>{@code 23514} (PostgreSQL) / {@code 23513} (H2) — check violation</li>
+ *   <li>{@code 23503} / {@code 23506} (H2 child-exists) — foreign-key violation</li>
+ * </ul>
+ *
+ * <p>Constraint and column names are extracted best-effort from the driver message. Only
+ * identifier names are ever extracted — never rejected data values, which must not be echoed
+ * back to clients.
+ */
+public final class DataIntegrityViolations {
+
+    /** What kind of integrity constraint was violated. */
+    public enum Kind {
+        UNIQUE,
+        NOT_NULL,
+        CHECK,
+        FOREIGN_KEY,
+        /** SQLSTATE class 23 but none of the specific codes above. */
+        OTHER_INTEGRITY,
+        /** No SQLSTATE available, or not an integrity-constraint SQLSTATE. */
+        UNKNOWN
+    }
+
+    /**
+     * Classification result. {@code constraintName} and {@code columnName} are best-effort
+     * extractions from the driver message and may be {@code null}.
+     */
+    public record Classification(
+            @NonNull Kind kind,
+            @Nullable String constraintName,
+            @Nullable String columnName) {}
+
+    /**
+     * Columns populated by the server (JPA auditing), never by the client. A not-null
+     * violation on one of these is a server defect (for example a missing
+     * {@code AuditorAware}, see issue #1464), not a client error.
+     */
+    private static final Set<String> SERVER_POPULATED_AUDIT_COLUMNS = Set.of(
+            "created_by",
+            "updated_by",
+            "last_modified_by",
+            "created_at",
+            "updated_at",
+            "created_date",
+            "last_modified_at",
+            "last_modified_date");
+
+    /** PostgreSQL and H2 both quote the offending column: {@code ... column "created_by" ...}. */
+    private static final Pattern COLUMN_PATTERN = Pattern.compile("column \"([^\"]+)\"");
+
+    /** PostgreSQL quotes the violated constraint: {@code ... violates unique constraint "uq_x" ...}. */
+    private static final Pattern CONSTRAINT_PATTERN = Pattern.compile("constraint \"([^\"]+)\"");
+
+    /** H2 names the index in unique-violation messages: {@code ... violation: "PUBLIC.UQ_X_INDEX_4 ON ..." ...}. */
+    private static final Pattern H2_UNIQUE_PATTERN = Pattern.compile("violation: \"(?:[A-Za-z0-9_]+\\.)?([^ \"]+)");
+
+    private DataIntegrityViolations() {
+        // Utility class - prevent instantiation
+    }
+
+    /** Classifies the given failure by the SQLSTATE of the first {@link SQLException} in its cause chain. */
+    public static @NonNull Classification classify(@NonNull Throwable exception) {
+        SQLException sqlException = firstSqlException(exception);
+        if (sqlException == null) {
+            return new Classification(Kind.UNKNOWN, null, null);
+        }
+        String sqlState = sqlException.getSQLState();
+        String message = sqlException.getMessage() == null ? "" : sqlException.getMessage();
+        if (sqlState == null) {
+            return new Classification(Kind.UNKNOWN, null, null);
+        }
+        return switch (sqlState) {
+            case "23505" -> new Classification(Kind.UNIQUE, extractConstraintName(message), null);
+            case "23502" -> new Classification(Kind.NOT_NULL, null, extractColumnName(message));
+            case "23513", "23514" -> new Classification(Kind.CHECK, extractConstraintName(message), null);
+            case "23503", "23506" -> new Classification(Kind.FOREIGN_KEY, extractConstraintName(message), null);
+            default ->
+                sqlState.startsWith("23")
+                        ? new Classification(Kind.OTHER_INTEGRITY, extractConstraintName(message), null)
+                        : new Classification(Kind.UNKNOWN, null, null);
+        };
+    }
+
+    /** True when the column is populated server-side (JPA auditing) and a not-null failure on it is a server defect. */
+    public static boolean isServerPopulatedAuditColumn(@Nullable String columnName) {
+        return columnName != null && SERVER_POPULATED_AUDIT_COLUMNS.contains(columnName.toLowerCase(Locale.ROOT));
+    }
+
+    private static @Nullable SQLException firstSqlException(Throwable exception) {
+        Throwable current = exception;
+        // Bounded walk: cause chains can be cyclic in pathological cases.
+        for (int depth = 0; current != null && depth < 20; depth++) {
+            if (current instanceof SQLException sqlException) {
+                return sqlException;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static @Nullable String extractConstraintName(String message) {
+        Matcher postgres = CONSTRAINT_PATTERN.matcher(message);
+        if (postgres.find()) {
+            return postgres.group(1);
+        }
+        Matcher h2 = H2_UNIQUE_PATTERN.matcher(message);
+        if (h2.find()) {
+            return h2.group(1);
+        }
+        return null;
+    }
+
+    private static @Nullable String extractColumnName(String message) {
+        return Optional.of(COLUMN_PATTERN.matcher(message))
+                .filter(Matcher::find)
+                .map(matcher -> matcher.group(1))
+                .orElse(null);
+    }
+}

--- a/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
@@ -197,11 +197,12 @@ public class GlobalApiExceptionHandler {
             @NonNull HttpServletResponse response) {
         String correlationId = resolveCorrelationId(request);
         response.setHeader(X_CORRELATION_ID, correlationId);
-        log.warn(
-                "Unreadable request body on {} [correlationId={}]: {}",
+        // Deliberately not logging ex.getMessage(): parser messages echo user-supplied body
+        // content, and a routine client 400 is DEBUG-level noise. The correlation id is enough.
+        log.debug(
+                "Unreadable request body on {} [correlationId={}]",
                 request != null ? request.getRequestURI() : "",
-                correlationId,
-                ex.getMessage());
+                correlationId);
         return envelope(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Malformed request body", correlationId);
     }
 
@@ -223,7 +224,9 @@ public class GlobalApiExceptionHandler {
             log.error("No converter for parameter on {} [correlationId={}]", path, correlationId, ex);
             return internalError(correlationId);
         }
-        log.warn("Parameter type mismatch on {} [correlationId={}]: {}", path, correlationId, ex.getMessage());
+        // Same reasoning as handleMessageNotReadable: the exception message echoes the
+        // user-supplied value, and a client 400 is DEBUG-level noise.
+        log.debug("Parameter type mismatch on {} [correlationId={}]", path, correlationId);
         return envelope(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Invalid parameter value", correlationId);
     }
 
@@ -309,7 +312,7 @@ public class GlobalApiExceptionHandler {
         if (correlationId == null || correlationId.isBlank()) {
             return UUIDv7Generator.generate().toString();
         }
-        return correlationId;
+        return correlationId.trim();
     }
 
     private static String withIdentifier(String message, @Nullable String identifier) {

--- a/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
@@ -1,0 +1,292 @@
+package com.positivity.web.common;
+
+import com.positivity.shared.error.ApiError;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.web.common.DataIntegrityViolations.Classification;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Platform fallback exception handler: guarantees that no exception leaves a service as
+ * Spring's bare default error page (issue #1471). Every response it produces carries the
+ * canonical {@link ApiError} envelope and echoes/generates {@code X-Correlation-Id}, as
+ * ADR-0017 §3/§4 require.
+ *
+ * <p>Registered at {@link Ordered#LOWEST_PRECEDENCE}, so any service-specific
+ * {@code @ControllerAdvice} that maps an exception type keeps precedence; this advice only
+ * sees what no other advice handled.
+ *
+ * <p>Response bodies stay generic on 500s — the correlation id, logged with the stack trace
+ * at ERROR, is what makes the failure diagnosable. Constraint and column identifiers may be
+ * named on 409/422; rejected data values are never echoed back.
+ */
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class GlobalApiExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalApiExceptionHandler.class);
+
+    private static final String X_CORRELATION_ID = "X-Correlation-Id";
+
+    /**
+     * Spring Security exceptions must reach the security filter chain's entry point /
+     * access-denied handler, not this advice. Resolved reflectively because pos-web-common
+     * does not depend on Spring Security, while most consuming services have it.
+     */
+    private static final List<Class<?>> SECURITY_EXCEPTIONS = loadSecurityExceptionTypes();
+
+    private final Clock clock;
+
+    public GlobalApiExceptionHandler(@NonNull Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Maps database integrity failures per ADR-0017 §2: {@code 409} for unique and
+     * foreign-key collisions, {@code 422} for not-null/check violations on client-supplied
+     * values. A not-null violation on a server-populated audit column (for example
+     * {@code created_by} with no {@code AuditorAware}, issue #1464) is a server defect and
+     * stays a {@code 500} — but an enveloped, correlated one.
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiError> handleDataIntegrityViolation(
+            @NonNull DataIntegrityViolationException ex,
+            @Nullable HttpServletRequest request,
+            @NonNull HttpServletResponse response) {
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+        String path = request != null ? request.getRequestURI() : "";
+        Classification classification = DataIntegrityViolations.classify(ex);
+
+        return switch (classification.kind()) {
+            case UNIQUE -> {
+                log.warn(
+                        "Unique constraint violation on {} [correlationId={}]: constraint={}",
+                        path,
+                        correlationId,
+                        classification.constraintName());
+                yield envelope(
+                        HttpStatus.CONFLICT,
+                        "DUPLICATE_RESOURCE",
+                        withIdentifier("Duplicate value violates unique constraint", classification.constraintName()),
+                        correlationId);
+            }
+            case NOT_NULL -> {
+                if (DataIntegrityViolations.isServerPopulatedAuditColumn(classification.columnName())) {
+                    log.error(
+                            "Not-null violation on server-populated column '{}' on {} [correlationId={}] — "
+                                    + "server-side defect (e.g. missing AuditorAware), not a client error",
+                            classification.columnName(),
+                            path,
+                            correlationId,
+                            ex);
+                    yield internalError(correlationId);
+                }
+                log.warn(
+                        "Not-null constraint violation on {} [correlationId={}]: column={}",
+                        path,
+                        correlationId,
+                        classification.columnName());
+                yield envelope(
+                        HttpStatus.UNPROCESSABLE_CONTENT,
+                        "MISSING_REQUIRED_VALUE",
+                        withIdentifier("Required value is missing for column", classification.columnName()),
+                        correlationId);
+            }
+            case CHECK -> {
+                log.warn(
+                        "Check constraint violation on {} [correlationId={}]: constraint={}",
+                        path,
+                        correlationId,
+                        classification.constraintName());
+                yield envelope(
+                        HttpStatus.UNPROCESSABLE_CONTENT,
+                        "CONSTRAINT_VIOLATION",
+                        withIdentifier("Value violates check constraint", classification.constraintName()),
+                        correlationId);
+            }
+            case FOREIGN_KEY -> {
+                log.warn(
+                        "Foreign-key constraint violation on {} [correlationId={}]: constraint={}",
+                        path,
+                        correlationId,
+                        classification.constraintName());
+                yield envelope(
+                        HttpStatus.CONFLICT,
+                        "REFERENCE_CONFLICT",
+                        withIdentifier(
+                                "Operation conflicts with referential constraint", classification.constraintName()),
+                        correlationId);
+            }
+            case OTHER_INTEGRITY -> {
+                log.warn(
+                        "Data integrity violation on {} [correlationId={}]: constraint={}",
+                        path,
+                        correlationId,
+                        classification.constraintName());
+                yield envelope(
+                        HttpStatus.CONFLICT,
+                        "DATA_INTEGRITY_VIOLATION",
+                        "Operation violates a data integrity constraint",
+                        correlationId);
+            }
+            case UNKNOWN -> {
+                log.error("Unclassifiable data integrity violation on {} [correlationId={}]", path, correlationId, ex);
+                yield internalError(correlationId);
+            }
+        };
+    }
+
+    /**
+     * Bean-validation failures that no service advice mapped. Without this handler the
+     * catch-all below would turn every {@code @Valid} failure into a 500.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleMethodArgumentNotValid(
+            @NonNull MethodArgumentNotValidException ex,
+            @Nullable HttpServletRequest request,
+            @NonNull HttpServletResponse response) {
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        List<ApiError.FieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> new ApiError.FieldError(
+                        fieldError.getField(),
+                        fieldError.getDefaultMessage() != null ? fieldError.getDefaultMessage() : "Invalid value"))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiError.withFieldErrors(
+                        "VALIDATION_ERROR",
+                        "Request validation failed",
+                        HttpStatus.BAD_REQUEST.value(),
+                        Instant.now(clock).toString(),
+                        correlationId,
+                        fieldErrors));
+    }
+
+    /**
+     * The catch-all ADR-0017 implies and issue #1471 makes explicit: whatever reaches here
+     * leaves with the envelope and a correlation id, and the stack trace is logged at ERROR
+     * against that id. Spring Security exceptions are rethrown so the filter chain renders
+     * its 401/403; framework {@link ErrorResponse} exceptions keep their own status instead
+     * of collapsing to 500.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleUnhandled(
+            @NonNull Exception ex, @Nullable HttpServletRequest request, @NonNull HttpServletResponse response)
+            throws Exception {
+        if (isSecurityException(ex)) {
+            throw ex;
+        }
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+        String path = request != null ? request.getRequestURI() : "";
+
+        if (ex instanceof ErrorResponse errorResponse) {
+            HttpStatusCode status = errorResponse.getStatusCode();
+            if (!status.is5xxServerError()) {
+                log.warn(
+                        "{} on {} [correlationId={}]: status={}",
+                        ex.getClass().getSimpleName(),
+                        path,
+                        correlationId,
+                        status.value());
+                return envelope(status, frameworkErrorCode(status), frameworkErrorMessage(status), correlationId);
+            }
+        }
+
+        log.error("Unhandled exception on {} [correlationId={}]", path, correlationId, ex);
+        return internalError(correlationId);
+    }
+
+    private ResponseEntity<ApiError> internalError(String correlationId) {
+        return envelope(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "Unexpected error occurred", correlationId);
+    }
+
+    private ResponseEntity<ApiError> envelope(
+            HttpStatusCode status, String code, String message, String correlationId) {
+        return ResponseEntity.status(status)
+                .body(ApiError.of(
+                        code, message, status.value(), Instant.now(clock).toString(), correlationId));
+    }
+
+    /**
+     * Codes/messages for Spring MVC's own {@link ErrorResponse} exceptions (unknown path,
+     * unsupported method/media type, malformed request). Deliberately generic: the request
+     * path and parameter values are user-controlled and must not be reflected (SonarCloud
+     * S5131); the path is already in the request the client sent.
+     */
+    private static String frameworkErrorCode(HttpStatusCode status) {
+        return switch (status.value()) {
+            case 400 -> "VALIDATION_ERROR";
+            case 404 -> "NOT_FOUND";
+            case 405 -> "METHOD_NOT_ALLOWED";
+            case 406 -> "NOT_ACCEPTABLE";
+            case 413 -> "PAYLOAD_TOO_LARGE";
+            case 415 -> "UNSUPPORTED_MEDIA_TYPE";
+            default -> "REQUEST_REJECTED";
+        };
+    }
+
+    private static String frameworkErrorMessage(HttpStatusCode status) {
+        return switch (status.value()) {
+            case 400 -> "Malformed request";
+            case 404 -> "No endpoint for the requested path";
+            case 405 -> "HTTP method not supported for this path";
+            case 415 -> "Unsupported media type";
+            default -> "Request rejected";
+        };
+    }
+
+    private String resolveCorrelationId(@Nullable HttpServletRequest request) {
+        if (request == null) {
+            return UUIDv7Generator.generate().toString();
+        }
+        String correlationId = request.getHeader(X_CORRELATION_ID);
+        if (correlationId == null || correlationId.isBlank()) {
+            return UUIDv7Generator.generate().toString();
+        }
+        return correlationId;
+    }
+
+    private static String withIdentifier(String message, @Nullable String identifier) {
+        return identifier == null ? message : message + " '" + identifier + "'";
+    }
+
+    private static boolean isSecurityException(Exception ex) {
+        return SECURITY_EXCEPTIONS.stream().anyMatch(type -> type.isInstance(ex));
+    }
+
+    private static List<Class<?>> loadSecurityExceptionTypes() {
+        return List.of(
+                        "org.springframework.security.access.AccessDeniedException",
+                        "org.springframework.security.core.AuthenticationException")
+                .stream()
+                .<Class<?>>mapMulti((name, consumer) -> {
+                    try {
+                        consumer.accept(Class.forName(name, false, GlobalApiExceptionHandler.class.getClassLoader()));
+                    } catch (ClassNotFoundException ignored) {
+                        // Spring Security not on the classpath: nothing to rethrow.
+                    }
+                })
+                .toList();
+    }
+}

--- a/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
@@ -12,12 +12,15 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.ConversionNotSupportedException;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -180,6 +183,48 @@ public class GlobalApiExceptionHandler {
                         Instant.now(clock).toString(),
                         correlationId,
                         fieldErrors));
+    }
+
+    /**
+     * Unreadable request bodies (malformed JSON, invalid enum values). Unlike most Spring MVC
+     * web exceptions this type does not implement {@link ErrorResponse}, so without this
+     * handler the catch-all below would turn a client's 400 into a 500.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleMessageNotReadable(
+            @NonNull HttpMessageNotReadableException ex,
+            @Nullable HttpServletRequest request,
+            @NonNull HttpServletResponse response) {
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+        log.warn(
+                "Unreadable request body on {} [correlationId={}]: {}",
+                request != null ? request.getRequestURI() : "",
+                correlationId,
+                ex.getMessage());
+        return envelope(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Malformed request body", correlationId);
+    }
+
+    /**
+     * Parameter/path-variable conversion failures. {@link ConversionNotSupportedException}
+     * means a missing server-side converter, so it stays a 500 via the catch-all; every other
+     * type mismatch is the client's 400. Neither implements {@link ErrorResponse} on all
+     * supported Spring lines, hence the explicit handler.
+     */
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<ApiError> handleTypeMismatch(
+            @NonNull TypeMismatchException ex,
+            @Nullable HttpServletRequest request,
+            @NonNull HttpServletResponse response) {
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+        String path = request != null ? request.getRequestURI() : "";
+        if (ex instanceof ConversionNotSupportedException) {
+            log.error("No converter for parameter on {} [correlationId={}]", path, correlationId, ex);
+            return internalError(correlationId);
+        }
+        log.warn("Parameter type mismatch on {} [correlationId={}]: {}", path, correlationId, ex.getMessage());
+        return envelope(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Invalid parameter value", correlationId);
     }
 
     /**

--- a/pos-web-common/src/main/java/com/positivity/web/common/WebCommonErrorAutoConfiguration.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/WebCommonErrorAutoConfiguration.java
@@ -1,0 +1,34 @@
+package com.positivity.web.common;
+
+import java.time.Clock;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Registers {@link GlobalApiExceptionHandler} for every servlet web application that has
+ * pos-web-common on its classpath — the "enforced rather than remembered" delivery mechanism
+ * for issue #1471's catch-all requirement.
+ *
+ * <p>Opt out with {@code pos.web.global-exception-handler.enabled=false} (for example in a
+ * test slice that asserts raw framework behavior). A service that defines its own
+ * {@code GlobalApiExceptionHandler} bean also suppresses this one.
+ */
+@AutoConfiguration
+@ConditionalOnWebApplication(type = Type.SERVLET)
+public class WebCommonErrorAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(
+            name = "pos.web.global-exception-handler.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    public GlobalApiExceptionHandler globalApiExceptionHandler(ObjectProvider<Clock> clockProvider) {
+        return new GlobalApiExceptionHandler(clockProvider.getIfAvailable(Clock::systemUTC));
+    }
+}

--- a/pos-web-common/src/main/java/com/positivity/web/common/package-info.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * Shared web MVC concerns for pos-* services.
+ *
+ * <p>
+ * Provides the platform fallback exception handling required by ADR-0017: every non-2xx
+ * response must carry the canonical {@code ApiError} envelope ({@code code}, {@code message},
+ * {@code status}, {@code timestamp}, {@code correlationId}) and echo/generate
+ * {@code X-Correlation-Id}. Issue #1471 documented unmapped exceptions escaping as Spring's
+ * bare default 500 page; this module closes that gap once, centrally, instead of per service.
+ * </p>
+ *
+ * <h2>Key Components</h2>
+ * <ul>
+ *   <li>{@link com.positivity.web.common.GlobalApiExceptionHandler} - lowest-precedence
+ *       {@code @RestControllerAdvice} catch-all; service-specific advices always win for the
+ *       exception types they map</li>
+ *   <li>{@link com.positivity.web.common.DataIntegrityViolations} - SQLSTATE-based
+ *       classification of {@code DataIntegrityViolationException} (unique, not-null, check,
+ *       foreign-key)</li>
+ *   <li>{@link com.positivity.web.common.WebCommonErrorAutoConfiguration} - registers the
+ *       advice automatically for servlet web applications; disable with
+ *       {@code pos.web.global-exception-handler.enabled=false}</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <p>
+ * Add pos-web-common as a dependency (pos-security-common re-exports it, so services using
+ * gateway security already have it). No further wiring is needed: the advice registers via
+ * Spring Boot auto-configuration and only handles exceptions no service advice mapped.
+ * </p>
+ */
+package com.positivity.web.common;

--- a/pos-web-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/pos-web-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.positivity.web.common.WebCommonErrorAutoConfiguration

--- a/pos-web-common/src/test/java/com/positivity/web/common/DataIntegrityViolationsTest.java
+++ b/pos-web-common/src/test/java/com/positivity/web/common/DataIntegrityViolationsTest.java
@@ -1,0 +1,125 @@
+package com.positivity.web.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.web.common.DataIntegrityViolations.Classification;
+import com.positivity.web.common.DataIntegrityViolations.Kind;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class DataIntegrityViolationsTest {
+
+    private static DataIntegrityViolationException wrap(SQLException sqlException) {
+        return new DataIntegrityViolationException(
+                "could not execute statement", new RuntimeException("jpa wrapper", sqlException));
+    }
+
+    @Test
+    void classifiesPostgresUniqueViolationWithConstraintName() {
+        SQLException cause = new SQLException(
+                "ERROR: duplicate key value violates unique constraint \"uq_party_customer_number\"", "23505");
+
+        Classification classification = DataIntegrityViolations.classify(wrap(cause));
+
+        assertThat(classification.kind()).isEqualTo(Kind.UNIQUE);
+        assertThat(classification.constraintName()).isEqualTo("uq_party_customer_number");
+    }
+
+    @Test
+    void classifiesH2UniqueViolationWithIndexName() {
+        SQLException cause = new SQLException(
+                "Unique index or primary key violation: \"PUBLIC.UQ_PARTY_CUSTOMER_NUMBER_INDEX_4 ON"
+                        + " PUBLIC.PARTY(CUSTOMER_NUMBER NULLS FIRST) VALUES ( /* 1 */ 'C-1001' )\"",
+                "23505");
+
+        Classification classification = DataIntegrityViolations.classify(wrap(cause));
+
+        assertThat(classification.kind()).isEqualTo(Kind.UNIQUE);
+        assertThat(classification.constraintName()).isEqualTo("UQ_PARTY_CUSTOMER_NUMBER_INDEX_4");
+    }
+
+    @Test
+    void classifiesPostgresNotNullViolationWithColumnName() {
+        SQLException cause = new SQLException(
+                "ERROR: null value in column \"created_by\" of relation \"purchase_order\" violates not-null"
+                        + " constraint",
+                "23502");
+
+        Classification classification = DataIntegrityViolations.classify(wrap(cause));
+
+        assertThat(classification.kind()).isEqualTo(Kind.NOT_NULL);
+        assertThat(classification.columnName()).isEqualTo("created_by");
+    }
+
+    @Test
+    void classifiesH2NotNullViolationWithColumnName() {
+        SQLException cause =
+                new SQLException("NULL not allowed for column \"CREATED_BY\"; SQL statement: insert ...", "23502");
+
+        Classification classification = DataIntegrityViolations.classify(wrap(cause));
+
+        assertThat(classification.kind()).isEqualTo(Kind.NOT_NULL);
+        assertThat(classification.columnName()).isEqualTo("CREATED_BY");
+    }
+
+    @Test
+    void classifiesCheckViolationForBothPostgresAndH2States() {
+        SQLException postgres = new SQLException(
+                "ERROR: new row for relation \"order_line\" violates check constraint \"chk_quantity_positive\"",
+                "23514");
+        SQLException h2 = new SQLException("Check constraint violation: \"CHK_QUANTITY_POSITIVE ...\"", "23513");
+
+        assertThat(DataIntegrityViolations.classify(wrap(postgres)).kind()).isEqualTo(Kind.CHECK);
+        assertThat(DataIntegrityViolations.classify(wrap(postgres)).constraintName())
+                .isEqualTo("chk_quantity_positive");
+        assertThat(DataIntegrityViolations.classify(wrap(h2)).kind()).isEqualTo(Kind.CHECK);
+    }
+
+    @Test
+    void classifiesForeignKeyViolation() {
+        SQLException postgres = new SQLException(
+                "ERROR: insert or update on table \"order_line\" violates foreign key constraint"
+                        + " \"fk_order_line_order\"",
+                "23503");
+        SQLException h2Child = new SQLException("Referential integrity constraint violation", "23506");
+
+        assertThat(DataIntegrityViolations.classify(wrap(postgres)).kind()).isEqualTo(Kind.FOREIGN_KEY);
+        assertThat(DataIntegrityViolations.classify(wrap(postgres)).constraintName())
+                .isEqualTo("fk_order_line_order");
+        assertThat(DataIntegrityViolations.classify(wrap(h2Child)).kind()).isEqualTo(Kind.FOREIGN_KEY);
+    }
+
+    @Test
+    void classifiesOtherIntegrityStatesAsOtherIntegrity() {
+        SQLException generic = new SQLException("integrity constraint violation", "23000");
+
+        assertThat(DataIntegrityViolations.classify(wrap(generic)).kind()).isEqualTo(Kind.OTHER_INTEGRITY);
+    }
+
+    @Test
+    void classifiesMissingSqlExceptionOrStateAsUnknown() {
+        DataIntegrityViolationException noSqlCause =
+                new DataIntegrityViolationException("no sql cause", new RuntimeException("boom"));
+        SQLException noState = new SQLException("driver gave no state", (String) null);
+        SQLException nonIntegrityState = new SQLException("serialization failure", "40001");
+
+        assertThat(DataIntegrityViolations.classify(noSqlCause).kind()).isEqualTo(Kind.UNKNOWN);
+        assertThat(DataIntegrityViolations.classify(wrap(noState)).kind()).isEqualTo(Kind.UNKNOWN);
+        assertThat(DataIntegrityViolations.classify(wrap(nonIntegrityState)).kind())
+                .isEqualTo(Kind.UNKNOWN);
+    }
+
+    @Test
+    void identifiesServerPopulatedAuditColumnsCaseInsensitively() {
+        assertThat(DataIntegrityViolations.isServerPopulatedAuditColumn("created_by"))
+                .isTrue();
+        assertThat(DataIntegrityViolations.isServerPopulatedAuditColumn("CREATED_BY"))
+                .isTrue();
+        assertThat(DataIntegrityViolations.isServerPopulatedAuditColumn("updated_at"))
+                .isTrue();
+        assertThat(DataIntegrityViolations.isServerPopulatedAuditColumn("customer_number"))
+                .isFalse();
+        assertThat(DataIntegrityViolations.isServerPopulatedAuditColumn(null)).isFalse();
+    }
+}

--- a/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
+++ b/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
@@ -1,0 +1,212 @@
+package com.positivity.web.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.validation.constraints.NotBlank;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+class GlobalApiExceptionHandlerTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-08-23T12:00:00Z");
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ThrowingController())
+                .setControllerAdvice(new GlobalApiExceptionHandler(Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC)))
+                .build();
+    }
+
+    @Test
+    void unmappedRuntimeExceptionReturnsEnvelopedInternalErrorWithGeneratedCorrelationId() throws Exception {
+        mockMvc.perform(get("/test/boom"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(header().exists("X-Correlation-Id"))
+                .andExpect(jsonPath("$.code").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.message").value("Unexpected error occurred"))
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void internalErrorBodyDoesNotLeakExceptionDetails() throws Exception {
+        String body =
+                mockMvc.perform(get("/test/boom")).andReturn().getResponse().getContentAsString();
+
+        assertThat(body).doesNotContain("secret detail");
+    }
+
+    @Test
+    void clientCorrelationIdIsEchoedInHeaderAndBody() throws Exception {
+        mockMvc.perform(get("/test/boom").header("X-Correlation-Id", "corr-123"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(header().string("X-Correlation-Id", "corr-123"))
+                .andExpect(jsonPath("$.correlationId").value("corr-123"));
+    }
+
+    @Test
+    void uniqueConstraintViolationReturns409NamingTheConstraint() throws Exception {
+        mockMvc.perform(get("/test/duplicate"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_RESOURCE"))
+                .andExpect(jsonPath("$.message")
+                        .value("Duplicate value violates unique constraint 'uq_party_customer_number'"))
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void notNullViolationOnClientColumnReturns422NamingTheColumn() throws Exception {
+        mockMvc.perform(get("/test/missing-value"))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("MISSING_REQUIRED_VALUE"))
+                .andExpect(jsonPath("$.message").value("Required value is missing for column 'customer_number'"))
+                .andExpect(jsonPath("$.status").value(422));
+    }
+
+    @Test
+    void notNullViolationOnServerPopulatedAuditColumnStaysEnveloped500() throws Exception {
+        mockMvc.perform(get("/test/missing-audit-value"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void checkConstraintViolationReturns422() throws Exception {
+        mockMvc.perform(get("/test/check-violation"))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("CONSTRAINT_VIOLATION"))
+                .andExpect(jsonPath("$.message").value("Value violates check constraint 'chk_quantity_positive'"));
+    }
+
+    @Test
+    void foreignKeyViolationReturns409() throws Exception {
+        mockMvc.perform(get("/test/fk-violation"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REFERENCE_CONFLICT"));
+    }
+
+    @Test
+    void unclassifiableIntegrityViolationStaysEnveloped500() throws Exception {
+        mockMvc.perform(get("/test/unknown-integrity"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_ERROR"));
+    }
+
+    @Test
+    void beanValidationFailureReturns400WithFieldErrors() throws Exception {
+        mockMvc.perform(post("/test/validated")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("name"))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void frameworkErrorResponseExceptionKeepsItsStatusInsteadOfCollapsingTo500() throws Exception {
+        mockMvc.perform(post("/test/boom"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"))
+                .andExpect(jsonPath("$.message").value("HTTP method not supported for this path"))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void springSecurityExceptionsAreRethrownForTheSecurityFilterChain() {
+        assertThatThrownBy(() -> mockMvc.perform(get("/test/denied")))
+                .isInstanceOf(jakarta.servlet.ServletException.class)
+                .hasRootCauseInstanceOf(AccessDeniedException.class);
+    }
+
+    private static DataIntegrityViolationException integrityViolation(String message, String sqlState) {
+        return new DataIntegrityViolationException("could not execute statement", new SQLException(message, sqlState));
+    }
+
+    record ValidatedRequest(@NotBlank String name) {}
+
+    @RestController
+    static class ThrowingController {
+
+        @GetMapping("/test/boom")
+        String boom() {
+            throw new IllegalStateException("secret detail");
+        }
+
+        @GetMapping("/test/duplicate")
+        String duplicate() {
+            throw integrityViolation(
+                    "ERROR: duplicate key value violates unique constraint \"uq_party_customer_number\"", "23505");
+        }
+
+        @GetMapping("/test/missing-value")
+        String missingValue() {
+            throw integrityViolation(
+                    "ERROR: null value in column \"customer_number\" of relation \"party\" violates not-null"
+                            + " constraint",
+                    "23502");
+        }
+
+        @GetMapping("/test/missing-audit-value")
+        String missingAuditValue() {
+            throw integrityViolation(
+                    "ERROR: null value in column \"created_by\" of relation \"purchase_order\" violates not-null"
+                            + " constraint",
+                    "23502");
+        }
+
+        @GetMapping("/test/check-violation")
+        String checkViolation() {
+            throw integrityViolation(
+                    "ERROR: new row for relation \"order_line\" violates check constraint \"chk_quantity_positive\"",
+                    "23514");
+        }
+
+        @GetMapping("/test/fk-violation")
+        String fkViolation() {
+            throw integrityViolation(
+                    "ERROR: insert or update on table \"order_line\" violates foreign key constraint"
+                            + " \"fk_order_line_order\"",
+                    "23503");
+        }
+
+        @GetMapping("/test/unknown-integrity")
+        String unknownIntegrity() {
+            throw new DataIntegrityViolationException("no sql cause", new RuntimeException("boom"));
+        }
+
+        @PostMapping("/test/validated")
+        String validated(@jakarta.validation.Valid @RequestBody ValidatedRequest request) {
+            return request.name();
+        }
+
+        @GetMapping("/test/denied")
+        String denied() {
+            throw new AccessDeniedException("nope");
+        }
+    }
+}

--- a/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
+++ b/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
@@ -128,6 +128,34 @@ class GlobalApiExceptionHandlerTest {
     }
 
     @Test
+    void malformedRequestBodyReturns400NotAnEnveloped500() throws Exception {
+        mockMvc.perform(post("/test/validated")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{not json"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("Malformed request body"))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void invalidEnumValueInBodyReturns400() throws Exception {
+        mockMvc.perform(post("/test/enum")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"NOT_A_LEVEL\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void parameterTypeMismatchReturns400() throws Exception {
+        mockMvc.perform(get("/test/typed/not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("Invalid parameter value"));
+    }
+
+    @Test
     void frameworkErrorResponseExceptionKeepsItsStatusInsteadOfCollapsingTo500() throws Exception {
         mockMvc.perform(post("/test/boom"))
                 .andExpect(status().isMethodNotAllowed())
@@ -148,6 +176,13 @@ class GlobalApiExceptionHandlerTest {
     }
 
     record ValidatedRequest(@NotBlank String name) {}
+
+    enum TrackingLevel {
+        NONE,
+        SERIAL
+    }
+
+    record EnumRequest(TrackingLevel level) {}
 
     @RestController
     static class ThrowingController {
@@ -202,6 +237,16 @@ class GlobalApiExceptionHandlerTest {
         @PostMapping("/test/validated")
         String validated(@jakarta.validation.Valid @RequestBody ValidatedRequest request) {
             return request.name();
+        }
+
+        @PostMapping("/test/enum")
+        String enumBody(@RequestBody EnumRequest request) {
+            return request.level().name();
+        }
+
+        @GetMapping("/test/typed/{count}")
+        String typed(@org.springframework.web.bind.annotation.PathVariable int count) {
+            return Integer.toString(count);
         }
 
         @GetMapping("/test/denied")

--- a/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
+++ b/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
@@ -67,6 +67,13 @@ class GlobalApiExceptionHandlerTest {
     }
 
     @Test
+    void clientCorrelationIdIsTrimmedBeforeEchoing() throws Exception {
+        mockMvc.perform(get("/test/boom").header("X-Correlation-Id", "  corr-123  "))
+                .andExpect(header().string("X-Correlation-Id", "corr-123"))
+                .andExpect(jsonPath("$.correlationId").value("corr-123"));
+    }
+
+    @Test
     void uniqueConstraintViolationReturns409NamingTheConstraint() throws Exception {
         mockMvc.perform(get("/test/duplicate"))
                 .andExpect(status().isConflict())

--- a/pos-web-common/src/test/java/com/positivity/web/common/WebCommonErrorAutoConfigurationTest.java
+++ b/pos-web-common/src/test/java/com/positivity/web/common/WebCommonErrorAutoConfigurationTest.java
@@ -1,0 +1,58 @@
+package com.positivity.web.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+class WebCommonErrorAutoConfigurationTest {
+
+    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(WebCommonErrorAutoConfiguration.class));
+
+    @Test
+    void registersTheAdviceForServletWebApplications() {
+        runner.run(context -> assertThat(context).hasSingleBean(GlobalApiExceptionHandler.class));
+    }
+
+    @Test
+    void backsOffWhenDisabledByProperty() {
+        runner.withPropertyValues("pos.web.global-exception-handler.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(GlobalApiExceptionHandler.class));
+    }
+
+    @Test
+    void backsOffWhenTheServiceDefinesItsOwnBean() {
+        runner.withUserConfiguration(CustomHandlerConfiguration.class).run(context -> {
+            assertThat(context).hasSingleBean(GlobalApiExceptionHandler.class);
+            assertThat(context.getBean(GlobalApiExceptionHandler.class))
+                    .isSameAs(context.getBean(CustomHandlerConfiguration.class).handler);
+        });
+    }
+
+    @Test
+    void doesNotRegisterOutsideServletWebApplications() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(WebCommonErrorAutoConfiguration.class))
+                .run(context -> assertThat(context).doesNotHaveBean(GlobalApiExceptionHandler.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomHandlerConfiguration {
+
+        final GlobalApiExceptionHandler handler =
+                new GlobalApiExceptionHandler(Clock.fixed(Instant.parse("2026-08-23T12:00:00Z"), ZoneOffset.UTC));
+
+        @Bean
+        GlobalApiExceptionHandler customGlobalApiExceptionHandler() {
+            return handler;
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (platform hardening, not a capability story)
- Parent STORY (durion): N/A — ADR PR: louisburroughs/durion (ADR-0056, opened alongside this PR)
- Child issue: louisburroughs/durion-positivity-backend#1471
- Domain: `domain:platform` (cross-cutting; all `pos-*` servlet services)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): platform-wide error envelope — governed by ADR-0017 (`docs/adr/0017-api-controller-http-response-codes.adr.md`) and the new ADR-0056 rather than a single domain `BACKEND_CONTRACT_GUIDE.md`; no domain contract guide semantics changed (previously-unmapped failures gain the canonical envelope, mapped ones are untouched)
- Durion contract PR (if applicable): ADR-0056 PR on louisburroughs/durion (link in first comment)

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A: no controller signatures changed; error responses use the already-documented `ApiError` schema
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A (no endpoint shape changes)
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A (`ApiError` unchanged)

## Scope
- What changed:
  - New shared library **`pos-web-common`** with an auto-configured `GlobalApiExceptionHandler` registered at `Ordered.LOWEST_PRECEDENCE`: every exception no service advice mapped now leaves with the canonical `ApiError` envelope (`code`, `message`, `status`, `timestamp`, `correlationId`), an echoed/generated `X-Correlation-Id` header, and — for 500s — the stack trace logged at ERROR against that correlation id. Service-specific advices keep precedence; Spring Security exceptions are rethrown to the filter chain; framework `ErrorResponse`/`HttpMessageNotReadableException`/`TypeMismatchException` keep their 4xx statuses instead of collapsing to 500.
  - Central `DataIntegrityViolationException` mapping by SQLSTATE (`DataIntegrityViolations`): unique → **409** `DUPLICATE_RESOURCE` (naming the constraint), foreign key → **409** `REFERENCE_CONFLICT`, check → **422** `CONSTRAINT_VIOLATION`, not-null on a client-supplied column → **422** `MISSING_REQUIRED_VALUE`, not-null on a server-populated audit column (`created_by` etc., the #1464 failure mode) → enveloped, ERROR-logged **500**. Data values are never echoed, only constraint/column identifiers.
  - Wiring: `pos-security-common` re-exports `pos-web-common` (covers all 22 gateway-secured services with no pom changes); `pos-event-receiver` and both vehicle-reference services depend on it directly (they must not inherit Spring Security's lockdown auto-config); `pos-security-service` keeps its own catch-all; `pos-api-gateway` (WebFlux) is exempt.
  - Enforcement: `GlobalExceptionHandlerEnforcementTest` in `pos-archunit` fails the build for any module with `@RestController` endpoints and no catch-all coverage.
  - Docs: ADR-0056 draft (`docs/adr-0056-global-exception-handling.md`, canonical home durion/docs/adr — see companion PR), platform fallback codes added to `docs/ERROR_ENVELOPE.md`, review report in `docs/compliance/`, CLAUDE.md library table updated.
- Why: issue #1471 — unhandled exceptions escaped as Spring's bare default 500 page with no error code or correlation id. Three production bugs in two days (#1460, #1464, #1469) all presented identically as "the environment is broken"; a unique-constraint violation on ~90% of calls was indistinguishable from a flapping service. ADR-0017 §3/§4 already required the envelope on every non-2xx; this makes it structurally impossible to violate.

## Tests
- [x] Unit tests added/updated — 28 in `pos-web-common` (advice via standalone MockMvc: DIVE mappings, catch-all, correlation echo/generation, security rethrow, malformed body/enum/type-mismatch 400s, no-leak 500 body; SQLSTATE classifier for PostgreSQL and H2 messages; auto-configuration back-off on property/user bean/non-servlet)
- [x] Integration tests added/updated — full reactor suite run twice: the first run caught `HttpMessageNotReadableException` collapsing to 500 in pos-catalog's `ProductContractAttributesContractTest` (fixed in a6872d0); second run green across all 42 modules with the advice active
- [x] Provider behavioral contract tests added/updated — `GlobalExceptionHandlerEnforcementTest` (pos-archunit) gates the catch-all requirement build-wide
- How to run: `./mvnw -pl pos-web-common -am test` · `./mvnw -pl pos-archunit -am -Dtest=GlobalExceptionHandlerEnforcementTest -Dsurefire.failIfNoSpecifiedTests=false test` · full: `./mvnw test`

## Risk & Rollback
- Risk level: Medium — changes the HTTP status/body of previously-unmapped failure paths in every servlet service (bare 500 → enveloped 409/422/500). Mapped paths and service advices are untouched; `@WebMvcTest` slices don't load the auto-config. Full reactor suite is green.
- Rollback plan: property kill-switch `pos.web.global-exception-handler.enabled=false` disables the advice per service without a deploy of code changes; full rollback = revert the three commits (the new module is additive).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (issue-driven platform change, branch `claude/adr-exception-handling-review-mgtstf`)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (no capability id)
- [x] Links to parent + child issues are present (#1471; ADR PR linked in first comment)
- [x] Contract guide updated (when contract semantics changed) — via ADR-0056 + `docs/ERROR_ENVELOPE.md` platform fallback codes
- [x] Required CI checks passing — full local reactor `./mvnw test` green (42/42 modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpRCpHf6Kc211v8phS4phq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpRCpHf6Kc211v8phS4phq)_