### PR TITLE
Honor @ResponseStatus in the platform fallback exception advice

### DIFF
--- a/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
@@ -47,6 +49,9 @@ public class GlobalApiExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalApiExceptionHandler.class);
 
     private static final String X_CORRELATION_ID = "X-Correlation-Id";
+
+    /** Bound on the cause-chain walk in {@link #findResponseStatus}, in case of a cyclic chain. */
+    private static final int MAX_CAUSE_DEPTH = 10;
 
     /**
      * Spring Security exceptions must reach the security filter chain's entry point /
@@ -234,8 +239,8 @@ public class GlobalApiExceptionHandler {
      * The catch-all ADR-0017 implies and issue #1471 makes explicit: whatever reaches here
      * leaves with the envelope and a correlation id, and the stack trace is logged at ERROR
      * against that id. Spring Security exceptions are rethrown so the filter chain renders
-     * its 401/403; framework {@link ErrorResponse} exceptions keep their own status instead
-     * of collapsing to 500.
+     * its 401/403; framework {@link ErrorResponse} exceptions and domain exceptions carrying
+     * {@link ResponseStatus @ResponseStatus} keep their own status instead of collapsing to 500.
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleUnhandled(
@@ -261,8 +266,51 @@ public class GlobalApiExceptionHandler {
             }
         }
 
+        ResponseStatus annotated = findResponseStatus(ex);
+        if (annotated != null) {
+            HttpStatusCode status = annotated.code();
+            String message = annotated.reason().isBlank() ? declaredErrorMessage(status) : annotated.reason();
+            if (status.is5xxServerError()) {
+                log.error(
+                        "{} on {} [correlationId={}]: status={}",
+                        ex.getClass().getSimpleName(),
+                        path,
+                        correlationId,
+                        status.value(),
+                        ex);
+            } else {
+                log.warn(
+                        "{} on {} [correlationId={}]: status={}",
+                        ex.getClass().getSimpleName(),
+                        path,
+                        correlationId,
+                        status.value());
+            }
+            return envelope(status, frameworkErrorCode(status), message, correlationId);
+        }
+
         log.error("Unhandled exception on {} [correlationId={}]", path, correlationId, ex);
         return internalError(correlationId);
+    }
+
+    /**
+     * Mirrors {@code ResponseStatusExceptionResolver}: the status a domain exception declares
+     * via {@link ResponseStatus @ResponseStatus}, on the exception itself or anywhere in its
+     * cause chain. Without this lookup the catch-all above would pre-empt that resolver — it
+     * runs first — and collapse every annotated 404/409 to a 500 (issue #1471 regression).
+     */
+    @Nullable
+    private static ResponseStatus findResponseStatus(Throwable ex) {
+        Throwable current = ex;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
+            ResponseStatus status =
+                    AnnotatedElementUtils.findMergedAnnotation(current.getClass(), ResponseStatus.class);
+            if (status != null) {
+                return status;
+            }
+            current = current.getCause() == current ? null : current.getCause();
+        }
+        return null;
     }
 
     private ResponseEntity<ApiError> internalError(String correlationId) {
@@ -285,12 +333,35 @@ public class GlobalApiExceptionHandler {
     private static String frameworkErrorCode(HttpStatusCode status) {
         return switch (status.value()) {
             case 400 -> "VALIDATION_ERROR";
+            case 401 -> "UNAUTHORIZED";
+            case 403 -> "FORBIDDEN";
             case 404 -> "NOT_FOUND";
             case 405 -> "METHOD_NOT_ALLOWED";
             case 406 -> "NOT_ACCEPTABLE";
+            case 409 -> "CONFLICT";
             case 413 -> "PAYLOAD_TOO_LARGE";
             case 415 -> "UNSUPPORTED_MEDIA_TYPE";
+            case 422 -> "UNPROCESSABLE_CONTENT";
+            case 500 -> "INTERNAL_ERROR";
             default -> "REQUEST_REJECTED";
+        };
+    }
+
+    /**
+     * Messages for exceptions that declare a status but no {@code reason}. Generic for the
+     * same reason as {@link #frameworkErrorMessage}: the exception's own message routinely
+     * embeds the identifier or value the client sent, and this envelope must not reflect it
+     * (SonarCloud S5131). The correlation id ties the response to the logged exception.
+     */
+    private static String declaredErrorMessage(HttpStatusCode status) {
+        return switch (status.value()) {
+            case 400 -> "Request was rejected";
+            case 401 -> "Authentication is required";
+            case 403 -> "Access is denied";
+            case 404 -> "Requested resource was not found";
+            case 409 -> "Request conflicts with the current state of the resource";
+            case 422 -> "Request could not be processed";
+            default -> status.is5xxServerError() ? "Unexpected error occurred" : "Request rejected";
         };
     }
 

--- a/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
+++ b/pos-web-common/src/test/java/com/positivity/web/common/GlobalApiExceptionHandlerTest.java
@@ -16,6 +16,7 @@ import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 class GlobalApiExceptionHandlerTest {
@@ -172,6 +174,41 @@ class GlobalApiExceptionHandlerTest {
     }
 
     @Test
+    void responseStatusAnnotatedExceptionKeepsItsStatusInsteadOfCollapsingTo500() throws Exception {
+        mockMvc.perform(get("/test/not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Requested resource was not found"))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    void responseStatusAnnotatedExceptionUsesItsReasonWhenDeclared() throws Exception {
+        mockMvc.perform(get("/test/conflict"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CONFLICT"))
+                .andExpect(jsonPath("$.message").value("Resource already exists"));
+    }
+
+    @Test
+    void responseStatusIsResolvedThroughTheCauseChain() throws Exception {
+        mockMvc.perform(get("/test/wrapped-not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void responseStatusAnnotatedBodyDoesNotEchoTheExceptionMessage() throws Exception {
+        String body = mockMvc.perform(get("/test/not-found"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(body).doesNotContain("bay 00000000-0000-0000-0000-000000000001");
+    }
+
+    @Test
     void springSecurityExceptionsAreRethrownForTheSecurityFilterChain() {
         assertThatThrownBy(() -> mockMvc.perform(get("/test/denied")))
                 .isInstanceOf(jakarta.servlet.ServletException.class)
@@ -183,6 +220,16 @@ class GlobalApiExceptionHandlerTest {
     }
 
     record ValidatedRequest(@NotBlank String name) {}
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    static class DomainNotFoundException extends RuntimeException {
+        DomainNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    @ResponseStatus(value = HttpStatus.CONFLICT, reason = "Resource already exists")
+    static class DomainConflictException extends RuntimeException {}
 
     enum TrackingLevel {
         NONE,
@@ -254,6 +301,21 @@ class GlobalApiExceptionHandlerTest {
         @GetMapping("/test/typed/{count}")
         String typed(@org.springframework.web.bind.annotation.PathVariable int count) {
             return Integer.toString(count);
+        }
+
+        @GetMapping("/test/not-found")
+        String notFound() {
+            throw new DomainNotFoundException("bay 00000000-0000-0000-0000-000000000001");
+        }
+
+        @GetMapping("/test/conflict")
+        String conflict() {
+            throw new DomainConflictException();
+        }
+
+        @GetMapping("/test/wrapped-not-found")
+        String wrappedNotFound() {
+            throw new IllegalStateException("wrapper", new DomainNotFoundException("bay"));
         }
 
         @GetMapping("/test/denied")


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — CI regression fix, no capability work
- Parent STORY (durion): n/a
- Child issue: regression introduced by louisburroughs/durion-positivity-backend#1471 (commit 61a4858)
- Domain: `domain:platform` (`pos-web-common`, affects every servlet service)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): no domain contract changes — no controller, DTO, event, or `openapi.yaml` is touched, so `BACKEND_CONTRACT_GUIDE.md` needs no new entry. Noting the filename explicitly because the change does alter HTTP status codes services return: it **restores** the statuses the contracts already document (404/409), which #1471 had been collapsing to 500.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

No controller changed; the generated specs already describe the 404/409 responses this restores.

## Scope

**What changed:** `GlobalApiExceptionHandler` (pos-web-common) now resolves `@ResponseStatus` before falling back to 500.

**Why:** The catch-all `@ExceptionHandler(Exception.class)` added by #1471 runs inside `ExceptionHandlerExceptionResolver`, which Spring consults *before* `ResponseStatusExceptionResolver`. It therefore intercepted every domain exception annotated `@ResponseStatus` before that resolver could map it, collapsing declared 404s and 409s into enveloped 500s across the whole reactor.

`pos-location` surfaced it first — five contract ITs expecting 404/409 from `ResourceNotFoundException` / `DuplicateResourceException` got 500, failing the `Backend CI/CD` run on main ([run 32665166267](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32665166267)) and skipping eight downstream modules. The blast radius was every `@ResponseStatus`-annotated exception, not just this module's.

The fallback now mirrors `ResponseStatusExceptionResolver`: a merged-annotation lookup on the exception type, then along its cause chain, bounded so a cyclic chain cannot loop. Declared 4xx is logged at WARN, declared 5xx at ERROR with the stack trace; both stay enveloped and correlated.

Response bodies use the annotation's `reason` when one is declared and a generic per-status message otherwise, rather than the exception's own message — those messages routinely embed the identifier the client supplied, and the envelope must not reflect user-controlled input back (SonarCloud S5131). The status-to-code map gains the 401/403/409/422/500 entries this path can now produce.

## Tests
- [x] Unit tests added/updated — four regression tests in `GlobalApiExceptionHandlerTest`: declared status is honored, a declared `reason` is used, resolution walks the cause chain, and the body does not echo the exception message.
- [x] Integration tests added/updated — no new ITs; the five existing `pos-location` contract ITs are what this fixes.
- [ ] Provider behavioral contract tests added/updated

**How to run:**
```bash
# The unit tests covering the fix
./mvnw -pl pos-web-common -am -DskipTests=false test

# The five ITs that were failing on main
./mvnw -pl pos-location -am -DskipTests=false -DskipITs=false \
  -Dit.test=BayContractBehaviorIT,MobileUnitContractBehaviorIT verify
```

Verified locally:

| Check | Result |
|---|---|
| `BayContractBehaviorIT` | 7/7 (was 2 failures) |
| `MobileUnitContractBehaviorIT` | 15/15 (was 3 failures) |
| `pos-web-common` unit tests | 20/20 (16 existing + 4 new) |
| Cross-module ArchUnit | 16/16 |
| Checkstyle / SpotBugs / jacoco ratchet on `pos-web-common` | clean |
| The 8 modules the broken reactor never reached | green, except 3 Testcontainers ITs that cannot pull `postgres:16-alpine` without a Docker daemon locally |

## Risk & Rollback
- Risk level: Low
- The change only widens what the lowest-precedence fallback can map. Service-specific `@ControllerAdvice` still takes precedence, the `ErrorResponse` and `DataIntegrityViolationException` paths are untouched, and Spring Security exceptions are still rethrown to the filter chain. Responses that move are ones that were 500 by mistake.
- One behavioral note for reviewers: a `@ResponseStatus` exception now yields a generic message rather than the exception's own text. No test asserted on those bodies, and the correlation id ties each response to the logged exception.
- Rollback plan: revert this commit. The `pos-location` ITs go red again and `@ResponseStatus` exceptions resume returning 500.

## Checklist
- [ ] Branch name matches `cap/{cap-id}` — branch was assigned for this CI-failure task
- [ ] PR title starts with `[CAP:{cap-id}]` — no capability id for this regression fix
- [x] Links to parent + child issues are present (origin issue #1471 and the failing CI run)
- [ ] Contract guide updated (when contract semantics changed) — not needed, see above
- [ ] Required CI checks passing — pending on this PR
