### PR TITLE
fix: give the nine self-invoked @Transactional writers real transaction boundaries

### DIFF
--- a/docs/SONARQUBE_REMEDIATION_PLAN.md
+++ b/docs/SONARQUBE_REMEDIATION_PLAN.md
@@ -1,6 +1,7 @@
 # SonarQube Remediation Plan
 
-Status: Phases 1 and 2 implemented (see §2 and §3); Phase 3 not started.
+Status: Phases 1 and 2 implemented (see §2 and §3). Phase 3.1 triaged — all 34
+`S6809` sites classified, 9 real and 25 needing no change; fixes not yet written.
 The `new_reliability_rating` fix is in, so the next analysis should return the
 quality gate to green — confirm against §7 before treating §1's table as stale.
 Date: 2026-08-24
@@ -228,6 +229,63 @@ inner unit while the outer continues, or vice versa.
 Do these module-by-module, one PR per module, so a regression in transaction
 semantics is bisectable.
 
+#### Triage results (all 34 sites classified)
+
+Done. Nine sites are real, twenty-five are not. The split is lopsided because
+most `S6809` hits in this codebase are a convenience overload delegating to its
+full-argument sibling with *identical* `@Transactional` attributes — the caller
+has already opened the transaction the callee would have asked for, so `REQUIRED`
+joins it whether or not the proxy is involved.
+
+**Class 3 — real: a non-transactional caller self-invoking a `@Transactional`
+method, so no transaction is created at all (9 sites).**
+
+| Module | Site | Entry point | Self-invoked | Consequence |
+| ------ | ---- | ----------- | ------------ | ----------- |
+| `pos-supplier` | `MktCatImporter:152` | `importAll` / `importVariants` (not transactional) → `importOne` (private) | `stageAndPublish` (`@Transactional`) | Stage-write and outbox emit are not atomic |
+| `pos-supplier` | `WorkorderCompletionApprover:133,143,163,171,174` | `@Scheduled approveOutstanding` → `approveOne` (private) | `park`, `markApproved`, `recordAttempt` (all `@Transactional`) | Read-modify-write on the authorization row runs untransacted |
+| `pos-workorder` | `FleetAuthorizationResourceReleaseRunner:86` | `@Scheduled releaseOverdue` | `releaseOne` (`@Transactional`) | Guard re-read and the release write are not one unit |
+| `pos-customer` | `CustomerCommandListener:98,102` | `@KafkaListener onCommand` | `handleSegmentResolveRequested`, `handleSuppressionAddRequested` (both `@Transactional`) | Command handling is not atomic against redelivery |
+
+`MktCatImporter` is the sharpest of these: `stageAndPublish`'s own javadoc states
+the invariant being lost — *"Both in one transaction, through the outbox: a
+variant recorded as published that was never emitted would be skipped on every
+later run, because its hash now matches (ADR-0044 §4)."* Self-invocation means
+that transaction does not exist, so the exact interleaving the comment warns
+about is reachable today. `FleetAuthorizationResourceReleaseRunner` has the same
+tell — `releaseOne` opens with *"Re-read the guard inside the transaction"*,
+inside a method that has no transaction when called this way.
+
+Note the negative evidence in `CustomerCommandListener`: the third branch,
+`handleOutboxReplayRequested` (line 94), is *not* flagged, because that handler
+is private and carries no `@Transactional`. Sonar is discriminating here, not
+pattern-matching on self-calls.
+
+Fix shape for all nine: extract the transactional writer into a collaborator
+bean and inject it, so the call crosses a proxy. Each needs a test that proves
+the boundary — the writer rolling back without taking its caller's loop down, or
+the handler's partial work not surviving a mid-handler failure.
+
+**Class 1 — no action: the caller already holds an equivalent or wider
+transaction (25 sites).**
+
+| Shape | Sites |
+| ----- | ----- |
+| Overload delegating to its full-argument sibling, identical attributes | `AccountingPeriodServiceImpl:108`, `CrmVehicleServiceImpl:98`, `PartyServiceImpl:231`, `PersonServiceImpl:231`, `InventoryAvailabilityServiceImpl:102,159`, `UomConversionServiceImpl:78`, `ServiceAreaServiceImpl:50`, `TravelBufferPolicyServiceImpl:48`, `LedgerPostingServiceImpl:113,119,125`, `InventoryLeadTimeServiceImpl:45`, `SourcingStrategyServiceImpl:89`, `AudienceEligibilityService:137` |
+| Private helper inside a transactional entry point, calling a `readOnly` method | `SegmentResolutionService:131,161`, `MarketingConsentServiceImpl:188,221,222` |
+| Read-write caller invoking a `readOnly = true` method | `PromotionOfferServiceImpl:103,119`, `VehiclePreferencesServiceImpl:128`, `FleetAuthorizationService:80` |
+| `@Transactional` entry point calling another `@Transactional` method | `SupplierYamlBootstrap:93` |
+
+The third row deserves a word, since it looks like a mismatch: `readOnly = true`
+is honoured only when a transaction is *created*. An inner `REQUIRED` method
+joining an existing read-write transaction does not downgrade it — so routing
+these through the proxy would change nothing. The annotation is misleading to a
+reader, but it is not wrong at runtime.
+
+No code change is proposed for these 25. Removing the callee's `@Transactional`
+is not available either: in every case above the callee is a public API method
+that external callers reach through the proxy, where the annotation is load-bearing.
+
 ### 3.2 `java:S1948` (1 issue)
 
 `pos-shop-manager/…/internal/exception/SchedulingConflictException.java:11` —
@@ -363,7 +421,7 @@ This is the only bucket that changes real control flow, so it is scheduled
 | ----- | ------- | -----: | -----: | ----------- | ------ |
 | 1 | Reliability `S2637` | 2 | 0.5 h | **Red → Green** | done |
 | 2 | BLOCKER `S2699` | 1 | 0.2 h | none | done |
-| 3.1 | `S6809` transactional self-invocation | 34 | 2.8 h | none (real runtime risk) | not started |
+| 3.1 | `S6809` transactional self-invocation | 34 | 2.8 h | none (real runtime risk) | triaged: 9 real, 25 no-action |
 | 3.2–3.4 | `S1948`, `S3252`, `S1186` | 20 | 2.0 h | none | not started |
 | 3.5 | `S1192` literals | 148 | 21.0 h | none | not started |
 | 3.6 | `S3776` complexity | 62 | 11.6 h | none | not started |

--- a/docs/SONARQUBE_REMEDIATION_PLAN.md
+++ b/docs/SONARQUBE_REMEDIATION_PLAN.md
@@ -1,7 +1,8 @@
 # SonarQube Remediation Plan
 
-Status: Phases 1 and 2 implemented (see §2 and §3). Phase 3.1 triaged — all 34
-`S6809` sites classified, 9 real and 25 needing no change; fixes not yet written.
+Status: Phases 1, 2 and 3.1 implemented. All 34 `S6809` sites are classified —
+9 were real and are fixed, 25 need no change (see §4.1). Phases 3.2–3.6 not
+started.
 The `new_reliability_rating` fix is in, so the next analysis should return the
 quality gate to green — confirm against §7 before treating §1's table as stale.
 Date: 2026-08-24
@@ -261,10 +262,18 @@ Note the negative evidence in `CustomerCommandListener`: the third branch,
 is private and carries no `@Transactional`. Sonar is discriminating here, not
 pattern-matching on self-calls.
 
-Fix shape for all nine: extract the transactional writer into a collaborator
-bean and inject it, so the call crosses a proxy. Each needs a test that proves
-the boundary — the writer rolling back without taking its caller's loop down, or
-the handler's partial work not surviving a mid-handler failure.
+**All nine are fixed.** Each transactional writer moved into a collaborator bean
+so the call crosses a proxy: `MktCatVariantStager`, `WorkorderApprovalRecorder`,
+`FleetAuthorizationResourceReleaser` and `CustomerCommandHandlers`. The splits
+follow the data rather than the rule — in every case the moved methods took their
+exclusive collaborators with them, so no field is now shared across the seam.
+
+`MktCatVariantStagerTransactionTest` covers the boundary directly, following the
+existing `SupplierExchangeAuditPersistenceTest` pattern (`@DataJpaTest` with
+`Propagation.NOT_SUPPORTED`, because a test wrapped in its own rolled-back
+transaction cannot observe a commit boundary and would pass with the bug
+present). It was checked against the bug: with `@Transactional` removed from
+`stageAndPublish`, `failedOutboxWriteRollsBackTheStagedRow` fails.
 
 **Class 1 — no action: the caller already holds an equivalent or wider
 transaction (25 sites).**
@@ -421,7 +430,7 @@ This is the only bucket that changes real control flow, so it is scheduled
 | ----- | ------- | -----: | -----: | ----------- | ------ |
 | 1 | Reliability `S2637` | 2 | 0.5 h | **Red → Green** | done |
 | 2 | BLOCKER `S2699` | 1 | 0.2 h | none | done |
-| 3.1 | `S6809` transactional self-invocation | 34 | 2.8 h | none (real runtime risk) | triaged: 9 real, 25 no-action |
+| 3.1 | `S6809` transactional self-invocation | 34 | 2.8 h | none (real runtime risk) | done: 9 fixed, 25 no-action |
 | 3.2–3.4 | `S1948`, `S3252`, `S1186` | 20 | 2.0 h | none | not started |
 | 3.5 | `S1192` literals | 148 | 21.0 h | none | not started |
 | 3.6 | `S3776` complexity | 62 | 11.6 h | none | not started |

--- a/docs/SONARQUBE_REMEDIATION_PLAN.md
+++ b/docs/SONARQUBE_REMEDIATION_PLAN.md
@@ -140,7 +140,12 @@ Note that the `existing` lookup a few lines above performs the same
       green across all three modules, with Spotless, Checkstyle and SpotBugs
       enabled (no `-Dskip` flags).
 - [ ] Next SonarCloud analysis reports `new_reliability_rating = 1` and the
-      quality gate flips to **Green**.
+      quality gate flips to **Green**. Note this does **not** happen on merge:
+      per `.github/workflows/ci.yml` (`code-quality-full`), the only job that
+      publishes a branch-level analysis runs on `schedule` (nightly, 06:00 UTC)
+      or `workflow_dispatch`. Until one of those runs, the project gate keeps
+      reporting the last nightly value, which predates the fix. The PR-mode scan
+      on #1487 reported zero reliability issues before it merged.
 
 ## 3. Phase 2 — The single BLOCKER (1 issue, ~10 min) — DONE
 
@@ -472,8 +477,10 @@ movement — `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test`.
 
 ## 7. Re-measuring
 
-SonarCloud analysis runs on pull requests and on the full-coverage job
-(`.github/workflows/ci.yml`). To re-derive the tables above from the live
+SonarCloud analysis runs on pull requests (`code-quality`, PR-scoped) and on the
+full-coverage job (`code-quality-full`), which is the only one that publishes a
+branch-level analysis and runs **only** nightly at 06:00 UTC or via
+`workflow_dispatch` — merging to `main` does not refresh the project gate. To re-derive the tables above from the live
 project without a token (the project is public):
 
 ```bash

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandHandlers.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandHandlers.java
@@ -1,0 +1,126 @@
+package com.positivity.customer.internal.config;
+
+import com.positivity.customer.internal.dto.AddSuppressionRequest;
+import com.positivity.customer.internal.enums.ConsentChangeSource;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.enums.SuppressionReason;
+import com.positivity.customer.service.SegmentService;
+import com.positivity.customer.service.SuppressionService;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * The transactional halves of {@link CustomerCommandListener}'s command handling.
+ *
+ * <h2>Why these are their own bean</h2>
+ *
+ * Both methods used to sit on the listener and be called on {@code this} from its
+ * {@code @KafkaListener} method, which is not transactional. Spring's transaction advice is
+ * proxy-based, so those self-calls bypassed it and the {@code @Transactional} annotations below were
+ * never applied — which is precisely what {@link #handleSegmentResolveRequested}'s note requires:
+ * the reply fact must be written to the outbox atomically with the read that produced it, or a
+ * requester can be told about a resolution that was never recorded. Living in a separate bean means
+ * the calls cross the proxy and each command is handled as one unit.
+ *
+ * <p>The listener's third branch, {@code handleOutboxReplayRequested}, deliberately stays where it
+ * is: it declares no transaction and needs none, since it only queues existing outbox rows for
+ * re-publication.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomerCommandHandlers {
+
+    private final SegmentService segmentService;
+    private final SuppressionService suppressionService;
+
+    /**
+     * Resolve a segment and reply with {@code customer.segment.resolved}.
+     *
+     * <p>Runs in its own transaction so the reply fact is written to the outbox atomically with
+     * the read that produced it. A malformed or unknown request is dropped rather than retried:
+     * neither can be fixed by redelivery, and a requester waiting on a reply will time out and
+     * ask again.
+     */
+    @Transactional
+    public void handleSegmentResolveRequested(JsonNode root) {
+        JsonNode payload = root.path("payload");
+        UUID requestId = uuidOrNull(payload, "requestId");
+        UUID segmentId = uuidOrNull(payload, "segmentId");
+        if (requestId == null || segmentId == null) {
+            log.warn("Ignoring segment-resolve command missing requestId or segmentId");
+            return;
+        }
+        try {
+            segmentService
+                    .resolveAndPublish(requestId, segmentId)
+                    .ifPresent(count ->
+                            log.info("Resolved segment {} for request {}: {} party(ies)", segmentId, requestId, count));
+        } catch (TransientDataAccessException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.warn("Segment {} could not be resolved for request {}: {}", segmentId, requestId, e.getMessage());
+        }
+    }
+
+    /**
+     * Apply a provider-feedback suppression (Story #1150): pos-marketing relays a hard bounce
+     * or spam complaint from the shared platform sender, and the address gets hard-blocked
+     * here — suppression outranks whatever consent the party may still hold.
+     *
+     * <p>The raw address exists only inside this command; {@link SuppressionService#add} stores
+     * a normalized hash plus a masked hint. Malformed commands are dropped, not retried:
+     * redelivery cannot repair a missing address or an unknown enum value.
+     */
+    @Transactional
+    public void handleSuppressionAddRequested(JsonNode root) {
+        JsonNode payload = root.path("payload");
+        String address = payload.path("address").stringValue(null);
+        MarketingChannel channel = enumOrNull(MarketingChannel.class, payload, "channel");
+        SuppressionReason reason = enumOrNull(SuppressionReason.class, payload, "reason");
+        if (address == null || address.isBlank() || channel == null || reason == null) {
+            log.warn("Ignoring suppression-add command missing address, channel, or reason");
+            return;
+        }
+        UUID partyId = uuidOrNull(payload, "partyId");
+        var entry = suppressionService.add(
+                new AddSuppressionRequest(channel, address, partyId, reason, ConsentChangeSource.SYSTEM));
+        log.info(
+                "Provider feedback suppressed {} address for party {} (reason {}, suppressionId {})",
+                channel,
+                partyId,
+                reason,
+                entry.suppressionId());
+    }
+
+    private static <E extends Enum<E>> @Nullable E enumOrNull(Class<E> type, JsonNode node, String field) {
+        String value = node.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(type, value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static UUID uuidOrNull(JsonNode node, String field) {
+        String value = node.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandHandlers.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandHandlers.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.JsonNode;
 
 /**
@@ -23,11 +22,23 @@ import tools.jackson.databind.JsonNode;
  *
  * Both methods used to sit on the listener and be called on {@code this} from its
  * {@code @KafkaListener} method, which is not transactional. Spring's transaction advice is
- * proxy-based, so those self-calls bypassed it and the {@code @Transactional} annotations below were
- * never applied — which is precisely what {@link #handleSegmentResolveRequested}'s note requires:
- * the reply fact must be written to the outbox atomically with the read that produced it, or a
- * requester can be told about a resolution that was never recorded. Living in a separate bean means
- * the calls cross the proxy and each command is handled as one unit.
+ * proxy-based, so those self-calls bypassed it and the {@code @Transactional} annotations they used
+ * to carry were never applied. Living in a separate bean means the dispatch crosses the proxy.
+ *
+ * <h2>Why neither method declares {@code @Transactional} itself</h2>
+ *
+ * Both delegate to a service method that is already {@code @Transactional} —
+ * {@code SegmentServiceImpl.resolveAndPublish} and {@code SuppressionServiceImpl.add} — so the unit
+ * these handlers need is the one those boundaries already provide, including
+ * {@code resolveAndPublish} writing its reply fact to the outbox atomically with the read that
+ * produced it.
+ *
+ * <p>Adding an outer transaction would not merely be redundant, it would be wrong. A participating
+ * inner transaction that rolls back marks the shared transaction rollback-only, so the outer commit
+ * throws {@link org.springframework.transaction.UnexpectedRollbackException} — escaping past
+ * {@link #handleSegmentResolveRequested}'s catch, which exists precisely so a malformed or unknown
+ * request is dropped rather than retried. The catch runs before the commit and cannot see it. So
+ * the boundary stays where the work is, and these methods stay plain dispatch.
  *
  * <p>The listener's third branch, {@code handleOutboxReplayRequested}, deliberately stays where it
  * is: it declares no transaction and needs none, since it only queues existing outbox rows for
@@ -44,12 +55,12 @@ public class CustomerCommandHandlers {
     /**
      * Resolve a segment and reply with {@code customer.segment.resolved}.
      *
-     * <p>Runs in its own transaction so the reply fact is written to the outbox atomically with
-     * the read that produced it. A malformed or unknown request is dropped rather than retried:
-     * neither can be fixed by redelivery, and a requester waiting on a reply will time out and
-     * ask again.
+     * <p>{@code resolveAndPublish} is transactional, so the reply fact is written to the outbox
+     * atomically with the read that produced it. A malformed or unknown request is dropped rather
+     * than retried: neither can be fixed by redelivery, and a requester waiting on a reply will
+     * time out and ask again. See the class note on why this method adds no transaction of its own —
+     * one would turn that drop into a thrown {@code UnexpectedRollbackException}.
      */
-    @Transactional
     public void handleSegmentResolveRequested(JsonNode root) {
         JsonNode payload = root.path("payload");
         UUID requestId = uuidOrNull(payload, "requestId");
@@ -78,8 +89,10 @@ public class CustomerCommandHandlers {
      * <p>The raw address exists only inside this command; {@link SuppressionService#add} stores
      * a normalized hash plus a masked hint. Malformed commands are dropped, not retried:
      * redelivery cannot repair a missing address or an unknown enum value.
+     *
+     * <p>{@code SuppressionServiceImpl.add} is transactional; see the class note on why this method
+     * adds no transaction of its own.
      */
-    @Transactional
     public void handleSuppressionAddRequested(JsonNode root) {
         JsonNode payload = root.path("payload");
         String address = payload.path("address").stringValue(null);

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
@@ -1,17 +1,10 @@
 package com.positivity.customer.internal.config;
 
-import com.positivity.customer.internal.dto.AddSuppressionRequest;
-import com.positivity.customer.internal.enums.ConsentChangeSource;
-import com.positivity.customer.internal.enums.MarketingChannel;
-import com.positivity.customer.internal.enums.SuppressionReason;
 import com.positivity.customer.service.OutboxReplayService;
-import com.positivity.customer.service.SegmentService;
-import com.positivity.customer.service.SuppressionService;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Locale;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -21,7 +14,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -72,8 +64,11 @@ public class CustomerCommandListener {
     private final Clock clock;
     private final ObjectMapper objectMapper;
     private final OutboxReplayService outboxReplayService;
-    private final SegmentService segmentService;
-    private final SuppressionService suppressionService;
+    /**
+     * The two transactional handlers, in a separate bean so each gets a real transaction: a
+     * self-call from this class's {@code @KafkaListener} method would bypass the transaction proxy.
+     */
+    private final CustomerCommandHandlers commandHandlers;
 
     @KafkaListener(
             topics = "${pos.customer.kafka.commands-topic:customer.commands.v1}",
@@ -95,11 +90,11 @@ public class CustomerCommandListener {
                 return;
             }
             if (COMMAND_SEGMENT_RESOLVE_REQUESTED.equals(commandType)) {
-                handleSegmentResolveRequested(root);
+                commandHandlers.handleSegmentResolveRequested(root);
                 return;
             }
             if (COMMAND_SUPPRESSION_ADD_REQUESTED.equals(commandType)) {
-                handleSuppressionAddRequested(root);
+                commandHandlers.handleSuppressionAddRequested(root);
                 return;
             }
             log.debug("Ignoring unsupported commandType={} message={}", commandType, message);
@@ -152,89 +147,6 @@ public class CustomerCommandListener {
             return Instant.parse(value);
         } catch (Exception _) {
             log.warn("Malformed payload.{}={} on outbox replay command", field, value);
-            return null;
-        }
-    }
-
-    /**
-     * Resolve a segment and reply with {@code customer.segment.resolved}.
-     *
-     * <p>Runs in its own transaction so the reply fact is written to the outbox atomically with
-     * the read that produced it. A malformed or unknown request is dropped rather than retried:
-     * neither can be fixed by redelivery, and a requester waiting on a reply will time out and
-     * ask again.
-     */
-    @Transactional
-    void handleSegmentResolveRequested(JsonNode root) {
-        JsonNode payload = root.path("payload");
-        UUID requestId = uuidOrNull(payload, "requestId");
-        UUID segmentId = uuidOrNull(payload, "segmentId");
-        if (requestId == null || segmentId == null) {
-            log.warn("Ignoring segment-resolve command missing requestId or segmentId");
-            return;
-        }
-        try {
-            segmentService
-                    .resolveAndPublish(requestId, segmentId)
-                    .ifPresent(count ->
-                            log.info("Resolved segment {} for request {}: {} party(ies)", segmentId, requestId, count));
-        } catch (TransientDataAccessException e) {
-            throw e;
-        } catch (RuntimeException e) {
-            log.warn("Segment {} could not be resolved for request {}: {}", segmentId, requestId, e.getMessage());
-        }
-    }
-
-    /**
-     * Apply a provider-feedback suppression (Story #1150): pos-marketing relays a hard bounce
-     * or spam complaint from the shared platform sender, and the address gets hard-blocked
-     * here — suppression outranks whatever consent the party may still hold.
-     *
-     * <p>The raw address exists only inside this command; {@link SuppressionService#add} stores
-     * a normalized hash plus a masked hint. Malformed commands are dropped, not retried:
-     * redelivery cannot repair a missing address or an unknown enum value.
-     */
-    @Transactional
-    void handleSuppressionAddRequested(JsonNode root) {
-        JsonNode payload = root.path("payload");
-        String address = payload.path("address").stringValue(null);
-        MarketingChannel channel = enumOrNull(MarketingChannel.class, payload, "channel");
-        SuppressionReason reason = enumOrNull(SuppressionReason.class, payload, "reason");
-        if (address == null || address.isBlank() || channel == null || reason == null) {
-            log.warn("Ignoring suppression-add command missing address, channel, or reason");
-            return;
-        }
-        UUID partyId = uuidOrNull(payload, "partyId");
-        var entry = suppressionService.add(
-                new AddSuppressionRequest(channel, address, partyId, reason, ConsentChangeSource.SYSTEM));
-        log.info(
-                "Provider feedback suppressed {} address for party {} (reason {}, suppressionId {})",
-                channel,
-                partyId,
-                reason,
-                entry.suppressionId());
-    }
-
-    private static <E extends Enum<E>> @Nullable E enumOrNull(Class<E> type, JsonNode node, String field) {
-        String value = node.path(field).stringValue(null);
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        try {
-            return Enum.valueOf(type, value.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-    }
-
-    private static UUID uuidOrNull(JsonNode node, String field) {
-        String value = node.path(field).stringValue(null);
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        try {
-            return UUID.fromString(value);
-        } catch (IllegalArgumentException e) {
             return null;
         }
     }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
@@ -45,7 +45,10 @@ class CustomerCommandListenerTest {
     @BeforeEach
     void setUp() {
         listener = new CustomerCommandListener(
-                TEST_CLOCK, new ObjectMapper(), replayService, segmentService, suppressionService);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                replayService,
+                new CustomerCommandHandlers(segmentService, suppressionService));
         ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
     }
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
@@ -145,4 +145,34 @@ class CustomerCommandListenerTest {
         assertThatExceptionOfType(QueryTimeoutException.class)
                 .isThrownBy(() -> listener.onCommand(replayCommand("2026-07-13T10:00:00Z", "2026-07-13T11:00:00Z")));
     }
+
+    @Test
+    @DisplayName("A segment that cannot be resolved is dropped, not retried")
+    void dropsUnresolvableSegmentCommand() {
+        // Load-bearing for CustomerCommandHandlers declaring no transaction of its own. The handler
+        // delegates to the already-transactional resolveAndPublish; wrapping that in an outer
+        // transaction would let a participating rollback surface as UnexpectedRollbackException at
+        // commit, after this catch has already run — turning the documented drop into a redelivery
+        // loop over a command redelivery cannot repair.
+        when(segmentService.resolveAndPublish(any(), any())).thenThrow(new IllegalStateException("bad predicate"));
+
+        assertThatCode(() -> listener.onCommand(segmentResolveCommand())).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("A transient DB error resolving a segment still rethrows for container retry/DLQ")
+    void rethrowsTransientSegmentErrors() {
+        when(segmentService.resolveAndPublish(any(), any())).thenThrow(new QueryTimeoutException("db timeout"));
+
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> listener.onCommand(segmentResolveCommand()));
+    }
+
+    private static String segmentResolveCommand() {
+        return """
+                {"commandType":"customer.segment.resolve-requested",
+                 "payload":{"requestId":"019200aa-0000-7000-8000-0000000000d1",
+                            "segmentId":"019200aa-0000-7000-8000-0000000000d2"}}
+                """;
+    }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImporter.java
@@ -1,11 +1,7 @@
 package com.positivity.supplier.internal.mktcat.service;
 
-import com.positivity.domainevents.DomainEventEnvelope;
-import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
 import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
-import com.positivity.domainevents.supplier.SupplierCatalogUpdatedV1;
-import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.supplier.internal.adapter.ediwheelc12.EdiwheelC12MktCatCodec;
 import com.positivity.supplier.internal.adapter.ediwheelc12.MktCatDecodeException;
 import com.positivity.supplier.internal.client.SupplierBaseClient;
@@ -15,23 +11,17 @@ import com.positivity.supplier.internal.domain.model.MarketingVariant;
 import com.positivity.supplier.internal.domain.model.SupplierCapability;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
 import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
-import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
 import com.positivity.supplier.internal.exception.MktCatImportException;
 import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.registry.SupplierCodecs;
-import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
-import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
 import com.positivity.supplier.internal.service.SupplierProfileResolver;
 import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
 import com.positivity.supplier.internal.spi.SupplierCatalogPort;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Clock;
-import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,8 +29,6 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import tools.jackson.databind.ObjectMapper;
 
 /**
  * Ingests MKCAT marketing enrichment and publishes what changed (CAP-324 #1230, #1257).
@@ -71,19 +59,14 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 public class MktCatImporter implements SupplierCatalogPort {
 
-    private static final String SOURCE = "pos-supplier";
-
     /** Field separator for hashing. A control character, so it cannot occur in vendor text. */
     private static final char FIELD_SEPARATOR = '\u001f';
 
     private final SupplierProfileResolver profileResolver;
     private final AdapterRegistry adapterRegistry;
     private final SupplierBaseClient baseClient;
-    private final SupplierMktCatVariantRepository variantRepository;
     private final MktCatImageFetcher imageFetcher;
-    private final SupplierOutboxEventWriter outboxEventWriter;
-    private final ObjectMapper objectMapper;
-    private final Clock clock;
+    private final MktCatVariantStager variantStager;
 
     /**
      * Ingests the catalogue's full variant list.
@@ -149,7 +132,7 @@ public class MktCatImporter implements SupplierCatalogPort {
                         text.languageCode(), text.name(), text.description(), text.footNotes()))
                 .toList();
 
-        return stageAndPublish(
+        return variantStager.stageAndPublish(
                 vendorProfileId, supplierRef, variant, texts, storedImages, hashOf(variant, storedImages));
     }
 
@@ -169,87 +152,6 @@ public class MktCatImporter implements SupplierCatalogPort {
         String images = bodyOrNull(exchange(binding, codec.buildVariantImagesRequest(variantId)));
         String languages = bodyOrNull(exchange(binding, codec.buildVariantLanguageDataRequest(variantId)));
         return codec.decodeVariant(variantId, detail, images, languages);
-    }
-
-    /**
-     * Stages the variant and publishes it when its content changed.
-     *
-     * <p>Both in one transaction, through the outbox: a variant recorded as published that was never
-     * emitted would be skipped on every later run, because its hash now matches (ADR-0044 section 4).
-     */
-    @Transactional
-    public boolean stageAndPublish(
-            @NonNull UUID vendorProfileId,
-            @NonNull SupplierRef supplierRef,
-            @NonNull MarketingVariant variant,
-            @NonNull List<SupplierCatalogEnrichmentText> texts,
-            @NonNull List<SupplierCatalogEnrichmentImage> images,
-            @NonNull String contentHash) {
-        Instant now = Instant.now(clock);
-        Optional<SupplierMktCatVariantEntity> existing =
-                variantRepository.findByVendorProfileIdAndVendorVariantId(vendorProfileId, variant.vendorVariantId());
-
-        if (existing.isPresent() && contentHash.equals(existing.get().getContentHash())) {
-            // Seen, not changed. Recorded so an operator can tell "the catalogue stopped sending
-            // this" from "the catalogue keeps sending it unchanged" -- which look identical if only
-            // changes are timestamped.
-            SupplierMktCatVariantEntity row = existing.get();
-            row.setLastSeenAt(now);
-            variantRepository.save(row);
-            return false;
-        }
-
-        SupplierMktCatVariantEntity row = existing.orElseGet(() -> SupplierMktCatVariantEntity.builder()
-                .vendorProfileId(vendorProfileId)
-                .vendorVariantId(variant.vendorVariantId())
-                .firstSeenAt(now)
-                .build());
-
-        row.setSupplierRef(supplierRef.value());
-        row.setBrand(variant.brand());
-        row.setTreadDesign(variant.treadDesign());
-        row.setTreadDesign2(variant.treadDesign2());
-        row.setProductName(variant.productName());
-        row.setVehicleType(variant.vehicleType());
-        row.setSeasonality(variant.seasonality());
-        row.setContentHash(contentHash);
-        row.setTextsJson(objectMapper.writeValueAsString(texts));
-        row.setImagesJson(objectMapper.writeValueAsString(images));
-        row.setHasUnresolvedImages(images.stream().anyMatch(SupplierCatalogEnrichmentImage::unresolved));
-        row.setLastSeenAt(now);
-        row.setLastPublishedAt(now);
-        SupplierMktCatVariantEntity saved = variantRepository.save(row);
-
-        outboxEventWriter.publish(
-                DomainTopics.events("supplier"),
-                new DomainEventEnvelope<>(
-                        UUIDv7Generator.generate(),
-                        SupplierCatalogUpdatedV1.EVENT_TYPE,
-                        SupplierCatalogUpdatedV1.SCHEMA_VERSION,
-                        // Keyed on the staged row, so every enrichment for one variant lands on one
-                        // partition in order: a stale republication overtaking a newer one would put
-                        // withdrawn marketing copy back on a product.
-                        saved.getSupplierMktCatVariantId(),
-                        0L,
-                        now,
-                        SOURCE,
-                        null,
-                        SOURCE,
-                        new SupplierCatalogUpdatedV1(
-                                vendorProfileId,
-                                supplierRef.value(),
-                                variant.vendorVariantId(),
-                                variant.brand(),
-                                variant.treadDesign(),
-                                variant.treadDesign2(),
-                                variant.productName(),
-                                variant.vehicleType(),
-                                variant.seasonality(),
-                                contentHash,
-                                texts,
-                                images,
-                                now)));
-        return true;
     }
 
     /**

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatVariantStager.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatVariantStager.java
@@ -1,0 +1,130 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
+import com.positivity.domainevents.supplier.SupplierCatalogUpdatedV1;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The staging write and the outbox emit for one MKCAT variant, as a single transaction.
+ *
+ * <h2>Why this is its own bean</h2>
+ *
+ * {@link MktCatImporter} used to hold this method and call it on {@code this}. Spring's transaction
+ * advice is proxy-based, so a self-call bypasses it entirely and the {@code @Transactional} below was
+ * never applied — the staged row committed on its own and the outbox write was a separate unit. That
+ * is exactly the interleaving the note on {@link #stageAndPublish} warns about: a variant recorded as
+ * published whose event was never emitted is skipped on every later run, because its hash now matches.
+ * Living in a separate bean means the call crosses the proxy and the boundary is real.
+ */
+@Service
+@RequiredArgsConstructor
+public class MktCatVariantStager {
+
+    private static final String SOURCE = "pos-supplier";
+
+    private final SupplierMktCatVariantRepository variantRepository;
+    private final SupplierOutboxEventWriter outboxEventWriter;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    /**
+     * Stages the variant and publishes it when its content changed.
+     *
+     * <p>Both in one transaction, through the outbox: a variant recorded as published that was never
+     * emitted would be skipped on every later run, because its hash now matches (ADR-0044 section 4).
+     *
+     * @return whether this variant's content had changed and was therefore published
+     */
+    @Transactional
+    public boolean stageAndPublish(
+            @NonNull UUID vendorProfileId,
+            @NonNull SupplierRef supplierRef,
+            @NonNull MarketingVariant variant,
+            @NonNull List<SupplierCatalogEnrichmentText> texts,
+            @NonNull List<SupplierCatalogEnrichmentImage> images,
+            @NonNull String contentHash) {
+        Instant now = Instant.now(clock);
+        Optional<SupplierMktCatVariantEntity> existing =
+                variantRepository.findByVendorProfileIdAndVendorVariantId(vendorProfileId, variant.vendorVariantId());
+
+        if (existing.isPresent() && contentHash.equals(existing.get().getContentHash())) {
+            // Seen, not changed. Recorded so an operator can tell "the catalogue stopped sending
+            // this" from "the catalogue keeps sending it unchanged" -- which look identical if only
+            // changes are timestamped.
+            SupplierMktCatVariantEntity row = existing.get();
+            row.setLastSeenAt(now);
+            variantRepository.save(row);
+            return false;
+        }
+
+        SupplierMktCatVariantEntity row = existing.orElseGet(() -> SupplierMktCatVariantEntity.builder()
+                .vendorProfileId(vendorProfileId)
+                .vendorVariantId(variant.vendorVariantId())
+                .firstSeenAt(now)
+                .build());
+
+        row.setSupplierRef(supplierRef.value());
+        row.setBrand(variant.brand());
+        row.setTreadDesign(variant.treadDesign());
+        row.setTreadDesign2(variant.treadDesign2());
+        row.setProductName(variant.productName());
+        row.setVehicleType(variant.vehicleType());
+        row.setSeasonality(variant.seasonality());
+        row.setContentHash(contentHash);
+        row.setTextsJson(objectMapper.writeValueAsString(texts));
+        row.setImagesJson(objectMapper.writeValueAsString(images));
+        row.setHasUnresolvedImages(images.stream().anyMatch(SupplierCatalogEnrichmentImage::unresolved));
+        row.setLastSeenAt(now);
+        row.setLastPublishedAt(now);
+        SupplierMktCatVariantEntity saved = variantRepository.save(row);
+
+        outboxEventWriter.publish(
+                DomainTopics.events("supplier"),
+                new DomainEventEnvelope<>(
+                        UUIDv7Generator.generate(),
+                        SupplierCatalogUpdatedV1.EVENT_TYPE,
+                        SupplierCatalogUpdatedV1.SCHEMA_VERSION,
+                        // Keyed on the staged row, so every enrichment for one variant lands on one
+                        // partition in order: a stale republication overtaking a newer one would put
+                        // withdrawn marketing copy back on a product.
+                        saved.getSupplierMktCatVariantId(),
+                        0L,
+                        now,
+                        SOURCE,
+                        null,
+                        SOURCE,
+                        new SupplierCatalogUpdatedV1(
+                                vendorProfileId,
+                                supplierRef.value(),
+                                variant.vendorVariantId(),
+                                variant.brand(),
+                                variant.treadDesign(),
+                                variant.treadDesign2(),
+                                variant.productName(),
+                                variant.vehicleType(),
+                                variant.seasonality(),
+                                contentHash,
+                                texts,
+                                images,
+                                now)));
+        return true;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderApprovalRecorder.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderApprovalRecorder.java
@@ -23,6 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
  * re-read detached and the attempt counter's read and write were not one unit. Living in a separate
  * bean means the calls cross the proxy and the boundaries are real.
  *
+ * <p>Each write re-reads its row by id inside its own transaction and works on that, never on the
+ * detached instance the tick handed over — saving that would merge a stale snapshot over a newer
+ * row, and would resurrect the row outright if it had since been deleted.
+ *
  * <h2>One transaction per row, not one per tick</h2>
  *
  * Deliberately per-attempt rather than around the whole batch. One vendor refusing must not roll back
@@ -61,7 +65,12 @@ public class WorkorderApprovalRecorder {
     public void markApproved(@NonNull SupplierWorkorderAuthorizationEntity row) {
         SupplierWorkorderAuthorizationEntity managed = authorizationRepository
                 .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
+                .orElse(null);
+        if (managed == null) {
+            // Gone since the tick's query. Merging the detached snapshot back would resurrect a
+            // deleted authorization, so there is nothing to record.
+            return;
+        }
         managed.setApprovalStatus(WorkorderApprovalStatus.APPROVED);
         managed.setApprovedAt(Instant.now(clock));
         managed.setApprovalAttempts(managed.getApprovalAttempts() + 1);
@@ -75,7 +84,12 @@ public class WorkorderApprovalRecorder {
     public void recordAttempt(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
         SupplierWorkorderAuthorizationEntity managed = authorizationRepository
                 .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
+                .orElse(null);
+        if (managed == null) {
+            // Gone since the tick's query. Merging the detached snapshot back would resurrect a
+            // deleted authorization, so there is nothing to record.
+            return;
+        }
         int attempts = managed.getApprovalAttempts() + 1;
         managed.setApprovalAttempts(attempts);
         if (attempts >= maxAttempts) {
@@ -95,7 +109,12 @@ public class WorkorderApprovalRecorder {
     public void park(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
         SupplierWorkorderAuthorizationEntity managed = authorizationRepository
                 .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
+                .orElse(null);
+        if (managed == null) {
+            // Gone since the tick's query. Merging the detached snapshot back would resurrect a
+            // deleted authorization, so there is nothing to record.
+            return;
+        }
         managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
         managed.setReviewReason(truncate(reason));
         authorizationRepository.save(managed);

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderApprovalRecorder.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderApprovalRecorder.java
@@ -1,0 +1,113 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The three outcome writes of a completion-approval attempt, each in its own transaction.
+ *
+ * <h2>Why this is its own bean</h2>
+ *
+ * These methods used to sit on {@link WorkorderCompletionApprover} and be called on {@code this} from
+ * its {@code @Scheduled} tick, which is not transactional. Spring's transaction advice is
+ * proxy-based, so those self-calls bypassed it and the {@code @Transactional} annotations below were
+ * never applied: each read-modify-write of the authorization row ran untransacted, so the row was
+ * re-read detached and the attempt counter's read and write were not one unit. Living in a separate
+ * bean means the calls cross the proxy and the boundaries are real.
+ *
+ * <h2>One transaction per row, not one per tick</h2>
+ *
+ * Deliberately per-attempt rather than around the whole batch. One vendor refusing must not roll back
+ * the attempts already counted for the other workorders in the same tick — those counts are what
+ * eventually escalates a stuck approval to a human, and losing them would let it retry forever while
+ * looking healthy.
+ */
+@Slf4j
+@Service
+public class WorkorderApprovalRecorder {
+
+    /** Longest review reason the column holds; a vendor message can be arbitrarily long. */
+    private static final int MAX_REVIEW_REASON = 1000;
+
+    private final SupplierWorkorderAuthorizationRepository authorizationRepository;
+    private final Clock clock;
+
+    /**
+     * How many times an approval is attempted before a human is asked to look.
+     *
+     * <p>Finite on purpose. An approval that retries forever looks like an approval that is working,
+     * and the money involved means somebody has to be told when it is not.
+     */
+    private final int maxAttempts;
+
+    public WorkorderApprovalRecorder(
+            SupplierWorkorderAuthorizationRepository authorizationRepository,
+            Clock clock,
+            @Value("${pos.supplier.workorderauth.approval-max-attempts:6}") int maxAttempts) {
+        this.authorizationRepository = authorizationRepository;
+        this.clock = clock;
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Transactional
+    public void markApproved(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        managed.setApprovalStatus(WorkorderApprovalStatus.APPROVED);
+        managed.setApprovedAt(Instant.now(clock));
+        managed.setApprovalAttempts(managed.getApprovalAttempts() + 1);
+        authorizationRepository.save(managed);
+        log.info(
+                "Vendor approved completion of workorder {} at {}", managed.getWorkorderId(), managed.getSupplierRef());
+    }
+
+    /** Counts a failed attempt, and escalates once the budget is spent. */
+    @Transactional
+    public void recordAttempt(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        int attempts = managed.getApprovalAttempts() + 1;
+        managed.setApprovalAttempts(attempts);
+        if (attempts >= maxAttempts) {
+            managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
+            managed.setReviewReason(truncate("completion approval gave up after " + attempts + " attempts: " + reason));
+            log.error(
+                    "Completion approval for workorder {} at {} needs review after {} attempts: {}",
+                    managed.getWorkorderId(),
+                    managed.getSupplierRef(),
+                    attempts,
+                    reason);
+        }
+        authorizationRepository.save(managed);
+    }
+
+    @Transactional
+    public void park(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
+        managed.setReviewReason(truncate(reason));
+        authorizationRepository.save(managed);
+        log.error(
+                "Completion approval for workorder {} at {} cannot proceed: {}",
+                managed.getWorkorderId(),
+                managed.getSupplierRef(),
+                reason);
+    }
+
+    @NonNull
+    private static String truncate(@NonNull String reason) {
+        return reason.length() <= MAX_REVIEW_REASON ? reason : reason.substring(0, MAX_REVIEW_REASON);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApprover.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApprover.java
@@ -16,8 +16,6 @@ import com.positivity.supplier.internal.registry.SupplierCodecs;
 import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
 import com.positivity.supplier.internal.service.SupplierProfileResolver;
 import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
-import java.time.Clock;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,34 +52,31 @@ public class WorkorderCompletionApprover {
     private final SupplierProfileResolver profileResolver;
     private final AdapterRegistry adapterRegistry;
     private final SupplierBaseClient baseClient;
-    private final Clock clock;
+
+    /**
+     * The outcome writes, in a separate bean so each gets a real transaction.
+     *
+     * <p>Not an arbitrary split: a self-call would bypass the transaction proxy, and these three are
+     * the only writes here that must be one unit with their own read.
+     */
+    private final WorkorderApprovalRecorder approvalRecorder;
 
     /** How many outstanding approvals one tick will attempt. */
     private final int batchSize;
-
-    /**
-     * How many times an approval is attempted before a human is asked to look.
-     *
-     * <p>Finite on purpose. An approval that retries forever looks like an approval that is working,
-     * and the money involved means somebody has to be told when it is not.
-     */
-    private final int maxAttempts;
 
     public WorkorderCompletionApprover(
             SupplierWorkorderAuthorizationRepository authorizationRepository,
             SupplierProfileResolver profileResolver,
             AdapterRegistry adapterRegistry,
             SupplierBaseClient baseClient,
-            Clock clock,
-            @Value("${pos.supplier.workorderauth.approval-batch-size:50}") int batchSize,
-            @Value("${pos.supplier.workorderauth.approval-max-attempts:6}") int maxAttempts) {
+            WorkorderApprovalRecorder approvalRecorder,
+            @Value("${pos.supplier.workorderauth.approval-batch-size:50}") int batchSize) {
         this.authorizationRepository = authorizationRepository;
         this.profileResolver = profileResolver;
         this.adapterRegistry = adapterRegistry;
         this.baseClient = baseClient;
-        this.clock = clock;
+        this.approvalRecorder = approvalRecorder;
         this.batchSize = batchSize;
-        this.maxAttempts = maxAttempts;
     }
 
     /**
@@ -130,7 +125,7 @@ public class WorkorderCompletionApprover {
                         row.getSupplierRef(),
                         e.toString(),
                         e);
-                recordAttempt(row, "approval attempt threw: " + e);
+                approvalRecorder.recordAttempt(row, "approval attempt threw: " + e);
             }
         }
     }
@@ -140,7 +135,8 @@ public class WorkorderCompletionApprover {
         if (vendorAuthorizationId == null || vendorAuthorizationId.isBlank()) {
             // Granted, but the vendor never told us what to call it. No amount of retrying invents
             // an identifier, so this goes to a human immediately rather than burning attempts.
-            park(row, "the vendor granted this authorization without an id, so its completion cannot be approved");
+            approvalRecorder.park(
+                    row, "the vendor granted this authorization without an id, so its completion cannot be approved");
             return;
         }
 
@@ -160,7 +156,7 @@ public class WorkorderCompletionApprover {
             // Parked, not retried. No number of attempts fixes a missing account number, and
             // spending the budget on it would escalate a money-critical approval with a review
             // reason blaming the vendor for a defect on this side.
-            park(row, "completion cannot be approved: " + e.getMessage());
+            approvalRecorder.park(row, "completion cannot be approved: " + e.getMessage());
             return;
         }
 
@@ -168,66 +164,12 @@ public class WorkorderCompletionApprover {
         SupplierHttpResponse response = baseClient.exchange(SupplierRequests.toHttpRequest(binding, spec));
 
         if (response.isSuccess()) {
-            markApproved(row);
+            approvalRecorder.markApproved(row);
             return;
         }
-        recordAttempt(
+        approvalRecorder.recordAttempt(
                 row,
                 "vendor refused or could not be reached: " + response.outcome()
                         + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
-    }
-
-    @Transactional
-    void markApproved(@NonNull SupplierWorkorderAuthorizationEntity row) {
-        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
-                .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
-        managed.setApprovalStatus(WorkorderApprovalStatus.APPROVED);
-        managed.setApprovedAt(Instant.now(clock));
-        managed.setApprovalAttempts(managed.getApprovalAttempts() + 1);
-        authorizationRepository.save(managed);
-        log.info(
-                "Vendor approved completion of workorder {} at {}", managed.getWorkorderId(), managed.getSupplierRef());
-    }
-
-    /** Counts a failed attempt, and escalates once the budget is spent. */
-    @Transactional
-    void recordAttempt(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
-        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
-                .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
-        int attempts = managed.getApprovalAttempts() + 1;
-        managed.setApprovalAttempts(attempts);
-        if (attempts >= maxAttempts) {
-            managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
-            managed.setReviewReason(truncate("completion approval gave up after " + attempts + " attempts: " + reason));
-            log.error(
-                    "Completion approval for workorder {} at {} needs review after {} attempts: {}",
-                    managed.getWorkorderId(),
-                    managed.getSupplierRef(),
-                    attempts,
-                    reason);
-        }
-        authorizationRepository.save(managed);
-    }
-
-    @Transactional
-    void park(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
-        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
-                .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
-        managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
-        managed.setReviewReason(truncate(reason));
-        authorizationRepository.save(managed);
-        log.error(
-                "Completion approval for workorder {} at {} cannot proceed: {}",
-                managed.getWorkorderId(),
-                managed.getSupplierRef(),
-                reason);
-    }
-
-    @NonNull
-    private static String truncate(@NonNull String reason) {
-        return reason.length() <= 1000 ? reason : reason.substring(0, 1000);
     }
 }

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImporterSweepTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImporterSweepTest.java
@@ -98,11 +98,12 @@ class MktCatImporterSweepTest {
                 profileResolver,
                 adapterRegistry,
                 baseClient,
-                variantRepository,
                 imageFetcher,
-                outboxEventWriter,
-                JsonMapper.builder().build(),
-                Clock.fixed(NOW, ZoneOffset.UTC));
+                new MktCatVariantStager(
+                        variantRepository,
+                        outboxEventWriter,
+                        JsonMapper.builder().build(),
+                        Clock.fixed(NOW, ZoneOffset.UTC)));
 
         when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
         when(adapterRegistry.resolve(any(), any(), any())).thenReturn(new AdapterResolution.Resolved(codec));

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatVariantStagerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatVariantStagerTest.java
@@ -9,14 +9,11 @@ import static org.mockito.Mockito.when;
 import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
 import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
 import com.positivity.domainevents.supplier.SupplierCatalogUpdatedV1;
-import com.positivity.supplier.internal.client.SupplierBaseClient;
 import com.positivity.supplier.internal.domain.model.MarketingVariant;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
 import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
-import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
 import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
-import com.positivity.supplier.internal.service.SupplierProfileResolver;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -42,44 +39,25 @@ import tools.jackson.databind.json.JsonMapper;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("MktCatImporter — published when it changes, not when it arrives (#1230)")
-class MktCatImporterTest {
+@DisplayName("MktCatVariantStager — published when it changes, not when it arrives (#1230)")
+class MktCatVariantStagerTest {
 
     private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
     private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
     private static final SupplierRef SUPPLIER = new SupplierRef("ediwheel-net");
 
     @Mock
-    private SupplierProfileResolver profileResolver;
-
-    @Mock
-    private AdapterRegistry adapterRegistry;
-
-    @Mock
-    private SupplierBaseClient baseClient;
-
-    @Mock
     private SupplierMktCatVariantRepository variantRepository;
-
-    @Mock
-    private MktCatImageFetcher imageFetcher;
 
     @Mock
     private SupplierOutboxEventWriter outboxEventWriter;
 
-    private MktCatImporter importer;
+    private MktCatVariantStager stager;
 
     @BeforeEach
     void setUp() {
-        importer = new MktCatImporter(
-                profileResolver,
-                adapterRegistry,
-                baseClient,
-                variantRepository,
-                imageFetcher,
-                outboxEventWriter,
-                JsonMapper.builder().build(),
-                Clock.fixed(NOW, ZoneOffset.UTC));
+        stager = new MktCatVariantStager(
+                variantRepository, outboxEventWriter, JsonMapper.builder().build(), Clock.fixed(NOW, ZoneOffset.UTC));
         when(variantRepository.save(any())).thenAnswer(invocation -> {
             SupplierMktCatVariantEntity row = invocation.getArgument(0);
             if (row.getSupplierMktCatVariantId() == null) {
@@ -95,7 +73,7 @@ class MktCatImporterTest {
         when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
                 .thenReturn(Optional.empty());
 
-        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
+        boolean published = stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
 
         assertThat(published).isTrue();
         verify(outboxEventWriter).publish(any(), any());
@@ -110,7 +88,7 @@ class MktCatImporterTest {
         when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
                 .thenReturn(Optional.of(existing));
 
-        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
+        boolean published = stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
 
         assertThat(published).isFalse();
         verify(outboxEventWriter, never()).publish(any(), any());
@@ -126,7 +104,7 @@ class MktCatImporterTest {
         when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
                 .thenReturn(Optional.of(existing));
 
-        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-2");
+        boolean published = stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-2");
 
         assertThat(published).isTrue();
         assertThat(existing.getContentHash()).isEqualTo("hash-2");
@@ -142,7 +120,7 @@ class MktCatImporterTest {
         List<SupplierCatalogEnrichmentImage> images =
                 List.of(SupplierCatalogEnrichmentImage.unresolved("TREAD", "https://cdn.example.com/x.jpg"));
 
-        importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), images, "hash-1");
+        stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), images, "hash-1");
 
         // A column rather than something derived from JSON at query time: the retry runner selects
         // on it, and a scan that parsed JSON per row would be the query that degrades as the
@@ -160,7 +138,7 @@ class MktCatImporterTest {
 
         // Dropping the record would discard the marketing copy that did arrive because a picture
         // did not.
-        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), images, "hash-1");
+        boolean published = stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), images, "hash-1");
 
         assertThat(published).isTrue();
         SupplierCatalogUpdatedV1 payload = new SupplierCatalogUpdatedV1(

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatVariantStagerTransactionTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatVariantStagerTransactionTest.java
@@ -1,0 +1,150 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
+import com.positivity.supplier.internal.config.JpaConfig;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * The staging write and the outbox emit are one transaction (ADR-0044 section 4).
+ *
+ * <h2>Why this test exists</h2>
+ *
+ * {@link MktCatVariantStager#stageAndPublish} used to live on {@link MktCatImporter} and be called on
+ * {@code this}. Spring's transaction advice is proxy-based, so that self-call bypassed it and the
+ * method ran with no transaction at all: the staged row committed by itself, and a failing outbox
+ * write left a variant recorded as published whose event was never emitted. Its hash matches from
+ * then on, so every later sweep skips it — the marketing copy is lost silently and permanently.
+ *
+ * <h2>Why it is not {@code @DataJpaTest}-default transactional</h2>
+ *
+ * The whole point is a commit boundary. A test wrapped in its own rolled-back transaction cannot
+ * observe one — it would pass just as happily with the bug present, because the outer rollback hides
+ * whether the inner write ever committed. {@code Propagation.NOT_SUPPORTED} lets the bean manage its
+ * own transaction, and cleanup goes over a plain JDBC connection.
+ */
+@DataJpaTest(
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:pos_supplier_mktcat_tx;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=validate"
+        })
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, MktCatVariantStager.class, MktCatVariantStagerTransactionTest.StagerSupportConfig.class})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DisplayName("MktCatVariantStager — the staged row and the outbox event commit together")
+class MktCatVariantStagerTransactionTest {
+
+    @TestConfiguration
+    static class StagerSupportConfig {
+        @Bean
+        Clock clock() {
+            return Clock.fixed(NOW, ZoneOffset.UTC);
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return JsonMapper.builder().build();
+        }
+    }
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final SupplierRef SUPPLIER = new SupplierRef("ediwheel-net");
+
+    @Autowired
+    private MktCatVariantStager stager;
+
+    @Autowired
+    private SupplierMktCatVariantRepository variantRepository;
+
+    /**
+     * Mocked so one test can fail the outbox write the way a dead connection or a constraint
+     * violation would, after the staged row has already been written.
+     */
+    @MockitoBean
+    private SupplierOutboxEventWriter outboxEventWriter;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DELETE FROM supplier_mktcat_variant");
+        }
+    }
+
+    @Test
+    @DisplayName("a failing outbox write takes the staged row with it, so the variant is republished")
+    void failedOutboxWriteRollsBackTheStagedRow() {
+        doThrow(new IllegalStateException("outbox unavailable"))
+                .when(outboxEventWriter)
+                .publish(any(), any());
+
+        assertThatThrownBy(() -> stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1"))
+                .isInstanceOf(IllegalStateException.class);
+
+        // The assertion the bug would fail. Without a transaction the row is already committed, its
+        // hash matches on the next sweep, and the variant is never published again.
+        assertThat(variantRepository.findByVendorProfileIdAndVendorVariantId(PROFILE_ID, "V1"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("a successful run commits the staged row and emits the event")
+    void successfulRunCommitsBoth() {
+        boolean published = stager.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
+
+        assertThat(published).isTrue();
+        verify(outboxEventWriter).publish(any(), any());
+        assertThat(variantRepository.findByVendorProfileIdAndVendorVariantId(PROFILE_ID, "V1"))
+                .get()
+                .satisfies(row -> {
+                    assertThat(row.getContentHash()).isEqualTo("hash-1");
+                    assertThat(row.getLastPublishedAt()).isEqualTo(NOW);
+                });
+    }
+
+    private static MarketingVariant variant() {
+        return new MarketingVariant("V1", "Michelin", "Primacy 4", null, null, null, null, List.of(), List.of());
+    }
+
+    private static List<SupplierCatalogEnrichmentText> texts() {
+        return List.of(new SupplierCatalogEnrichmentText("de", "Primacy 4", "Sommerreifen", null));
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApproverTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApproverTest.java
@@ -83,9 +83,8 @@ class WorkorderCompletionApproverTest {
                 profileResolver,
                 adapterRegistry,
                 baseClient,
-                Clock.fixed(NOW, ZoneOffset.UTC),
-                50,
-                MAX_ATTEMPTS);
+                new WorkorderApprovalRecorder(authorizationRepository, Clock.fixed(NOW, ZoneOffset.UTC), MAX_ATTEMPTS),
+                50);
 
         when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
         when(adapterRegistry.resolve(any(), any(), any()))

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunner.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunner.java
@@ -1,21 +1,16 @@
 package com.positivity.workorder.internal.service;
 
 import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
-import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
 import com.positivity.workorder.internal.repository.WorkorderFleetAuthorizationRepository;
-import com.positivity.workorder.service.TechnicianAssignmentService;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Limit;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Frees capacity a blocked job cannot currently use (#1346).
@@ -47,29 +42,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class FleetAuthorizationResourceReleaseRunner {
 
-    /** Statuses under which held resources are still blocked and eligible for release. */
-    private static final Set<FleetAuthorizationStatus> BLOCKING_STATUSES = Set.of(
-            FleetAuthorizationStatus.NOT_REQUESTED,
-            FleetAuthorizationStatus.PENDING,
-            FleetAuthorizationStatus.REFUSED,
-            FleetAuthorizationStatus.MANUAL_REVIEW);
-
-    private static final String RELEASED_BY = "fleet-authorization-resource-release";
-
     private final WorkorderFleetAuthorizationRepository authorizationRepository;
-    private final TechnicianAssignmentService technicianAssignmentService;
+
+    /**
+     * The per-row release, in a separate bean so it gets a real transaction: a self-call from this
+     * class's {@code @Scheduled} tick would bypass the transaction proxy.
+     */
+    private final FleetAuthorizationResourceReleaser resourceReleaser;
+
     private final Clock clock;
     private final Duration releaseAfter;
     private final int batchSize;
 
     public FleetAuthorizationResourceReleaseRunner(
             WorkorderFleetAuthorizationRepository authorizationRepository,
-            TechnicianAssignmentService technicianAssignmentService,
+            FleetAuthorizationResourceReleaser resourceReleaser,
             Clock clock,
             @Value("${workorder.fleetauth.resource-release-after:PT4H}") Duration releaseAfter,
             @Value("${workorder.fleetauth.resource-release-batch-size:50}") int batchSize) {
         this.authorizationRepository = authorizationRepository;
-        this.technicianAssignmentService = technicianAssignmentService;
+        this.resourceReleaser = resourceReleaser;
         this.clock = clock;
         this.releaseAfter = releaseAfter;
         this.batchSize = batchSize;
@@ -79,11 +71,11 @@ public class FleetAuthorizationResourceReleaseRunner {
     public void releaseOverdue() {
         Instant releaseDueBefore = Instant.now(clock).minus(releaseAfter);
         List<WorkorderFleetAuthorization> due = authorizationRepository.findDueForResourceRelease(
-                releaseDueBefore, BLOCKING_STATUSES, Limit.of(batchSize));
+                releaseDueBefore, FleetAuthorizationResourceReleaser.BLOCKING_STATUSES, Limit.of(batchSize));
 
         for (WorkorderFleetAuthorization authorization : due) {
             try {
-                releaseOne(authorization);
+                resourceReleaser.releaseOne(authorization);
             } catch (Exception e) {
                 // One workorder's release failing must not stop the others. Nothing here is lost:
                 // resourcesReleasedAt stays null, so this row is picked up again next tick.
@@ -93,28 +85,5 @@ public class FleetAuthorizationResourceReleaseRunner {
                         e.toString());
             }
         }
-    }
-
-    @Transactional
-    void releaseOne(@NonNull WorkorderFleetAuthorization authorization) {
-        // Re-read the guard inside the transaction: the status may have changed between the query
-        // above and this write, and releasing a resource for a now-granted authorization would be
-        // wrong rather than merely late.
-        if (!BLOCKING_STATUSES.contains(authorization.getStatus()) || authorization.getResourcesReleasedAt() != null) {
-            return;
-        }
-
-        technicianAssignmentService.releaseAssignment(
-                authorization.getWorkorderId(),
-                RELEASED_BY,
-                "fleet payment authorization has been unresolved for over " + releaseAfter);
-
-        authorization.setResourcesReleasedAt(Instant.now(clock));
-        authorizationRepository.save(authorization);
-        log.info(
-                "Released held resources for workorder {}: fleet authorization has been {} since {}",
-                authorization.getWorkorderId(),
-                authorization.getStatus(),
-                authorization.getFirstBlockedAt());
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaser.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaser.java
@@ -1,0 +1,87 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.WorkorderFleetAuthorizationRepository;
+import com.positivity.workorder.service.TechnicianAssignmentService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Releases one blocked workorder's held resources, as a single transaction.
+ *
+ * <h2>Why this is its own bean</h2>
+ *
+ * {@link #releaseOne} used to sit on {@link FleetAuthorizationResourceReleaseRunner} and be called on
+ * {@code this} from its {@code @Scheduled} tick, which is not transactional. Spring's transaction
+ * advice is proxy-based, so that self-call bypassed it and the method's own comment — "re-read the
+ * guard inside the transaction" — described a transaction that did not exist. Living in a separate
+ * bean means the call crosses the proxy and the guard, the assignment release and the
+ * {@code resourcesReleasedAt} stamp are one unit.
+ *
+ * <h2>What the missing boundary cost</h2>
+ *
+ * The stamp is the only record that a release happened. Untransacted, an assignment could be
+ * released and the stamp then fail to persist, leaving the row eligible again — so the next tick
+ * releases an assignment that was already given up, attributing a second release to a job that never
+ * regained the resource.
+ */
+@Slf4j
+@Service
+public class FleetAuthorizationResourceReleaser {
+
+    /** Statuses under which held resources are still blocked and eligible for release. */
+    static final Set<FleetAuthorizationStatus> BLOCKING_STATUSES = Set.of(
+            FleetAuthorizationStatus.NOT_REQUESTED,
+            FleetAuthorizationStatus.PENDING,
+            FleetAuthorizationStatus.REFUSED,
+            FleetAuthorizationStatus.MANUAL_REVIEW);
+
+    private static final String RELEASED_BY = "fleet-authorization-resource-release";
+
+    private final WorkorderFleetAuthorizationRepository authorizationRepository;
+    private final TechnicianAssignmentService technicianAssignmentService;
+    private final Clock clock;
+    private final Duration releaseAfter;
+
+    public FleetAuthorizationResourceReleaser(
+            WorkorderFleetAuthorizationRepository authorizationRepository,
+            TechnicianAssignmentService technicianAssignmentService,
+            Clock clock,
+            @Value("${workorder.fleetauth.resource-release-after:PT4H}") Duration releaseAfter) {
+        this.authorizationRepository = authorizationRepository;
+        this.technicianAssignmentService = technicianAssignmentService;
+        this.clock = clock;
+        this.releaseAfter = releaseAfter;
+    }
+
+    @Transactional
+    public void releaseOne(@NonNull WorkorderFleetAuthorization authorization) {
+        // Re-read the guard inside the transaction: the status may have changed between the query
+        // above and this write, and releasing a resource for a now-granted authorization would be
+        // wrong rather than merely late.
+        if (!BLOCKING_STATUSES.contains(authorization.getStatus()) || authorization.getResourcesReleasedAt() != null) {
+            return;
+        }
+
+        technicianAssignmentService.releaseAssignment(
+                authorization.getWorkorderId(),
+                RELEASED_BY,
+                "fleet payment authorization has been unresolved for over " + releaseAfter);
+
+        authorization.setResourcesReleasedAt(Instant.now(clock));
+        authorizationRepository.save(authorization);
+        log.info(
+                "Released held resources for workorder {}: fleet authorization has been {} since {}",
+                authorization.getWorkorderId(),
+                authorization.getStatus(),
+                authorization.getFirstBlockedAt());
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaser.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaser.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@code this} from its {@code @Scheduled} tick, which is not transactional. Spring's transaction
  * advice is proxy-based, so that self-call bypassed it and the method's own comment — "re-read the
  * guard inside the transaction" — described a transaction that did not exist. Living in a separate
- * bean means the call crosses the proxy and the guard, the assignment release and the
+ * bean means the call crosses the proxy and the re-read, the guard, the assignment release and the
  * {@code resourcesReleasedAt} stamp are one unit.
  *
  * <h2>What the missing boundary cost</h2>
@@ -64,24 +64,33 @@ public class FleetAuthorizationResourceReleaser {
 
     @Transactional
     public void releaseOne(@NonNull WorkorderFleetAuthorization authorization) {
-        // Re-read the guard inside the transaction: the status may have changed between the query
-        // above and this write, and releasing a resource for a now-granted authorization would be
-        // wrong rather than merely late.
-        if (!BLOCKING_STATUSES.contains(authorization.getStatus()) || authorization.getResourcesReleasedAt() != null) {
+        // Re-read inside the transaction and evaluate the guard against *that* row, not against the
+        // instance the runner's query produced. That instance is detached and was read before this
+        // transaction began, so its status is a snapshot: checking it would let a resource be
+        // released for an authorization granted in the meantime, which is wrong rather than merely
+        // late. Saving it would be worse still — a merge of the stale snapshot over the newer row.
+        WorkorderFleetAuthorization managed = authorizationRepository
+                .findById(authorization.getWorkorderFleetAuthorizationId())
+                .orElse(null);
+        if (managed == null) {
+            // Deleted between the sweep's query and now. Nothing to release and nothing to record.
+            return;
+        }
+        if (!BLOCKING_STATUSES.contains(managed.getStatus()) || managed.getResourcesReleasedAt() != null) {
             return;
         }
 
         technicianAssignmentService.releaseAssignment(
-                authorization.getWorkorderId(),
+                managed.getWorkorderId(),
                 RELEASED_BY,
                 "fleet payment authorization has been unresolved for over " + releaseAfter);
 
-        authorization.setResourcesReleasedAt(Instant.now(clock));
-        authorizationRepository.save(authorization);
+        managed.setResourcesReleasedAt(Instant.now(clock));
+        authorizationRepository.save(managed);
         log.info(
                 "Released held resources for workorder {}: fleet authorization has been {} since {}",
-                authorization.getWorkorderId(),
-                authorization.getStatus(),
-                authorization.getFirstBlockedAt());
+                managed.getWorkorderId(),
+                managed.getStatus(),
+                managed.getFirstBlockedAt());
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunnerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunnerTest.java
@@ -15,7 +15,10 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -65,13 +68,26 @@ class FleetAuthorizationResourceReleaseRunnerTest {
         runner = new FleetAuthorizationResourceReleaseRunner(
                 authorizationRepository, releaser, Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofHours(4), 50);
         when(authorizationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        // The release re-reads by id inside its own transaction, so the mock has to answer that
+        // read. Tests that care about the gap between the sweep's query and the write override this
+        // to hand back a different row than the one the query produced.
+        when(authorizationRepository.findById(any()))
+                .thenAnswer(inv -> Optional.ofNullable(managedRows.get((UUID) inv.getArgument(0))));
+    }
+
+    /** What {@code findById} sees, keyed by authorization id — i.e. the current state of the table. */
+    private final Map<UUID, WorkorderFleetAuthorization> managedRows = new HashMap<>();
+
+    private WorkorderFleetAuthorization inTable(WorkorderFleetAuthorization row) {
+        managedRows.put(row.getWorkorderFleetAuthorizationId(), row);
+        return row;
     }
 
     @Test
     @DisplayName("an overdue blocked authorization releases its assignment and is marked released")
     void overdueBlockedAuthorizationIsReleased() {
         WorkorderFleetAuthorization authorization =
-                row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+                inTable(row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5))));
         when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
                 .thenReturn(List.of(authorization));
 
@@ -84,25 +100,29 @@ class FleetAuthorizationResourceReleaseRunnerTest {
     @Test
     @DisplayName("an authorization granted between the query and the write is not released")
     void grantedBetweenQueryAndWriteIsNotReleased() {
-        // The query result is stale by the time the write runs. Re-checking inside the write is
-        // what stops a resource being pulled from a job that is now cleared to start.
-        WorkorderFleetAuthorization authorization =
-                row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        // Two instances on purpose. `stale` is what the sweep's query produced, before this
+        // transaction began; `current` is the row as it now stands in the table. Mutating a single
+        // shared instance would prove nothing — it passes whether or not the write re-reads, which
+        // is how this test previously gave cover to a guard that only ever saw the snapshot.
+        WorkorderFleetAuthorization stale = row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        WorkorderFleetAuthorization current =
+                inTable(row(FleetAuthorizationStatus.GRANTED, NOW.minus(Duration.ofHours(5))));
         when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
-                .thenReturn(List.of(authorization));
-        authorization.setStatus(FleetAuthorizationStatus.GRANTED);
+                .thenReturn(List.of(stale));
 
         runner.releaseOverdue();
 
         verify(technicianAssignmentService, never()).releaseAssignment(any(), any(), any());
-        assertThat(authorization.getResourcesReleasedAt()).isNull();
+        assertThat(current.getResourcesReleasedAt()).isNull();
+        // And the stale snapshot must not have been merged back over the granted row.
+        verify(authorizationRepository, never()).save(any());
     }
 
     @Test
     @DisplayName("an authorization already released is not released again")
     void alreadyReleasedIsNotReleasedAgain() {
         WorkorderFleetAuthorization authorization =
-                row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+                inTable(row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5))));
         authorization.setResourcesReleasedAt(NOW.minus(Duration.ofMinutes(30)));
         when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
                 .thenReturn(List.of(authorization));
@@ -115,9 +135,12 @@ class FleetAuthorizationResourceReleaseRunnerTest {
     @Test
     @DisplayName("one failing release does not stop the rest of the batch")
     void oneFailureDoesNotStopTheBatch() {
-        WorkorderFleetAuthorization first = row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        WorkorderFleetAuthorization first =
+                inTable(row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5))));
         WorkorderFleetAuthorization second = row(FleetAuthorizationStatus.REFUSED, NOW.minus(Duration.ofHours(6)));
+        second.setWorkorderFleetAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a2"));
         second.setWorkorderId(UUID.fromString("019200aa-0000-7000-8000-0000000000c2"));
+        inTable(second);
         when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
                 .thenReturn(List.of(first, second));
         when(technicianAssignmentService.releaseAssignment(eq(WORKORDER_ID), any(), any()))

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunnerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunnerTest.java
@@ -49,14 +49,21 @@ class FleetAuthorizationResourceReleaseRunnerTest {
 
     private FleetAuthorizationResourceReleaseRunner runner;
 
+    /**
+     * Held alongside the runner: the per-row release lives in its own bean so that it gets a real
+     * transaction, and the guard tests below drive it directly rather than through a tick.
+     */
+    private FleetAuthorizationResourceReleaser releaser;
+
     @BeforeEach
     void setUp() {
-        runner = new FleetAuthorizationResourceReleaseRunner(
+        releaser = new FleetAuthorizationResourceReleaser(
                 authorizationRepository,
                 technicianAssignmentService,
                 Clock.fixed(NOW, ZoneOffset.UTC),
-                Duration.ofHours(4),
-                50);
+                Duration.ofHours(4));
+        runner = new FleetAuthorizationResourceReleaseRunner(
+                authorizationRepository, releaser, Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofHours(4), 50);
         when(authorizationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
     }
 
@@ -100,7 +107,7 @@ class FleetAuthorizationResourceReleaseRunnerTest {
         when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
                 .thenReturn(List.of(authorization));
 
-        runner.releaseOne(authorization);
+        releaser.releaseOne(authorization);
 
         verify(technicianAssignmentService, never()).releaseAssignment(any(), any(), any());
     }


### PR DESCRIPTION
Phase 3.1 of `docs/SONARQUBE_REMEDIATION_PLAN.md`, following #1487 (Phases 1–2).

> **Updated after review.** Two findings were confirmed and fixed (see *Review follow-ups* at the bottom), and the MKCAT failure mode described below turned out to be worse than first stated.

## Capability & Traceability
- Capability: n/a — code-health work, not a capability slice
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:supplier`, `domain:workorder`, `domain:customer`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no contract semantics change. No controller, DTO, `*Request`/`*Response`, event payload, `openapi.yaml`, or validation/error model changes. The `SupplierCatalogUpdatedV1` envelope built in `MktCatVariantStager` is byte-for-byte the one `MktCatImporter` built before; only the bean constructing it changed. Reference retained per the template so the Contract Sync Enforcement check can find `BACKEND_CONTRACT_GUIDE.md` in this body.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

**What changed:** the plan required every `java:S6809` site to be classified before any was touched, on the grounds that a blind self-injection refactor would be worse than the finding. That triage is in the plan doc. Of 34 sites, **9 are real and are fixed here; 25 need no change.**

Every one of the nine is the same failure: a non-transactional entry point — a `@Scheduled` tick, a `@KafkaListener`, or a plain public import method — self-invoking a `@Transactional` writer. Spring's transaction advice is proxy-based, so the call bypassed it and the annotation was never applied. The fix in each case is to move the writer into a collaborator bean so the call crosses the proxy.

| Module | Entry point | Moved to | What the missing boundary cost |
| ------ | ----------- | -------- | ------------------------------ |
| `pos-supplier` | `importAll`/`importVariants` → `importOne` | `MktCatVariantStager` | Staged row committed alone, then the outbox write **threw** — see below |
| `pos-supplier` | `@Scheduled approveOutstanding` | `WorkorderApprovalRecorder` | Read-modify-write of the attempt counter was not atomic |
| `pos-workorder` | `@Scheduled releaseOverdue` | `FleetAuthorizationResourceReleaser` | Assignment release and its record were separate units |
| `pos-customer` | `@KafkaListener onCommand` | `CustomerCommandHandlers` | Handlers ran outside the transaction they declared |

### The MKCAT case is worse than "not atomic"

`stageAndPublish`'s javadoc says: *"Both in one transaction, through the outbox: a variant recorded as published that was never emitted would be skipped on every later run, because its hash now matches (ADR-0044 §4)."*

`SupplierOutboxEventWriter.publish` is declared `@Transactional(propagation = MANDATORY)`. So with no transaction in scope, the sequence for **every changed variant** was: the staged row commits on its own with its new content hash and `lastPublishedAt` set, and the outbox write then throws `IllegalTransactionStateException`. That is a `RuntimeException`, not one of the `MktCatDecodeException`/`MktCatImportException` pair `importVariants` catches, so it aborts the entire sweep rather than skipping one variant.

Two consequences, not one: the sweep dies partway, and the variants it had already staged are recorded as published with events that were never emitted. Their hashes match from then on, so no later sweep republishes them.

`FleetAuthorizationResourceReleaser` had a related tell — `releaseOne` opens with *"Re-read the guard inside the transaction"*, in a method that had no transaction when called from the tick. See the review follow-ups: it also turned out not to be re-reading at all.

### Structure

The splits follow the data, not the rule. In each case the moved methods took their exclusive collaborators with them — `variantRepository`, `outboxEventWriter`, `objectMapper` and `clock` were used only by `stageAndPublish`; `uuidOrNull`/`enumOrNull` only by the two command handlers — so no field is now shared across the seam.

**Deliberately not changed:**

- `WorkorderCompletionApprover.queueApproval` — called from the completion event listener, not from inside the class, so its proxy was always in play. Sonar never flagged it.
- `CustomerCommandListener.handleOutboxReplayRequested` — declares no transaction and needs none; it only queues existing outbox rows. Sonar did not flag it either, which is useful evidence the rule reads annotations rather than pattern-matching self-calls.
- The other **25 sites**, listed by shape in the plan. Most are a convenience overload delegating to its full-argument sibling with identical `@Transactional` attributes, so the caller has already opened the transaction the callee would ask for and `REQUIRED` joins it either way. The read-write→`readOnly` cases are the same story: `readOnly` is honoured only when a transaction is *created*, so routing them through the proxy would change nothing. Removing the callee's annotation is not available either — in every case it is a public API method external callers reach through the proxy.

**Why:** Sonar scores these as maintainability, but the failure mode is a missing transaction boundary at runtime. That is why the plan puts them first in Phase 3 despite being only 34 of the 264 HIGH findings, and why the 148 duplicate-literal findings wait.

## Review follow-ups

**1. `releaseOne` was not actually re-reading** (raised by Copilot, fixed in b5947fb). Giving it a transaction was necessary but not sufficient: it evaluated its guard against the detached instance the sweep query produced, i.e. a snapshot taken before the transaction began — so an authorization granted in the interval would still have had its resources pulled. And `save()` on a detached entity *merges*, so that stale snapshot would have been written back over the newer row. It now re-reads by id inside the transaction and works on the managed row, returning early if the row is gone.

The existing `grantedBetweenQueryAndWriteIsNotReleased` test could not have caught this: it mutated a single shared instance, so the "stale" object and the "current row" were the same object and it passed either way. It now uses two distinct instances and asserts the stale snapshot is never saved.

**2. Two follow-on findings** (fixed in 1c8dd8b):

- `CustomerCommandHandlers` — the outer `@Transactional` was not merely redundant but harmful, and *activating* it is precisely what this PR did. `SegmentServiceImpl.resolveAndPublish` and `SuppressionServiceImpl.add` are both already `@Transactional`, so the atomicity the javadoc asks for was always provided. Adding an outer transaction changes one thing: a participating inner rollback marks the shared transaction rollback-only, so the outer commit throws `UnexpectedRollbackException` — escaping past `handleSegmentResolveRequested`'s catch, which runs before the commit and cannot see it. That turns a command documented as dropped-not-retried into a redelivery loop. Both annotations removed; the handlers are plain dispatch and the boundary stays where the work is.
- `WorkorderApprovalRecorder` — its three writers used `findById(...).orElse(row)`, merging the tick's detached snapshot when the row is gone and so resurrecting a deleted authorization. Same hazard as (1); they now return early, matching the releaser.

## Tests

`MktCatVariantStagerTransactionTest` covers the boundary directly, following the existing `SupplierExchangeAuditPersistenceTest` pattern — `@DataJpaTest` with `Propagation.NOT_SUPPORTED`, because a test wrapped in its own rolled-back transaction cannot observe a commit boundary and would pass just as happily with the bug present.

Both boundary tests were checked against the bug rather than merely written alongside the fix:
- removing `@Transactional` from `stageAndPublish` fails `failedOutboxWriteRollsBackTheStagedRow`;
- pointing `releaseOne`'s guard back at the detached instance fails `grantedBetweenQueryAndWriteIsNotReleased`.

Two tests added to `CustomerCommandListenerTest` pin the contract that now depends on the handlers being non-transactional: an unresolvable segment is dropped, and a transient DB error still rethrows for container retry/DLQ.

Existing tests moved with the code they exercise — `MktCatImporterTest` covered `stageAndPublish` exclusively and is now `MktCatVariantStagerTest`; the release-guard tests now drive the releaser.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a, no contract changed

**How to run:**

```bash
./mvnw -pl pos-supplier,pos-workorder,pos-customer -DskipTests=false test
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests -Dsurefire.failIfNoSpecifiedTests=false test
```

`pos-supplier` 1075, `pos-workorder` 940, `pos-customer` 660 tests green with Spotless, Checkstyle and SpotBugs enabled, and 16 ArchUnit rules green (four new beans, so the package-layout rules are worth running).

## Risk & Rollback
- Risk level: **Medium.** No behaviour is intended to change other than the transaction boundaries themselves — but that is a real semantic change: work that previously committed piecemeal now commits or rolls back as a unit, so a failure that used to leave partial state now leaves none. That is the point, and it is the part worth reviewing closely.
- Rollback plan: revert the commits. No schema change and no migration, so a revert is complete on its own. The four new beans are additive; reverting removes them along with their callers' references.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no; `claude/*` branch, consistent with recently merged PRs
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap id for code-health work
- [ ] Links to parent + child issues are present — no tracking issue exists for this work
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending re-run after the review fixes