### PR TITLE
Fix generated-client contracts: SSE stream schema (#1455) and flat paging/filter params (#1465)

### DIFF
--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -82,11 +82,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -912,11 +931,30 @@ paths:
           - APPLIED
           - VOIDED
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -1149,11 +1187,30 @@ paths:
           - PARTIALLY_CONSUMED
           - CONSUMED
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -1861,11 +1918,32 @@ paths:
         required: false
         schema:
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - receivedAt,DESC
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -2306,11 +2384,32 @@ paths:
         '
       operationId: listExportHistory
       parameters:
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - requestedAt,DESC
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -5720,11 +5819,32 @@ paths:
         '
       operationId: listReportExports
       parameters:
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - requestedAt,DESC
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -11195,21 +11315,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/APPaymentController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/APPaymentController.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -245,7 +246,7 @@ public class APPaymentController {
                             required = false)
                     @Nullable
                     UUID vendorId,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
 
         Page<VendorBillSummaryResponse> bills = apPaymentService.listEligibleBills(vendorId, pageable);
         return ResponseEntity.ok(bills);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CreditMemoController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CreditMemoController.java
@@ -21,6 +21,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -254,7 +255,7 @@ public class CreditMemoController {
             @Parameter(description = "Filter by status (DRAFT, POSTED, APPLIED, VOIDED)")
                     @RequestParam(required = false)
                     CreditMemoStatus status,
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
 
         log.debug(
                 "Listing Credit Memos: customerId={}, invoiceId={}, status={}, page={}",

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CustomerCreditController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CustomerCreditController.java
@@ -22,6 +22,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -90,7 +91,7 @@ public class CustomerCreditController {
             @Parameter(description = "Filter by customer") @RequestParam(required = false) UUID customerId,
             @Parameter(description = "Filter by consumption state") @RequestParam(required = false)
                     CustomerCreditStatus status,
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         return ResponseEntity.ok(customerCreditService.listCredits(customerId, status, pageable));
     }
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/EventIngestionController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/EventIngestionController.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -104,7 +105,8 @@ public class EventIngestionController {
             @Parameter(description = "Filter by domain key") @RequestParam(required = false) String domainKeyId,
             @Parameter(description = "Filter by invoice UUID") @RequestParam(required = false) UUID invoiceId,
             @Parameter(description = "Filter by processing status") @RequestParam(required = false) String status,
-            @PageableDefault(size = 20, sort = "receivedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "receivedAt", direction = Sort.Direction.DESC)
+                    Pageable pageable) {
 
         AccountingEventStatus parsedStatus = null;
         if (status != null) {

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -232,7 +233,8 @@ public class ReportExportController {
     @ApiResponse(responseCode = "401", description = "Unauthorized")
     @ApiResponse(responseCode = "403", description = "Forbidden - missing accounting:report:export")
     public ResponseEntity<Page<ReportExportResponse>> getExportHistory(
-            @PageableDefault(size = 20, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "requestedAt", direction = Sort.Direction.DESC)
+                    Pageable pageable) {
 
         Page<ReportExportResponse> page = reportExportService.getExportHistory(pageable);
         return ResponseEntity.ok(page);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/TimekeepingExportController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/TimekeepingExportController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -134,7 +135,8 @@ public class TimekeepingExportController {
     @ApiResponse(responseCode = "200", description = "Export history returned")
     @ApiResponse(responseCode = "403", description = "Forbidden")
     public ResponseEntity<Page<ExportJobResponse>> listExportHistory(
-            @PageableDefault(size = 20, sort = "requestedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "requestedAt", direction = Sort.Direction.DESC)
+                    Pageable pageable) {
         Page<ExportJobResponse> history = timekeepingExportService.listExportHistory(pageable);
         return ResponseEntity.ok(history);
     }

--- a/pos-bulk-loader/openapi.yaml
+++ b/pos-bulk-loader/openapi.yaml
@@ -38,11 +38,30 @@ paths:
         '
       operationId: listBulkLoadJobs
       parameters:
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -1466,21 +1485,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/BulkLoadJobController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/BulkLoadJobController.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -121,7 +122,7 @@ public class BulkLoadJobController {
                     error responses.
                     """)
     @ApiResponse(responseCode = "200", description = "Jobs listed")
-    public ResponseEntity<Page<BulkLoadJobResponse>> listJobs(@NonNull Pageable pageable) {
+    public ResponseEntity<Page<BulkLoadJobResponse>> listJobs(@ParameterObject @NonNull Pageable pageable) {
         String operatorId = currentOperatorId();
         return ResponseEntity.ok(bulkLoadJobService.listJobsForOperator(operatorId, pageable));
     }

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -90,12 +90,32 @@ paths:
         required: false
         schema:
           type: string
-      - description: Pagination parameters (page, size, sort)
+      - description: Zero-based page index (0..N)
         in: query
-        name: pageable
-        required: true
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - customerNumber,ASC
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -173,12 +193,33 @@ paths:
         '
       operationId: browseParties
       parameters:
-      - description: Pagination parameters (page, size, sort). The service uses legalName,asc by default and appends partyId,asc as a stable tie-breaker whenever the requested sort list does not explicitly include partyId; legalName sorting is case-insensitive.
+      - description: Zero-based page index (0..N)
         in: query
-        name: pageable
-        required: true
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - legalName,ASC
+          - partyId,ASC
+          items:
+            type: string
+          type: array
       - description: Filter by name (case-insensitive contains on legal/display name)
         in: query
         name: name
@@ -6248,21 +6289,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -297,11 +298,7 @@ public class CrmAccountsController {
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
     @EmitEvent(id = "CUSTOMER_PARTY_BROWSE", apiVersion = "1")
     public ResponseEntity<SearchPartiesResponse> browseParties(
-            @Parameter(
-                            description = "Pagination parameters (page, size, sort). The service uses legalName,asc "
-                                    + "by default and appends partyId,asc as a stable tie-breaker whenever the "
-                                    + "requested sort list does not explicitly include partyId; legalName sorting "
-                                    + "is case-insensitive.")
+            @ParameterObject
                     @PageableDefault(
                             size = 20,
                             sort = {"legalName", "partyId"})

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -74,9 +75,7 @@ public class CustomerController {
             @Parameter(description = "Case-insensitive email filter for typeahead search", example = "jdoe@acme.com")
                     @RequestParam(required = false)
                     String email,
-            @Parameter(description = "Pagination parameters (page, size, sort)")
-                    @PageableDefault(size = 20, sort = "customerNumber")
-                    Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "customerNumber") Pageable pageable) {
         CustomerService service = COMMERCIAL.equalsIgnoreCase(customerType) ? commercialService : personService;
 
         boolean searching = (name != null && !name.isBlank()) || (email != null && !email.isBlank());

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -2836,11 +2836,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -2886,11 +2905,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -4139,11 +4177,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -4978,11 +5035,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -6690,11 +6766,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -10692,21 +10787,6 @@ components:
       required:
       - itemId
       - quantity
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PickListResponse:
       description: Pick list details returned after creation, generation, or lookup

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryReferenceDataController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryReferenceDataController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -67,7 +68,8 @@ public class InventoryReferenceDataController {
             description = "User lacks required location view authority",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<Page<LocationDto>> listLocations(
-            @RequestParam(required = false) UUID siteId, @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(required = false) UUID siteId,
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(inventoryReferenceDataService.listLocations(siteId, pageable));
     }
 
@@ -103,7 +105,8 @@ public class InventoryReferenceDataController {
             description = "User lacks required location view authority",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<Page<StorageLocationDto>> listStorageLocations(
-            @RequestParam(required = false) UUID locationId, @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(required = false) UUID locationId,
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(inventoryReferenceDataService.listStorageLocations(locationId, pageable));
     }
 
@@ -139,7 +142,8 @@ public class InventoryReferenceDataController {
             description = "User lacks required location view authority",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<Page<LocationZoneDto>> listLocationZones(
-            @RequestParam(required = false) UUID locationId, @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(required = false) UUID locationId,
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(inventoryReferenceDataService.listLocationZones(locationId, pageable));
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/PurchaseSuggestionController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/PurchaseSuggestionController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -89,7 +90,7 @@ public class PurchaseSuggestionController {
                     String status,
             @Parameter(description = "Stock item (SKU) filter") @RequestParam(required = false) String sku,
             @Parameter(description = "Destination location filter") @RequestParam(required = false) UUID locationId,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(purchaseSuggestionService.listPurchaseSuggestions(status, sku, locationId, pageable));
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
@@ -21,6 +21,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -106,7 +107,7 @@ public class ReplenishmentController {
             @io.swagger.v3.oas.annotations.Parameter(description = "Location identifier")
                     @RequestParam(required = false)
                     UUID locationId,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(replenishmentService.getReplenishmentPolicies(locationId, pageable));
     }
 

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -553,11 +553,32 @@ paths:
         required: false
         schema:
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 25
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - createdAt,DESC
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -2731,21 +2752,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -80,8 +81,7 @@ public class InvoiceSearchController {
                     @RequestParam(required = false)
                     @Nullable
                     String q,
-            @Parameter(schema = @Schema(implementation = Pageable.class))
-                    @PageableDefault(size = 25, sort = "createdAt", direction = Sort.Direction.DESC)
+            @ParameterObject @PageableDefault(size = 25, sort = "createdAt", direction = Sort.Direction.DESC)
                     Pageable pageable) {
         return invoiceSearchService.search(q == null ? "" : q.trim(), capPageSize(pageable));
     }

--- a/pos-location/openapi.yaml
+++ b/pos-location/openapi.yaml
@@ -257,11 +257,30 @@ paths:
         schema:
           format: date-time
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -1205,11 +1224,30 @@ paths:
           - MAINTENANCE
           - QUARANTINED
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -3173,21 +3211,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/LocationController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/LocationController.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -123,7 +124,7 @@ public class LocationController {
                     @RequestParam(required = false)
                     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
                     Instant sinceUpdatedAt,
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         return locationRosterService.getRoster(status, sinceUpdatedAt, pageable);
     }
 

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/StorageLocationController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/StorageLocationController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -125,7 +126,7 @@ public class StorageLocationController {
             @PathVariable UUID siteId,
             @RequestParam(required = false) StorageLocationType type,
             @RequestParam(required = false) StorageLocationStatus status,
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         return storageLocationService.listStorageLocations(siteId, type, status, pageable);
     }
 

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -300,9 +300,9 @@ paths:
           content:
             text/event-stream:
               schema:
-                items:
-                  $ref: '#/components/schemas/ServerSentEventString'
-                type: array
+                description: Raw text/event-stream body to be read incrementally; each event has event type chat and a single response token as its data payload
+                format: binary
+                type: string
           description: Stream of SSE chat tokens
       security:
       - bearerAuth:
@@ -1350,31 +1350,6 @@ components:
           $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
-      type: object
-    ServerSentEventString:
-      description: A Server-Sent Event carrying a string data payload
-      properties:
-        comment:
-          description: Comment line carried by the event
-          example: keep-alive
-          type: string
-        data:
-          description: String data payload of the event, typically a response token
-          example: Hi
-          type: string
-        event:
-          description: Event name
-          example: chat
-          type: string
-        id:
-          description: Event identifier
-          example: '1'
-          type: string
-        retry:
-          description: Reconnection time in milliseconds the client should wait before retrying
-          example: 3000
-          format: int64
-          type: integer
       type: object
     SortObject:
       properties:

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
@@ -6,14 +6,12 @@ import com.positivity.mcp.internal.service.CurrentUserContextResolver;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.StreamingAgentOrchestrationService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -69,10 +67,15 @@ public class McpStreamingChatController {
                         content =
                                 @Content(
                                         mediaType = MediaType.TEXT_EVENT_STREAM_VALUE,
-                                        array =
-                                                @ArraySchema(
-                                                        schema =
-                                                                @Schema(implementation = ServerSentEventString.class))))
+                                        schema =
+                                                @Schema(
+                                                        type = "string",
+                                                        format = "binary",
+                                                        description =
+                                                                "Raw text/event-stream body to be read incrementally;"
+                                                                        + " each event has event type chat and a"
+                                                                        + " single response token as its data"
+                                                                        + " payload")))
             })
     @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_STREAM + "')")
@@ -122,35 +125,4 @@ public class McpStreamingChatController {
             @NotBlank
             @NonNull
             String message) {}
-
-    @Schema(name = "ServerSentEventString", description = "A Server-Sent Event carrying a string data payload")
-    public record ServerSentEventString(
-            @Schema(description = "Event identifier", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-            @Nullable
-            String id,
-
-            @Schema(description = "Event name", example = "chat", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-            @Nullable
-            String event,
-
-            @Schema(
-                    description = "String data payload of the event, typically a response token",
-                    example = "Hi",
-                    requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-            @Nullable
-            String data,
-
-            @Schema(
-                    description = "Reconnection time in milliseconds the client should wait before retrying",
-                    example = "3000",
-                    requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-            @Nullable
-            Long retry,
-
-            @Schema(
-                    description = "Comment line carried by the event",
-                    example = "keep-alive",
-                    requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-            @Nullable
-            String comment) {}
 }

--- a/pos-order/openapi.yaml
+++ b/pos-order/openapi.yaml
@@ -1037,16 +1037,75 @@ paths:
         '
       operationId: listPurchaseOrders
       parameters:
-      - in: query
-        name: filter
-        required: true
+      - description: Filter to purchase orders placed with this vendor
+        example: 01960003-0000-7000-8000-000000000001
+        in: query
+        name: vendorId
+        required: false
         schema:
-          $ref: '#/components/schemas/ListPurchaseOrdersRequest'
-      - in: query
-        name: pageable
-        required: true
+          description: Filter to purchase orders placed with this vendor
+          example: 01960003-0000-7000-8000-000000000001
+          format: uuid
+          type: string
+      - description: Filter to purchase orders in this lifecycle status
+        example: APPROVED
+        in: query
+        name: status
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          description: Filter to purchase orders in this lifecycle status
+          enum:
+          - DRAFT
+          - APPROVED
+          - PARTIALLY_RECEIVED
+          - FULLY_RECEIVED
+          - CLOSED
+          - CANCELLED
+          example: APPROVED
+          type: string
+      - description: Filter to purchase orders denominated in this ISO 4217 currency code
+        example: USD
+        in: query
+        name: currency
+        required: false
+        schema:
+          description: Filter to purchase orders denominated in this ISO 4217 currency code
+          example: USD
+          type: string
+      - description: Filter to purchase orders shipping to this location
+        example: 01960003-0000-7000-8000-000000000002
+        in: query
+        name: locationId
+        required: false
+        schema:
+          description: Filter to purchase orders shipping to this location
+          example: 01960003-0000-7000-8000-000000000002
+          format: uuid
+          type: string
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -2768,35 +2827,6 @@ components:
       - sourceId
       - sourceType
       type: object
-    ListPurchaseOrdersRequest:
-      description: Optional filter criteria for listing purchase orders
-      properties:
-        currency:
-          description: Filter to purchase orders denominated in this ISO 4217 currency code
-          example: USD
-          type: string
-        locationId:
-          description: Filter to purchase orders shipping to this location
-          example: 01960003-0000-7000-8000-000000000002
-          format: uuid
-          type: string
-        status:
-          description: Filter to purchase orders in this lifecycle status
-          enum:
-          - DRAFT
-          - APPROVED
-          - PARTIALLY_RECEIVED
-          - FULLY_RECEIVED
-          - CLOSED
-          - CANCELLED
-          example: APPROVED
-          type: string
-        vendorId:
-          description: Filter to purchase orders placed with this vendor
-          example: 01960003-0000-7000-8000-000000000001
-          format: uuid
-          type: string
-      type: object
     OpenSessionRequest:
       description: Request payload for opening a register session
       properties:
@@ -2879,21 +2909,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -187,7 +188,7 @@ public class PurchaseOrderController {
             description = "User lacks required purchase order view authority",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<Page<PurchaseOrderResponse>> listPurchaseOrders(
-            @ModelAttribute ListPurchaseOrdersRequest filter, Pageable pageable) {
+            @ParameterObject @ModelAttribute ListPurchaseOrdersRequest filter, @ParameterObject Pageable pageable) {
         return ResponseEntity.ok(purchaseOrderService.listPurchaseOrders(filter, pageable));
     }
 

--- a/pos-order/src/test/java/com/positivity/order/PurchaseOrderListOpenApiContractTest.java
+++ b/pos-order/src/test/java/com/positivity/order/PurchaseOrderListOpenApiContractTest.java
@@ -19,8 +19,8 @@ import tools.jackson.databind.ObjectMapper;
  * <p>Spring binds flat query parameters (vendorId=, page=, size=), so the OpenAPI spec must
  * declare them flat as well. Without {@code @ParameterObject} springdoc renders the
  * {@code @ModelAttribute} filter and {@code Pageable} as object-typed parameters, and generated
- * clients then send {@code filter[vendorId]=..&pageable[size]=..} — which Spring silently ignores,
- * serving default paging with no filter applied.
+ * clients then send {@code filter[vendorId]=..} and {@code pageable[size]=..} — which Spring
+ * silently ignores, serving default paging with no filter applied.
  */
 class PurchaseOrderListOpenApiContractTest extends BaseContractIntegrationTest {
 

--- a/pos-order/src/test/java/com/positivity/order/PurchaseOrderListOpenApiContractTest.java
+++ b/pos-order/src/test/java/com/positivity/order/PurchaseOrderListOpenApiContractTest.java
@@ -1,0 +1,64 @@
+package com.positivity.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Guards the query-parameter contract of the paged purchase-order listing (issue #1465).
+ *
+ * <p>Spring binds flat query parameters (vendorId=, page=, size=), so the OpenAPI spec must
+ * declare them flat as well. Without {@code @ParameterObject} springdoc renders the
+ * {@code @ModelAttribute} filter and {@code Pageable} as object-typed parameters, and generated
+ * clients then send {@code filter[vendorId]=..&pageable[size]=..} — which Spring silently ignores,
+ * serving default paging with no filter applied.
+ */
+class PurchaseOrderListOpenApiContractTest extends BaseContractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("listPurchaseOrders declares flat filter and paging query parameters, not object-typed ones")
+    @SuppressWarnings("unchecked")
+    void listPurchaseOrders_declaresFlatQueryParameters() throws Exception {
+        MvcResult result = mockMvc.perform(withGatewayAuth(get("/v3/api-docs")))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> openApiSpec =
+                objectMapper.readValue(result.getResponse().getContentAsString(), Map.class);
+        Map<String, Object> paths = (Map<String, Object>) openApiSpec.get("paths");
+        Map<String, Object> pathItem = (Map<String, Object>) paths.get("/v1/orders/purchase-orders");
+        assertThat(pathItem).as("path /v1/orders/purchase-orders should exist").isNotNull();
+
+        Map<String, Object> operation = (Map<String, Object>) pathItem.get("get");
+        assertThat(operation)
+                .as("GET /v1/orders/purchase-orders operation should exist")
+                .isNotNull();
+
+        List<Map<String, Object>> parameters = (List<Map<String, Object>>) operation.get("parameters");
+        assertThat(parameters).as("parameters should be declared").isNotNull();
+        List<String> parameterNames =
+                parameters.stream().map(p -> (String) p.get("name")).toList();
+
+        assertThat(parameterNames)
+                .as("filter fields and paging must be flat query parameters matching what Spring binds")
+                .contains("vendorId", "status", "currency", "locationId", "page", "size", "sort");
+        assertThat(parameterNames)
+                .as("object-typed filter/pageable parameters generate clients whose requests Spring "
+                        + "silently ignores")
+                .doesNotContain("filter", "pageable");
+    }
+}

--- a/pos-security-service/openapi.yaml
+++ b/pos-security-service/openapi.yaml
@@ -150,6 +150,30 @@ paths:
           items:
             type: string
           type: array
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -1536,6 +1560,30 @@ paths:
         required: false
         schema:
           type: string
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -3891,6 +3939,30 @@ paths:
         required: false
         schema:
           type: string
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -200,7 +201,7 @@ public class AuditController {
                             example = "11111111-1111-1111-1111-111111111111")
                     @RequestParam(required = false)
                     List<String> locationIds,
-            @Parameter(hidden = true) Pageable pageable) {
+            @ParameterObject Pageable pageable) {
 
         AuditEventSearchFilter filter = AuditEventSearchFilter.builder()
                 .fromDate(fromDate)

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PermissionController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PermissionController.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -285,7 +286,7 @@ public class PermissionController {
             @Parameter(description = "Optional domain filter", required = false, example = "catalog")
                     @RequestParam(required = false)
                     String domain,
-            @Parameter(hidden = true) Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         Page<PermissionDto> permissions = permissionService.listPermissions(domain, pageable);
         return ResponseEntity.ok(permissions);
     }

--- a/pos-shop-manager/openapi.yaml
+++ b/pos-shop-manager/openapi.yaml
@@ -676,11 +676,86 @@ paths:
         '
       operationId: searchShopAudit
       parameters:
-      - in: query
-        name: filter
-        required: true
+      - description: Workorder UUID to filter by - one word per workspace naming policy
+        example: 01960003-0000-7000-8000-000000000001
+        in: query
+        name: workorderId
+        required: false
         schema:
-          $ref: '#/components/schemas/ShopAuditFilter'
+          description: Workorder UUID to filter by - one word per workspace naming policy
+          example: 01960003-0000-7000-8000-000000000001
+          type: string
+      - description: Appointment UUID to filter by
+        example: 01960003-0000-7000-8000-000000000002
+        in: query
+        name: appointmentId
+        required: false
+        schema:
+          description: Appointment UUID to filter by
+          example: 01960003-0000-7000-8000-000000000002
+          type: string
+      - description: Mechanic user ID to filter by
+        example: 01960003-0000-7000-8000-000000000010
+        in: query
+        name: mechanicId
+        required: false
+        schema:
+          description: Mechanic user ID to filter by
+          example: 01960003-0000-7000-8000-000000000010
+          type: string
+      - description: Actor user ID to filter by
+        example: 01960003-0000-7000-8000-000000000020
+        in: query
+        name: actorUserId
+        required: false
+        schema:
+          description: Actor user ID to filter by
+          example: 01960003-0000-7000-8000-000000000020
+          type: string
+      - description: Specific audit event type to filter by
+        example: SCHEDULE_UPDATED
+        in: query
+        name: eventType
+        required: false
+        schema:
+          description: Specific audit event type to filter by
+          enum:
+          - SCHEDULE_CREATED
+          - SCHEDULE_UPDATED
+          - SCHEDULE_CANCELLED
+          - ASSIGNMENT_CREATED
+          - ASSIGNMENT_REMOVED
+          example: SCHEDULE_UPDATED
+          type: string
+      - description: Location ID to filter by
+        example: 01960003-0000-7000-8000-000000000003
+        in: query
+        name: locationId
+        required: false
+        schema:
+          description: Location ID to filter by
+          example: 01960003-0000-7000-8000-000000000003
+          type: string
+      - description: Inclusive start timestamp for date-time range filter
+        example: 2026-01-01 00:00:00+00:00
+        in: query
+        name: fromDateTime
+        required: false
+        schema:
+          description: Inclusive start timestamp for date-time range filter
+          example: 2026-01-01 00:00:00+00:00
+          format: date-time
+          type: string
+      - description: Inclusive end timestamp for date-time range filter
+        example: 2026-12-31 23:59:59+00:00
+        in: query
+        name: toDateTime
+        required: false
+        schema:
+          description: Inclusive end timestamp for date-time range filter
+          example: 2026-12-31 23:59:59+00:00
+          format: date-time
+          type: string
       responses:
         '200':
           content:
@@ -1456,50 +1531,6 @@ components:
       - id
       - recordedAt
       - retentionYears
-      type: object
-    ShopAuditFilter:
-      description: Filter criteria for querying the shop audit trail. At least one field must be non-null.
-      properties:
-        actorUserId:
-          description: Actor user ID to filter by
-          example: 01960003-0000-7000-8000-000000000020
-          type: string
-        appointmentId:
-          description: Appointment UUID to filter by
-          example: 01960003-0000-7000-8000-000000000002
-          type: string
-        eventType:
-          description: Specific audit event type to filter by
-          enum:
-          - SCHEDULE_CREATED
-          - SCHEDULE_UPDATED
-          - SCHEDULE_CANCELLED
-          - ASSIGNMENT_CREATED
-          - ASSIGNMENT_REMOVED
-          example: SCHEDULE_UPDATED
-          type: string
-        fromDateTime:
-          description: Inclusive start timestamp for date-time range filter
-          example: 2026-01-01 00:00:00+00:00
-          format: date-time
-          type: string
-        locationId:
-          description: Location ID to filter by
-          example: 01960003-0000-7000-8000-000000000003
-          type: string
-        mechanicId:
-          description: Mechanic user ID to filter by
-          example: 01960003-0000-7000-8000-000000000010
-          type: string
-        toDateTime:
-          description: Inclusive end timestamp for date-time range filter
-          example: 2026-12-31 23:59:59+00:00
-          format: date-time
-          type: string
-        workorderId:
-          description: Workorder UUID to filter by - one word per workspace naming policy
-          example: 01960003-0000-7000-8000-000000000001
-          type: string
       type: object
   securitySchemes:
     bearerAuth:

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ShopAuditController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ShopAuditController.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -73,7 +74,7 @@ public class ShopAuditController {
             responseCode = "403",
             description = "Insufficient authority",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public @NonNull List<ShopAuditEntryResponse> searchAudit(@ModelAttribute ShopAuditFilter filter) {
+    public @NonNull List<ShopAuditEntryResponse> searchAudit(@ParameterObject @ModelAttribute ShopAuditFilter filter) {
         return shopAuditService.search(filter);
     }
 

--- a/pos-warranty/openapi.yaml
+++ b/pos-warranty/openapi.yaml
@@ -85,11 +85,32 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          default:
+          - createdAt,DESC
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -2789,21 +2810,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ClaimController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ClaimController.java
@@ -28,6 +28,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -184,7 +185,8 @@ public class ClaimController {
             @Parameter(description = "Exact claim code, e.g. WC-2026-000123") @RequestParam(required = false)
                     String claimCode,
             @Parameter(description = "Filter by location id") @RequestParam(required = false) UUID locationId,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                    Pageable pageable) {
         return ResponseEntity.ok(claimService.search(customerId, vehicleId, status, claimCode, locationId, pageable));
     }
 

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -415,11 +415,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 25
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -800,11 +819,30 @@ paths:
         schema:
           default: false
           type: boolean
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 25
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -2548,11 +2586,30 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
-        name: pageable
-        required: true
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
         schema:
-          $ref: '#/components/schemas/Pageable'
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 25
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
       responses:
         '200':
           content:
@@ -7603,21 +7660,6 @@ components:
         totalPages:
           format: int32
           type: integer
-      type: object
-    Pageable:
-      properties:
-        page:
-          format: int32
-          minimum: 0
-          type: integer
-        size:
-          format: int32
-          minimum: 1
-          type: integer
-        sort:
-          items:
-            type: string
-          type: array
       type: object
     PageableObject:
       properties:

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateSearchController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateSearchController.java
@@ -6,12 +6,12 @@ import com.positivity.workorder.internal.security.WorkorderPermissions;
 import com.positivity.workorder.service.EstimateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -60,8 +60,7 @@ public class EstimateSearchController {
                     UUID customerId,
             @Parameter(description = "Filter by vehicle UUID (optional)") @RequestParam(required = false) @Nullable
                     UUID vehicleId,
-            @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
-                    Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 25) Pageable pageable) {
         if (q != null && !q.isBlank()) {
             return estimateService.findEstimatesByQuery(q.trim(), pageable);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WipController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WipController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -73,7 +74,7 @@ public class WipController {
                             schema = @Schema(type = "boolean", defaultValue = "false"))
                     @RequestParam(defaultValue = "false")
                     boolean multiLocation,
-            @PageableDefault(size = 25) Pageable pageable,
+            @ParameterObject @PageableDefault(size = 25) Pageable pageable,
             Authentication authentication) {
 
         if (multiLocation

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
@@ -8,7 +8,6 @@ import com.positivity.workorder.internal.security.WorkorderPermissions;
 import com.positivity.workorder.service.WorkorderSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -16,6 +15,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -69,8 +69,7 @@ public class WorkorderSearchController {
                     @RequestParam(required = false)
                     @Nullable
                     UUID vehicleId,
-            @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
-                    Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 25) Pageable pageable) {
         return workorderSearchService.search(q == null ? "" : q.trim(), customerId, vehicleId, pageable);
     }
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (bug fixes, no capability id on the issues)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1455, louisburroughs/durion-positivity-backend#1465
- Domain: cross-cutting (`mcp`, `order`, `accounting`, `bulk-loader`, `customer`, `inventory`, `invoice`, `location`, `security`, `shop-manager`, `warranty`, `workorder`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract-semantics change: request/response payloads and server binding are untouched; the specs are corrected to describe the flat query parameters Spring already binds and the SSE wire format the stream endpoint already emits.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated for all 12 affected modules (`-Popenapi` + `scripts/sanitize-openapi.py`); `pos-api-gateway/docs/openapi-aggregate.yaml` regenerated with no diff (path set unchanged)
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — follow-up in the SDK repos: regenerate `@durion-sdk/mcp-server` and the paged-list clients, then revert the durion-positivity-sdk#13 seeder workaround and drop the known-limitation note in `packages/sdk-mcp-server/README.md` (per the #1455/#1465 acceptance criteria)

## Scope
- What changed:
  - **#1455** — `POST /v1/mcp/chat/stream` 200 response is now declared under `text/event-stream` as `type: string, format: binary` instead of a JSON array of `ServerSentEventString`. Generators stop emitting `JSONApiResponse` (which JSON-parsed the SSE body and threw) and clients can read the raw response stream incrementally. The `ServerSentEventString` record existed only to feed the broken array schema and is removed. Option 1 from the issue, as chosen by the owner.
  - **#1465** — swept every controller that binds `@ModelAttribute` or `Pageable` from query parameters (23 controllers across 12 modules) and annotated those parameters with springdoc's `@ParameterObject`, so specs declare the flat `page`, `size`, `sort` and individual filter fields Spring actually binds instead of object-typed `filter`/`pageable` params that generated clients serialized as `filter[vendorId]=..&pageable[size]=..` — which Spring silently ignored. Also covers `pos-security-service`'s `@Parameter(hidden = true) Pageable` (generated clients previously had no way to page at all) and the `@Parameter(schema = @Schema(implementation = Pageable.class))` variant in `pos-invoice`/`pos-workorder`.
  - Regenerated `openapi.yaml` for all 12 touched modules; no object-typed `name: filter` / `name: pageable` parameters remain anywhere in the repo.
- Why: both defects made generated SDK clients silently unusable — the SSE endpoint threw at runtime, and paged listings returned default page 0/size 20 with filters dropped (root cause of the seeder re-creating purchase orders: 50 orders for 30 products on alpha).

## Tests
- [x] Unit tests added/updated — new `PurchaseOrderListOpenApiContractTest` asserts the purchase-order listing declares flat `vendorId`/`status`/`currency`/`locationId`/`page`/`size`/`sort` parameters and no object-typed `filter`/`pageable` params, guarding the regression class
- [ ] Integration tests added/updated — n/a (no server behavior change)
- [x] Provider behavioral contract tests added/updated — existing suites for all 12 modules pass (1,200+ tests), plus `OpenApiRepositoryValidationTest` in `pos-openapi-validation`
- How to run: `./mvnw -pl pos-order -Dtest=PurchaseOrderListOpenApiContractTest test` and `./mvnw -pl pos-accounting,pos-bulk-loader,pos-customer,pos-inventory,pos-invoice,pos-location,pos-order,pos-security-service,pos-shop-manager,pos-warranty,pos-workorder,pos-mcp-server test`

## Risk & Rollback
- Risk level: Low — annotation/documentation-only on the server side; runtime request binding and responses are unchanged. The spec changes are breaking only for generated-client code paths that were already broken (object-serialized params were ignored; the SSE client threw).
- Rollback plan: revert the two commits; specs regenerate back to the previous shape.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, working branch `claude/issues-1455-1465-gdoug4` was designated for this session
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability id
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — no semantics change, see Contract References
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtU1dLfAx4dQKwLQBUVbxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtU1dLfAx4dQKwLQBUVbxt)_