### PR TITLE
fix(workorder): record the creator on the appointment-to-estimate bridge

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -1518,12 +1518,19 @@ public class EstimateServiceImpl implements EstimateService {
                     .build();
         }
 
+        // created_by_id is NOT NULL. Every other create path sets it from the
+        // security context; this one did not, so the insert died on the
+        // constraint and the endpoint answered 500 for every caller.
+        String createdBy = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+
         Estimate estimate = Estimate.builder()
                 .status(EstimateStatus.DRAFT)
                 .customerId(request.getCustomerId())
                 .vehicleId(request.getVehicleId())
                 .locationId(request.getLocationId())
                 .appointmentId(request.getAppointmentId())
+                .createdById(createdBy)
+                .createdByUserId(createdBy)
                 .build();
 
         Estimate saved = estimateRepository.save(estimate);

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateFromAppointmentCreatedByIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateFromAppointmentCreatedByIT.java
@@ -53,8 +53,20 @@ class EstimateFromAppointmentCreatedByIT {
                 .as("created_by_id is NOT NULL; the bridge has to supply it like every other create path")
                 .isNotNull();
 
-        // The endpoint is idempotent on the appointment, not on the key.
-        CreateEstimateFromAppointmentResponse replay = estimateService.createEstimateFromAppointment(request);
+        // Idempotent on the appointment, not on the key: the service looks the
+        // estimate up by appointmentId. Replaying with the same key would pass
+        // either way, so the replay deliberately carries a different one.
+        CreateEstimateFromAppointmentRequest replayRequest = new CreateEstimateFromAppointmentRequest();
+        replayRequest.setIdempotencyKey(UUID.randomUUID());
+        replayRequest.setAppointmentId(appointmentId);
+        replayRequest.setCustomerId(UUID.randomUUID());
+        replayRequest.setVehicleId(UUID.randomUUID());
+        replayRequest.setLocationId(UUID.randomUUID());
+        assertThat(replayRequest.getIdempotencyKey())
+                .as("the replay must not reuse the first key, or it proves nothing about the appointment")
+                .isNotEqualTo(request.getIdempotencyKey());
+
+        CreateEstimateFromAppointmentResponse replay = estimateService.createEstimateFromAppointment(replayRequest);
         assertThat(replay.isCreated()).isFalse();
         assertThat(replay.getEstimateId()).isEqualTo(first.getEstimateId());
     }

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateFromAppointmentCreatedByIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateFromAppointmentCreatedByIT.java
@@ -1,0 +1,61 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.workorder.internal.dto.CreateEstimateFromAppointmentRequest;
+import com.positivity.workorder.internal.dto.CreateEstimateFromAppointmentResponse;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.service.EstimateService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Pins that the appointment bridge fills the audited creator.
+ *
+ * <p>It did not. {@code Estimate.createdById} is {@code @Column(nullable = false)} and every other
+ * create path sets it from the security context, but createEstimateFromAppointment built its entity
+ * without it - so the insert died on the constraint and the endpoint answered a bare 500 to every
+ * caller. Nothing covered the persisting path: the existing controller test mocks the service.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("An estimate created from an appointment records who created it")
+class EstimateFromAppointmentCreatedByIT {
+
+    @Autowired
+    private EstimateService estimateService;
+
+    @Autowired
+    private EstimateRepository estimateRepository;
+
+    @Test
+    @DisplayName("the bridge persists, and the idempotent replay returns the same estimate")
+    void bridgePersistsAndReplays() {
+        UUID appointmentId = UUID.randomUUID();
+        CreateEstimateFromAppointmentRequest request = new CreateEstimateFromAppointmentRequest();
+        request.setIdempotencyKey(UUID.randomUUID());
+        request.setAppointmentId(appointmentId);
+        request.setCustomerId(UUID.randomUUID());
+        request.setVehicleId(UUID.randomUUID());
+        request.setLocationId(UUID.randomUUID());
+
+        CreateEstimateFromAppointmentResponse first = estimateService.createEstimateFromAppointment(request);
+
+        assertThat(first.isCreated()).isTrue();
+        assertThat(first.getEstimateId()).isNotNull();
+        assertThat(estimateRepository.findById(first.getEstimateId()))
+                .get()
+                .extracting(estimate -> estimate.getCreatedById())
+                .as("created_by_id is NOT NULL; the bridge has to supply it like every other create path")
+                .isNotNull();
+
+        // The endpoint is idempotent on the appointment, not on the key.
+        CreateEstimateFromAppointmentResponse replay = estimateService.createEstimateFromAppointment(request);
+        assertThat(replay.isCreated()).isFalse();
+        assertThat(replay.getEstimateId()).isEqualTo(first.getEstimateId());
+    }
+}


### PR DESCRIPTION
## Symptom

`POST /v1/workorders/estimates/from-appointment` returns **500 for every caller**, with Spring's default error body — so the exception never reached the `@ControllerAdvice`:

```json
{"timestamp":"2026-08-23T18:03:19.899Z","status":500,"error":"Internal Server Error","path":"/v1/workorders/estimates/from-appointment"}
```

## Cause

`Estimate.createdById` is `@Column(nullable = false)` and `estimate.created_by_id` is `NOT NULL`. Every other create path fills it from the security context:

```java
// createEstimate, line 262
String userId = SecurityContextHelper.getCurrentUsernameOrDefault(resolvedUsername);
Estimate.builder()....createdById(userId)
```

`createEstimateFromAppointment` built its entity from five fields and left it out:

```java
Estimate estimate = Estimate.builder()
        .status(EstimateStatus.DRAFT)
        .customerId(request.getCustomerId())
        .vehicleId(request.getVehicleId())
        .locationId(request.getLocationId())
        .appointmentId(request.getAppointmentId())
        .build();                                  // no createdById
```

So the insert died on the constraint. **This endpoint has never worked** — it is not a regression.

## Why nothing caught it

The existing `EstimateFromAppointmentControllerTest` mocks the service, so the persisting path was never exercised. The new test drives the real `EstimateService` against the schema: on `main` it fails with `NULL not allowed for column "CREATED_BY_ID"`, and passes with this change.

It also pins the documented idempotency while it is there — a replay for the same appointment returns `created=false` and the same `estimateId`, which is the behaviour the operation's description promises and nothing asserted.

## Verification

- New `EstimateFromAppointmentCreatedByIT`: fails on main with the constraint violation, passes here
- pos-workorder suite: **879 tests, 0 failures, 0 errors**

## Related

Third instance of the same shape in three days — a NOT NULL column unset on one path, surfacing as an undiagnosable bare 500 (#1460 catalog, #1464 order, #1469 customer). #1471 tracks the general fix: map `DataIntegrityViolationException` to 409/422 and give every service a catch-all that carries a correlation id. Each of these took hours that a mapped status would have made minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
