### PR TITLE
feat(ci): automate the coverage ratchet and gate it against stale floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,6 +894,44 @@ jobs:
           echo "Coverage ratchet failed for $MODULES module(s) ($VIOLATIONS violation(s)); see the job summary."
           exit 1
 
+      - name: Enforce coverage floor drift
+        # The ratchet step above only catches a module falling BELOW its floor.
+        # Nothing caught a floor that had fallen behind the module, and floors
+        # were hand-edited, so §6.2's "raise a module's floor when its coverage
+        # rises" was advice with no enforcement. Measured at the time this step
+        # was added, the reactor's floors permitted ~3,400 covered lines and ~970
+        # covered branches to disappear — about four points of overall coverage —
+        # without one build turning red.
+        #
+        # This runs on the same `verify -DskipITs` output the ratchet reads, and
+        # for the same reason: floors derived from any other measurement describe
+        # coverage the gate cannot reproduce (§6.1). It reads each module's OWN
+        # target/site/jacoco/jacoco.csv, never the aggregate, because that is what
+        # jacoco:check evaluates.
+        #
+        # Fix a failure with `scripts/update-coverage-floors.sh --apply` after a
+        # local -DskipITs build, then commit the poms.
+        if: always()
+        run: |
+          set -o pipefail
+          if scripts/check-coverage-floor-drift.sh 2>&1 | tee "$RUNNER_TEMP/floor-drift.log"; then
+            exit 0
+          fi
+          {
+            echo "## Coverage floor drift"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/floor-drift.log"
+            echo '```'
+            echo
+            echo "Re-derive the floors after a -DskipITs build:"
+            echo '```'
+            echo "./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C"
+            echo "scripts/update-coverage-floors.sh --apply"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
       - name: Upload aggregate JaCoCo coverage report
         if: always()
         uses: actions/upload-artifact@v6

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -762,6 +762,7 @@ them are binding:
 | PR — "Test changed modules and dependents" | `test` + `jacoco:check`, `-DskipITs` | **yes** — pre-merge gate |
 | main — "…incl. ITs" | `verify`, ITs included | no — `haltOnFailure=false` |
 | nightly — "Build aggregate coverage report" | `verify -DskipITs`, full reactor | **yes** — job fails on any violation |
+| nightly — "Enforce coverage floor drift" | the same `-DskipITs` reports, read by `scripts/check-coverage-floor-drift.sh` | **yes** — job fails on a stale, thin, or missing floor |
 
 The PR step invokes `jacoco:check` directly instead of running `verify`. The
 `check-ratchet` execution is bound to `verify`, so a build that stops at `test`
@@ -779,11 +780,16 @@ are derived (§6.1).
 **Working rules.**
 
 - Raise a module's floor when its coverage rises — that is what makes it a
-  ratchet rather than a fixed bar.
-- Never lower a floor without saying why in the commit message.
+  ratchet rather than a fixed bar. `scripts/update-coverage-floors.sh --apply`
+  does this for the whole reactor; `scripts/check-coverage-floor-drift.sh` fails
+  the nightly when a floor has been left behind. Both are described in
+  `scripts/README.md`, and §6.5 records why they exist.
+- Never lower a floor without saying why in the commit message. The updater
+  refuses to lower one at all unless `--allow-lower` is passed.
 - Re-derive floors only from a `-DskipITs` run. If you find yourself reading a
   coverage number that included the ITs, stop: that number cannot be turned into
-  a floor, because the gate will never reproduce it.
+  a floor, because the gate will never reproduce it. Both scripts refuse to run
+  when they find Failsafe reports, for exactly this reason.
 - A floor sitting within ~2 points of measured coverage is not "tight", it is
   unstable, and it will fail on a night when nothing changed. Treat a
   thin-margin module as a bug in the floor or a gap in the tests, not as a
@@ -855,6 +861,59 @@ The fix, applied in `ci.yml`:
 Branch-level coverage for `main` now has exactly one source: the aggregate report.
 Keep it that way — any new job that runs `sonar-maven-plugin` outside PR mode must
 import the aggregate XML, never per-module reports.
+
+### 6.5 The ratchet is now enforced in both directions (2026-08-24)
+
+§6.2 has said "raise a module's floor when its coverage rises" since the ratchet
+landed. Nothing implemented it. Floors were hand-edited, so they moved only when
+someone remembered, and `jacoco:check` is blind in that direction by
+construction: it fails a module that falls **below** its floor and says nothing
+about a floor sitting far **under** a module that improved.
+
+Measured on `main` at the time of writing, summing every guarded module's
+distance from its own floor:
+
+```
+3,437 covered lines + 971 covered conditions may go uncovered before any floor trips
+implied overall floor: 74.2%, against 78.2% measured
+```
+
+Four points of overall coverage could be given back without one build turning
+red — on a project whose gate target is 80%. The individual findings were small
+and specific: `pos-supplier` sat 1.0 point over both its floors (the sub-2-point
+margin this section calls a coin toss), `pos-domain-events` more than 10 points
+over its line floor, and `pos-web-common` carried no floor at all despite having
+real code and 188 lines to cover — it is absent from §6.1's table entirely.
+
+Two scripts close this, sharing `scripts/coverage_floors.py`:
+
+| script | what it does |
+|---|---|
+| `scripts/update-coverage-floors.sh` | re-derives every floor from the last `-DskipITs` build (measured coverage minus `--cushion`, default 3, rounded down to 2dp — the §6.2 formula) and writes the poms |
+| `scripts/check-coverage-floor-drift.sh` | fails on `BREACH`, `THIN` (cushion < 2), `STALE` (cushion > 6), or `UNGUARDED` (a module over 50 lines with no floor) |
+
+Both inherit this section's constraints rather than restating them: they read
+each module's own `jacoco.csv` and not the aggregate (§6.1), they refuse to
+score a build whose `target/failsafe-reports` shows Failsafe ran, and the
+updater raises but never lowers unless `--allow-lower` is passed. The drift
+check runs in the nightly `code-quality-full` job immediately after the ratchet.
+
+`STALE` at 6 points is deliberately two full cushions: at 3 points the check
+would fire on the ordinary drift of a module that gained a test since the last
+re-derivation, and a gate that fires on healthy movement gets switched off.
+
+**First run.** The floors in §6.1 were derived on 2026-08-16 and the check has
+never been run against a fresh measurement, so the first nightly after this
+lands will report the modules that have drifted since. The fix is one command
+against that build's reports:
+
+```bash
+./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C
+scripts/update-coverage-floors.sh --apply
+```
+
+Then regenerate §6.1's table from the same reports, so the document and the poms
+describe one measurement rather than two.
 
 ## 7. What is still open
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,8 @@ Utility scripts for development, operations, testing, and deployment.
 | [`workorder-kafka-local.sh`](#workorder-kafka-localsh) | Kafka | Manage the local Kafka stack for `pos-workorder` |
 | [`check-noarg-now.sh`](#check-noarg-nowsh) | Code Quality | Detect forbidden no-arg `Instant.now()` / `LocalDateTime.now()` calls |
 | [`check-flyway-hygiene.sh`](#check-flyway-hygienesh) | Code Quality | Validate Flyway migration hygiene across `pos-*` modules |
+| [`check-coverage-floor-drift.sh`](#check-coverage-floor-driftsh) | Coverage | Verify each module's JaCoCo floor still sits a sane distance under its coverage |
+| [`update-coverage-floors.sh`](#update-coverage-floorssh) | Coverage | Re-derive the per-module JaCoCo coverage floors and write them into the poms |
 | [`verify-secrets.sh`](#verify-secretssh) | Security | Scan `application.yml` files for hardcoded secrets |
 | [`verify-docker-compose-secrets.sh`](#verify-docker-compose-secretssh) | Security | Verify `docker-compose.yml` secrets are fully externalized |
 | [`check-authz-doc-drift.sh`](#check-authz-doc-driftsh) | Documentation / Security | Check live authz docs against current token, endpoint, and catalog-version expectations |
@@ -350,6 +352,59 @@ Verifies that every module with a committed `openapi.yaml` is registered in
 - Exits non-zero on either kind of drift; runs in CI alongside the other drift guards.
 - Registration mode is not checked — only presence. A module that cannot be made `STRICT`-clean should be registered `REPORT_ONLY` or `EXCEPTION` rather than left out.
 - `EXEMPT_MODULES` in the script exists for specs the validator cannot load at all; prefer an `EXCEPTION` entry with a reason in the inventory itself.
+
+---
+
+### `check-coverage-floor-drift.sh`
+
+Verifies that every module's coverage ratchet still gates something.
+
+Root `pom.xml` checks each module against `<jacoco.line.min>` / `<jacoco.branch.min>`, set a few points below measured coverage (`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §6.2). Nothing kept those floors in step with the code: `jacoco:check` catches a module falling below its floor, but not a floor left far behind a module that improved. When this check was written the reactor's floors permitted roughly 3,400 covered lines and 970 covered branches to disappear — about four points of overall coverage — without one build turning red.
+
+**Usage:**
+```bash
+# Measure the way both binding gates measure, then check.
+./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C
+./scripts/check-coverage-floor-drift.sh
+```
+
+**Fails on:**
+- `BREACH` — measured coverage is under the floor (`jacoco:check` fails too; this names the module and counter)
+- `THIN` — the cushion is under `--min-cushion` (default 2). §6.2: "a cushion any thinner than about two points is not a gate, it is a coin toss"
+- `STALE` — the cushion is over `--max-cushion` (default 6), i.e. coverage rose and the floor was never raised behind it
+- `UNGUARDED` — a module with at least `--min-lines` lines (default 50) carries no floor
+
+**Notes:**
+- Reads each module's own `target/site/jacoco/jacoco.csv`, never the aggregate — the aggregate credits a shared library with its consumers' coverage, and it is not what `jacoco:check` evaluates (§6.1).
+- Refuses to score coverage produced with ITs. Failsafe inherits the JaCoCo agent through `@{argLine}` and appends to the same `jacoco.exec`, so an IT-inclusive run yields floors the gate can never reproduce. `--allow-its` overrides, at the cost of that guarantee.
+- Modules with no `jacoco.csv` are listed and skipped, not failed — only a build that ran tests produces one.
+- Runs nightly in the `Full Coverage SonarCloud Analysis` job, right after the ratchet itself.
+- Fix any finding with `update-coverage-floors.sh --apply`.
+
+---
+
+### `update-coverage-floors.sh`
+
+Re-derives every module's JaCoCo floors from the last `-DskipITs` build and writes them into the module poms. This is what makes the ratchet a ratchet — §6.2 says "raise a module's floor when its coverage rises", and before this script nothing did.
+
+**Usage:**
+```bash
+./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C
+./scripts/update-coverage-floors.sh            # preview the changes
+./scripts/update-coverage-floors.sh --apply    # write the poms
+```
+
+**Options:**
+- `--cushion N` — points below measured coverage (default 3, per §6.2)
+- `--allow-lower` — permit lowering a floor; §6.2 requires the reason in the commit message
+- `--allow-its` — proceed despite Failsafe reports, accepting floors the gate cannot reproduce
+
+**Notes:**
+- Floors are raised, never lowered: a proposal below the standing floor is reported and dropped unless `--allow-lower`.
+- Never writes a `0.00` floor — "a 0.00 floor is not a gate" (§6.2); an all-zero module needs first tests, not a threshold.
+- Refreshes the `Coverage ratchet: measured …` comment in each pom it touches, so the recorded numbers and cushion stay honest.
+- Adds the properties (and a `<properties>` block, in POM-sequence position) to a module that has none.
+- Both scripts share `coverage_floors.py`; its tests are `scripts/tests/test_coverage_floors.py`.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -379,7 +379,7 @@ Root `pom.xml` checks each module against `<jacoco.line.min>` / `<jacoco.branch.
 - Refuses to score coverage produced with ITs. Failsafe inherits the JaCoCo agent through `@{argLine}` and appends to the same `jacoco.exec`, so an IT-inclusive run yields floors the gate can never reproduce. `--allow-its` overrides, at the cost of that guarantee.
 - Modules with no `jacoco.csv` are listed and skipped, not failed — only a build that ran tests produces one.
 - Runs nightly in the `Full Coverage SonarCloud Analysis` job, right after the ratchet itself.
-- Fix any finding with `update-coverage-floors.sh --apply`.
+- Fix any finding with `./scripts/update-coverage-floors.sh --apply`.
 
 ---
 

--- a/scripts/check-coverage-floor-drift.sh
+++ b/scripts/check-coverage-floor-drift.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Guards the coverage ratchet against its own floors going stale.
+#
+# Root pom.xml gates each module on <jacoco.line.min> / <jacoco.branch.min>, set
+# a few points below measured coverage (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+# §6.2). Nothing kept those floors in step with the code, and a floor that has
+# fallen behind fails nothing while the module gives back everything it gained.
+# At the time this check was written the reactor's floors permitted roughly
+# 3,400 covered lines and 970 covered branches to disappear -- about four points
+# of overall coverage -- without one build turning red.
+#
+# Fails on:
+#   BREACH     measured coverage is under the floor (jacoco:check fails too;
+#              this names the module and counter)
+#   THIN       the cushion is under --min-cushion. §6.2: "a cushion any thinner
+#              than about two points is not a gate, it is a coin toss"
+#   STALE      the cushion is over --max-cushion, i.e. the floor was never
+#              raised after coverage rose
+#   UNGUARDED  a module big enough to need a floor has none
+#
+# Modules with no jacoco.csv are reported and skipped, not failed: only a build
+# that ran tests produces one. Run it after the same -DskipITs build the gate
+# measures -- the script refuses to score Failsafe-contaminated coverage (§6.1).
+#
+#   ./mvnw -pl pos-coverage-aggregate -am verify -DskipITs \
+#       -Darchunit.skipTests=true -T 1C
+#   scripts/check-coverage-floor-drift.sh
+#
+# Fix drift with scripts/update-coverage-floors.sh --apply.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+case "${1-}" in
+  -h|--help)
+    cat <<'USAGE'
+Verify every module's coverage floor still sits a sane distance under its
+measured coverage.
+
+Usage:
+  scripts/check-coverage-floor-drift.sh [options] [module...]
+
+Options:
+  --min-cushion N  Floors closer than this to measured coverage are THIN
+                   (default 2)
+  --max-cushion N  Floors further than this below it are STALE (default 6)
+  --min-lines N    Modules smaller than this need no floor (default 50)
+  --allow-its      Score the report even though Failsafe reports were found
+  -h, --help       Show this help
+USAGE
+    exit 0
+    ;;
+esac
+
+exec python3 scripts/coverage_floors.py --check "$@"

--- a/scripts/coverage_floors.py
+++ b/scripts/coverage_floors.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Derive, apply, and audit the per-module JaCoCo coverage floors (the ratchet).
+
+Root `pom.xml` gates every module on two properties, defaulted to 0.00:
+
+    <jacoco.line.min>   <jacoco.branch.min>
+
+Each module overrides them a fixed number of points below its measured
+coverage (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md section 6.2). That cushion is
+what keeps a parallel `-T 1C` CI run from failing on ordinary run-to-run
+variation, measured at roughly 1.7 points on pos-order.
+
+Until this script existed the floors were hand-edited, which made the ratchet
+one-directional in name only: nothing raised a floor when a module's coverage
+rose, so every point won drifted back out of the gate. Two failure modes follow,
+and both are reported here:
+
+  THIN   the floor sits within --min-cushion of measured coverage. Section 6.2:
+         "a cushion any thinner than about two points is not a gate, it is a
+         coin toss".
+  STALE  the floor sits more than --max-cushion below measured coverage, i.e.
+         coverage rose and the floor was never raised behind it. The module can
+         shed everything it gained without failing a build.
+
+MEASUREMENT CONTRACT. Floors may only be derived from a `-DskipITs` run, because
+that is what both binding gates run (section 6.2, "Where the gate actually
+runs"). Failsafe inherits the JaCoCo agent through `@{argLine}` and appends to
+the same target/jacoco.exec, so an IT-inclusive build silently produces higher
+per-module numbers than the gate can ever reproduce. Deriving floors from those
+numbers is the exact bug section 6.1 was rewritten to undo: it consumed the
+whole cushion and parked modules on the boundary, where run-to-run variation
+decided whether the nightly went green. This script therefore refuses to run
+when it finds Failsafe reports, unless --allow-its is passed.
+
+Reads each module's OWN target/site/jacoco/jacoco.csv, never the aggregate:
+report-aggregate credits a shared library with its consumers' coverage, and it
+is not what `jacoco:check` evaluates (section 6.1).
+
+Usage:
+  scripts/coverage_floors.py --check     audit only, non-zero exit on drift
+  scripts/coverage_floors.py --dry-run   print the floors that would be written
+  scripts/coverage_floors.py --apply     rewrite the module poms
+
+The two wrappers -- scripts/check-coverage-floor-drift.sh and
+scripts/update-coverage-floors.sh -- call this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Points below measured coverage that a freshly derived floor sits at. Section
+# 6.2 fixes this at 3: enough to absorb a refactor moving a few lines plus the
+# ~1.7 points of parallel-CI variation, tight enough to catch a real regression.
+DEFAULT_CUSHION = 3.0
+# Below this a floor is noise-triggered rather than regression-triggered.
+DEFAULT_MIN_CUSHION = 2.0
+# Above this the floor was never raised after coverage rose. Two full cushions:
+# beyond it, the gap cannot be explained by measurement variance.
+DEFAULT_MAX_CUSHION = 6.0
+# Modules with fewer lines than this are not worth a floor -- a handful of lines
+# swings the ratio by whole points. Section 6.1 leaves exactly this class of
+# module unguarded.
+DEFAULT_MIN_LINES = 50
+
+LINE_PROP = "jacoco.line.min"
+BRANCH_PROP = "jacoco.branch.min"
+COUNTERS = ("line", "branch")
+
+OK = "OK"
+BREACH = "BREACH"
+THIN = "THIN"
+STALE = "STALE"
+UNGUARDED = "UNGUARDED"
+NO_DATA = "NO-DATA"
+EXEMPT = "EXEMPT"
+
+# A module's status is the worst of its per-counter findings.
+SEVERITY = {BREACH: 5, STALE: 4, THIN: 3, UNGUARDED: 2, NO_DATA: 1, EXEMPT: 0, OK: 0}
+FAILING = frozenset({BREACH, THIN, STALE, UNGUARDED})
+
+COMMENT_RE = re.compile(r"measured [0-9.]+% line / [0-9.]+% branch")
+CUSHION_RE = re.compile(r"Floors sit [0-9.]+ points under")
+
+COMMENT_LINES = (
+    "<!-- Coverage ratchet: measured {line}% line / {branch}% branch by the gate's own",
+    "     command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).",
+    "     Floors sit {cushion:g} points under. Re-derive them ONLY from a -DskipITs run — an",
+    "     IT-inclusive measurement describes coverage the gate cannot see.",
+    "     Regenerate with scripts/update-coverage-floors.sh. -->",
+)
+
+# Elements that follow <properties> in the POM 4.0.0 sequence. Inserting
+# immediately before the first one present keeps the document schema-valid.
+AFTER_PROPERTIES = (
+    "<dependencyManagement>",
+    "<dependencies>",
+    "<build>",
+    "<reporting>",
+    "<profiles>",
+    "</project>",
+)
+
+
+def prop_for(counter: str) -> str:
+    return LINE_PROP if counter == "line" else BRANCH_PROP
+
+
+@dataclass
+class Counter:
+    """A JaCoCo missed/covered pair for one counter of one module."""
+
+    missed: int = 0
+    covered: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.missed + self.covered
+
+    @property
+    def ratio(self) -> float | None:
+        """Covered ratio, or None when the counter has nothing to measure.
+
+        A module with no branches reports 0/0; JaCoCo skips a limit on an empty
+        counter, so there is nothing for a floor to gate either.
+        """
+        return self.covered / self.total if self.total else None
+
+
+@dataclass
+class Finding:
+    counter: str  # "line", "branch", or "-" for a module-wide finding
+    status: str
+    detail: str
+
+
+@dataclass
+class Module:
+    name: str
+    pom: Path
+    line: Counter | None = None  # None => no jacoco.csv on disk
+    branch: Counter | None = None
+    floor_line: float | None = None  # None => property absent from the pom
+    floor_branch: float | None = None
+    has_it_reports: bool = False
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        if not self.findings:
+            return OK
+        return max((f.status for f in self.findings), key=lambda s: SEVERITY[s])
+
+    def floor(self, counter: str) -> float | None:
+        return self.floor_line if counter == "line" else self.floor_branch
+
+    def counter(self, counter: str) -> Counter | None:
+        return self.line if counter == "line" else self.branch
+
+    def percent(self, counter: str) -> float | None:
+        found = self.counter(counter)
+        ratio = found.ratio if found else None
+        return ratio * 100 if ratio is not None else None
+
+
+def reactor_modules() -> list[str]:
+    """Module names from the root pom's <modules> list, in declaration order."""
+    text = (ROOT / "pom.xml").read_text(encoding="utf-8")
+    block = re.search(r"<modules>(.*?)</modules>", text, re.DOTALL)
+    return re.findall(r"<module>([^<]+)</module>", block.group(1)) if block else []
+
+
+def read_counters(module_dir: Path) -> tuple[Counter, Counter] | None:
+    """Sum LINE_* and BRANCH_* over every class row of a module's jacoco.csv.
+
+    This is the summation section 6.1 prescribes for regenerating its table by
+    hand. Returns None when the module was not built with coverage.
+    """
+    csv_path = module_dir / "target" / "site" / "jacoco" / "jacoco.csv"
+    if not csv_path.is_file():
+        return None
+    line, branch = Counter(), Counter()
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            line.missed += int(row["LINE_MISSED"])
+            line.covered += int(row["LINE_COVERED"])
+            branch.missed += int(row["BRANCH_MISSED"])
+            branch.covered += int(row["BRANCH_COVERED"])
+    return line, branch
+
+
+def has_it_reports(module_dir: Path) -> bool:
+    """True when Failsafe ran here, so jacoco.exec includes IT coverage.
+
+    An absent or empty directory is the `-DskipITs` case -- what the gate
+    measures -- so only actual report files mean the numbers are contaminated.
+    """
+    reports = module_dir / "target" / "failsafe-reports"
+    return reports.is_dir() and any(reports.glob("TEST-*.xml"))
+
+
+def read_floor(pom_text: str, prop: str) -> float | None:
+    match = re.search(rf"<{re.escape(prop)}>\s*([^<\s]+)\s*</{re.escape(prop)}>", pom_text)
+    return float(match.group(1)) if match else None
+
+
+def floor_for(ratio: float, cushion: float) -> float:
+    """The floor for a measured ratio: cushion points under, rounded down to 2dp.
+
+    Section 6.2. The round() guards floor() against binary-float dust -- 0.80 -
+    0.03 lands on 76.99999999999999 often enough to matter, and that would
+    silently hand the module an extra point of slack.
+    """
+    return max(0.0, math.floor(round((ratio - cushion / 100) * 100, 9)) / 100)
+
+
+def load_modules(names: list[str]) -> list[Module]:
+    modules: list[Module] = []
+    for name in names:
+        module_dir = ROOT / name
+        pom = module_dir / "pom.xml"
+        if not pom.is_file():
+            continue
+        pom_text = pom.read_text(encoding="utf-8")
+        counters = read_counters(module_dir)
+        modules.append(
+            Module(
+                name=name,
+                pom=pom,
+                line=counters[0] if counters else None,
+                branch=counters[1] if counters else None,
+                floor_line=read_floor(pom_text, LINE_PROP),
+                floor_branch=read_floor(pom_text, BRANCH_PROP),
+                has_it_reports=has_it_reports(module_dir),
+            )
+        )
+    return modules
+
+
+def evaluate(module: Module, args: argparse.Namespace) -> None:
+    """Classify each counter of one module, populating module.findings."""
+    module.findings = []
+
+    if module.line is None:
+        # Not built, or built without coverage. A warning, never a failure: the
+        # PR gate invokes `jacoco:check` directly and writes no report.
+        module.findings.append(Finding("-", NO_DATA, "no target/site/jacoco/jacoco.csv"))
+        return
+
+    if module.line.total < args.min_lines:
+        module.findings.append(
+            Finding("-", EXEMPT, f"{module.line.total} lines, under the {args.min_lines}-line threshold")
+        )
+        return
+
+    for name in COUNTERS:
+        measured = module.percent(name)
+        floor = module.floor(name)
+
+        if measured is None:
+            if floor is not None:
+                module.findings.append(
+                    Finding(name, NO_DATA, f"floor {floor:.2f} is set but the module has no {name} counters")
+                )
+            continue
+
+        if floor is None:
+            module.findings.append(
+                Finding(name, UNGUARDED, f"measured {measured:.1f}%, no {prop_for(name)} in the pom")
+            )
+            continue
+
+        cushion = measured - floor * 100
+        if cushion < 0:
+            module.findings.append(
+                Finding(name, BREACH, f"measured {measured:.1f}% is below the {floor:.2f} floor")
+            )
+        elif cushion < args.min_cushion:
+            module.findings.append(
+                Finding(name, THIN, f"measured {measured:.1f}% is only {cushion:.1f} pts over the {floor:.2f} floor")
+            )
+        elif cushion > args.max_cushion:
+            module.findings.append(
+                Finding(name, STALE, f"measured {measured:.1f}% is {cushion:.1f} pts over the {floor:.2f} floor")
+            )
+
+
+def proposed_floors(
+    module: Module,
+    args: argparse.Namespace,
+    dropped: list[str] | None = None,
+) -> dict[str, float]:
+    """The floors --apply would write, keyed by counter name.
+
+    Ratchet semantics: a proposal below the standing floor is dropped unless
+    --allow-lower. Section 6.2: "Never lower a floor without saying why in the
+    commit message." Names of refused lowerings are appended to `dropped`, so
+    the caller can say that out loud rather than reporting "no changes" for a
+    module that is actually under water.
+    """
+    if module.line is None or module.line.total < args.min_lines:
+        return {}
+
+    result: dict[str, float] = {}
+    for name in COUNTERS:
+        found = module.counter(name)
+        if found is None or found.ratio is None:
+            continue
+        candidate = floor_for(found.ratio, args.cushion)
+        if candidate <= 0:
+            # A 0.00 floor is not a gate (section 6.2); such a module needs
+            # first tests, not a threshold.
+            continue
+        current = module.floor(name)
+        if current is not None:
+            if candidate < current and not args.allow_lower:
+                if dropped is not None:
+                    dropped.append(f"{module.name} {prop_for(name)} {current:.2f} -> {candidate:.2f}")
+                continue
+            if abs(candidate - current) < 1e-9:
+                continue
+        result[name] = candidate
+    return result
+
+
+def detect_indent(pom_text: str) -> str:
+    """One indentation unit for this pom -- tabs in the root, 4 spaces in modules."""
+    return "\t" if re.search(r"(?m)^\t", pom_text) else "    "
+
+
+def set_property(pom_text: str, prop: str, value: float) -> str | None:
+    """Replace an existing property value in place. None when it is absent."""
+    pattern = re.compile(rf"(<{re.escape(prop)}>)\s*[^<\s]+\s*(</{re.escape(prop)}>)")
+    if not pattern.search(pom_text):
+        return None
+    return pattern.sub(rf"\g<1>{value:.2f}\g<2>", pom_text, count=1)
+
+
+def property_lines(values: dict[str, float], indent: str) -> list[str]:
+    return [f"{indent}<{prop_for(name)}>{values[name]:.2f}</{prop_for(name)}>" for name in COUNTERS if name in values]
+
+
+def comment_lines(indent: str, line_pct: float, branch_pct: float, cushion: float) -> list[str]:
+    return [
+        indent + text.format(line=f"{line_pct:.1f}", branch=f"{branch_pct:.1f}", cushion=cushion)
+        for text in COMMENT_LINES
+    ]
+
+
+def insert_properties(
+    pom_text: str,
+    values: dict[str, float],
+    *,
+    with_comment: bool,
+    line_pct: float,
+    branch_pct: float,
+    cushion: float,
+) -> str:
+    """Add floor properties to a pom that lacks them, keeping the POM sequence valid."""
+    unit = detect_indent(pom_text)
+
+    existing = re.search(r"(?m)^([ \t]*)<properties>[ \t]*$", pom_text)
+    if existing:
+        indent = existing.group(1) + unit
+        body = comment_lines(indent, line_pct, branch_pct, cushion) if with_comment else []
+        body += property_lines(values, indent)
+        return pom_text[: existing.end()] + "\n" + "\n".join(body) + pom_text[existing.end() :]
+
+    for anchor in AFTER_PROPERTIES:
+        match = re.search(rf"(?m)^([ \t]*){re.escape(anchor)}", pom_text)
+        if not match:
+            continue
+        outer = match.group(1) or unit
+        indent = outer + unit
+        body = comment_lines(indent, line_pct, branch_pct, cushion) if with_comment else []
+        body += property_lines(values, indent)
+        block = f"{outer}<properties>\n" + "\n".join(body) + f"\n{outer}</properties>\n\n"
+        return pom_text[: match.start()] + block + pom_text[match.start() :]
+
+    raise ValueError("no anchor element found to insert <properties> before")
+
+
+def refresh_comment(pom_text: str, line_pct: float, branch_pct: float, cushion: float) -> str:
+    """Keep the ratchet comment honest after a rewrite.
+
+    Both halves matter: a comment still quoting last quarter's coverage is how a
+    reader talks themselves out of re-deriving, and one quoting the wrong cushion
+    misdescribes the gate for anyone running a non-default --cushion.
+    """
+    pom_text = COMMENT_RE.sub(f"measured {line_pct:.1f}% line / {branch_pct:.1f}% branch", pom_text, count=1)
+    return CUSHION_RE.sub(f"Floors sit {cushion:g} points under", pom_text, count=1)
+
+
+def apply_module(module: Module, values: dict[str, float], args: argparse.Namespace) -> bool:
+    """Write the proposed floors into a module pom. True when the file changed."""
+    if not values:
+        return False
+
+    original = module.pom.read_text(encoding="utf-8")
+    pom_text = original
+    missing: dict[str, float] = {}
+
+    for name, value in values.items():
+        updated = set_property(pom_text, prop_for(name), value)
+        if updated is None:
+            missing[name] = value
+        else:
+            pom_text = updated
+
+    line_pct = module.percent("line") or 0.0
+    branch_pct = module.percent("branch") or 0.0
+
+    if missing:
+        pom_text = insert_properties(
+            pom_text,
+            missing,
+            with_comment=COMMENT_RE.search(pom_text) is None,
+            line_pct=line_pct,
+            branch_pct=branch_pct,
+            cushion=args.cushion,
+        )
+
+    pom_text = refresh_comment(pom_text, line_pct, branch_pct, args.cushion)
+
+    if pom_text == original:
+        return False
+    module.pom.write_text(pom_text, encoding="utf-8")
+    return True
+
+
+def annotate(level: str, message: str) -> None:
+    """A GitHub Actions annotation in CI, plain text elsewhere."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::{level}::{message}")
+    else:
+        print(f"{level.upper()}: {message}")
+
+
+def report(modules: list[Module]) -> None:
+    header = f"{'module':<30}{'line%':>7}{'floor':>7}{'cush':>7}{'branch%':>9}{'floor':>7}{'cush':>7}  status"
+    print(header)
+    print("-" * len(header))
+    for module in sorted(modules, key=lambda m: (-SEVERITY[m.status], m.name)):
+        cells: list[str] = []
+        for name in COUNTERS:
+            measured = module.percent(name)
+            floor = module.floor(name)
+            if measured is None:
+                cells += ["-", "-", "-"]
+                continue
+            cells.append(f"{measured:.1f}")
+            cells.append(f"{floor:.2f}" if floor is not None else "-")
+            cells.append(f"{measured - floor * 100:+.1f}" if floor is not None else "-")
+        print(
+            f"{module.name:<30}{cells[0]:>7}{cells[1]:>7}{cells[2]:>7}"
+            f"{cells[3]:>9}{cells[4]:>7}{cells[5]:>7}  {module.status}"
+        )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Derive, apply, and audit the per-module JaCoCo coverage floors.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="audit only; exit non-zero on drift (CI mode)")
+    mode.add_argument("--apply", action="store_true", help="rewrite module poms with the derived floors")
+    mode.add_argument("--dry-run", action="store_true", help="print the floors --apply would write (default)")
+    parser.add_argument("--cushion", type=float, default=DEFAULT_CUSHION,
+                        help=f"points below measured coverage (default {DEFAULT_CUSHION:g})")
+    parser.add_argument("--min-cushion", type=float, default=DEFAULT_MIN_CUSHION,
+                        help=f"flag a floor closer than this as THIN (default {DEFAULT_MIN_CUSHION:g})")
+    parser.add_argument("--max-cushion", type=float, default=DEFAULT_MAX_CUSHION,
+                        help=f"flag a floor further than this as STALE (default {DEFAULT_MAX_CUSHION:g})")
+    parser.add_argument("--min-lines", type=int, default=DEFAULT_MIN_LINES,
+                        help=f"modules smaller than this need no floor (default {DEFAULT_MIN_LINES})")
+    parser.add_argument("--allow-lower", action="store_true",
+                        help="permit lowering a floor (say why in the commit message)")
+    parser.add_argument("--allow-its", action="store_true",
+                        help="proceed despite Failsafe reports (the numbers will not match the gate)")
+    parser.add_argument("modules", nargs="*", help="limit to these modules (default: every reactor module)")
+    args = parser.parse_args(argv)
+    if not (args.check or args.apply):
+        args.dry_run = True
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    modules = load_modules(args.modules or reactor_modules())
+    if not modules:
+        annotate("error", "no reactor modules found; run from a checkout of the repository")
+        return 1
+
+    contaminated = [m.name for m in modules if m.has_it_reports]
+    if contaminated and not args.allow_its:
+        shown = ", ".join(contaminated[:5]) + (" and others" if len(contaminated) > 5 else "")
+        annotate(
+            "error",
+            f"Failsafe reports found in {shown} -- this coverage includes ITs, which neither binding "
+            "gate runs. Re-measure with -DskipITs (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1), "
+            "or pass --allow-its.",
+        )
+        return 1
+
+    measured = [m for m in modules if m.line is not None]
+    if not measured:
+        annotate(
+            "error",
+            "no module has target/site/jacoco/jacoco.csv; run "
+            "`./mvnw verify -DskipITs -Darchunit.skipTests=true` first",
+        )
+        return 1
+
+    for module in modules:
+        evaluate(module, args)
+
+    report(modules)
+    print()
+
+    no_data = sorted(m.name for m in modules if m.status == NO_DATA)
+    if no_data:
+        shown = ", ".join(no_data[:8]) + (f" and {len(no_data) - 8} others" if len(no_data) > 8 else "")
+        print(f"{len(no_data)} module(s) had no coverage data and were skipped: {shown}")
+
+    if args.check:
+        failures = [m for m in modules if m.status in FAILING]
+        if not failures:
+            print(
+                f"PASS: {len(measured)} measured module(s); every floor sits "
+                f"{args.min_cushion:g}-{args.max_cushion:g} pts under its coverage."
+            )
+            return 0
+        print()
+        for module in sorted(failures, key=lambda m: (-SEVERITY[m.status], m.name)):
+            for finding in module.findings:
+                if finding.status in FAILING:
+                    annotate("error", f"{module.name} {finding.counter}: {finding.status} -- {finding.detail}")
+        print()
+        print("Re-derive the floors from a -DskipITs build and commit the result:")
+        print("  ./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C")
+        print("  scripts/update-coverage-floors.sh --apply")
+        return 1
+
+    by_name = {m.name: m for m in modules}
+    dropped: list[str] = []
+    changes = {m.name: proposed_floors(m, args, dropped) for m in modules}
+    changes = {name: values for name, values in changes.items() if values}
+
+    if dropped:
+        print(f"{len(dropped)} floor(s) would drop and were left alone (pass --allow-lower, and say why in the commit):")
+        for entry in dropped:
+            print(f"  {entry}")
+        print()
+
+    if not changes:
+        print("No floor changes: every module's floor already matches its measured coverage.")
+        return 0
+
+    print(f"{'module':<30}{'property':<22}{'current':>9}{'proposed':>10}")
+    print("-" * 71)
+    for name, values in changes.items():
+        module = by_name[name]
+        for counter, value in values.items():
+            current = module.floor(counter)
+            shown = f"{current:.2f}" if current is not None else "-"
+            print(f"{name:<30}{prop_for(counter):<22}{shown:>9}{value:>10.2f}")
+    print()
+
+    if args.dry_run:
+        print(f"{len(changes)} module(s) would change. Re-run with --apply to write them.")
+        return 0
+
+    written = [name for name, values in changes.items() if apply_module(by_name[name], values, args)]
+    print(f"Updated {len(written)} module pom(s): {', '.join(sorted(written))}")
+    print("Review the diff and commit; a lowered floor needs its reason in the commit message.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_coverage_floors.py
+++ b/scripts/tests/test_coverage_floors.py
@@ -1,0 +1,459 @@
+"""Tests for scripts/coverage_floors.py -- the coverage-floor ratchet."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import coverage_floors as cf  # noqa: E402
+
+CSV_HEADER = (
+    "GROUP,PACKAGE,CLASS,INSTRUCTION_MISSED,INSTRUCTION_COVERED,BRANCH_MISSED,BRANCH_COVERED,"
+    "LINE_MISSED,LINE_COVERED,COMPLEXITY_MISSED,COMPLEXITY_COVERED,METHOD_MISSED,METHOD_COVERED"
+)
+
+# Every row of the authoritative baseline table in
+# docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1: measured line%, measured branch%,
+# and the floors that table publishes. The floors are the specification; this
+# asserts the script's arithmetic reproduces them exactly rather than
+# approximately, because a floor one hundredth too high is a false red every
+# night and one too low is slack nobody notices.
+BASELINE_6_1 = [
+    ("pos-accounting", 80.3, 67.3, 0.77, 0.64),
+    ("pos-inventory", 79.2, 64.1, 0.76, 0.61),
+    ("pos-workorder", 77.7, 63.1, 0.74, 0.60),
+    ("pos-mcp-server", 80.2, 68.5, 0.77, 0.65),
+    ("pos-customer", 82.4, 69.6, 0.79, 0.66),
+    ("pos-supplier", 87.3, 73.5, 0.84, 0.70),
+    ("pos-order", 84.4, 71.3, 0.81, 0.68),
+    ("pos-security-service", 77.1, 66.6, 0.74, 0.63),
+    ("pos-invoice", 77.3, 63.7, 0.74, 0.60),
+    ("pos-catalog", 77.6, 61.6, 0.74, 0.58),
+    ("pos-people", 78.7, 73.1, 0.75, 0.70),
+    ("pos-warranty", 87.3, 78.9, 0.84, 0.75),
+    ("pos-location", 78.1, 66.1, 0.75, 0.63),
+    ("pos-shop-manager", 79.9, 63.5, 0.76, 0.60),
+    ("pos-bulk-loader", 76.6, 65.3, 0.73, 0.62),
+    ("pos-people-contact", 72.8, 62.2, 0.69, 0.59),
+    ("pos-marketing", 90.7, 85.2, 0.87, 0.82),
+    ("pos-price", 94.4, 80.4, 0.91, 0.77),
+    ("pos-vehicle-inventory", 79.6, 74.7, 0.76, 0.71),
+    ("pos-tax", 78.5, 66.8, 0.75, 0.63),
+    ("pos-domain-events", 84.9, 78.9, 0.81, 0.75),
+    ("pos-vehicle-fitment", 78.4, 63.6, 0.75, 0.60),
+    ("pos-event-receiver", 77.6, 87.2, 0.74, 0.84),
+    ("pos-api-gateway", 85.6, 72.2, 0.82, 0.69),
+    ("pos-security-common", 79.4, 80.7, 0.76, 0.77),
+    ("pos-documents", 72.9, 75.0, 0.69, 0.72),
+    ("pos-openapi-validation", 94.2, 81.2, 0.91, 0.78),
+    ("pos-vehicle-reference-nhtsa", 53.4, 58.3, 0.50, 0.55),
+    ("pos-events", 59.8, 57.1, 0.56, 0.54),
+    ("pos-document-helper", 95.7, 90.0, 0.92, 0.87),
+    ("pos-tax-common", 89.4, 74.1, 0.86, 0.71),
+    ("pos-vehicle-reference-carapi", 78.3, 88.9, 0.75, 0.85),
+    ("pos-image", 31.1, 100.0, 0.28, 0.97),
+]
+
+
+def options(**overrides) -> argparse.Namespace:
+    defaults = dict(
+        cushion=cf.DEFAULT_CUSHION,
+        min_cushion=cf.DEFAULT_MIN_CUSHION,
+        max_cushion=cf.DEFAULT_MAX_CUSHION,
+        min_lines=cf.DEFAULT_MIN_LINES,
+        allow_lower=False,
+        allow_its=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def module(line=(20, 80), branch=(35, 65), floor_line=0.77, floor_branch=0.62, pom=Path("pom.xml")) -> cf.Module:
+    return cf.Module(
+        name="pos-example",
+        pom=pom,
+        line=cf.Counter(*line) if line else None,
+        branch=cf.Counter(*branch) if branch else None,
+        floor_line=floor_line,
+        floor_branch=floor_branch,
+    )
+
+
+def write_csv(module_dir: Path, rows: list[tuple[int, int, int, int]]) -> None:
+    """rows: (branch_missed, branch_covered, line_missed, line_covered)."""
+    report = module_dir / "target" / "site" / "jacoco"
+    report.mkdir(parents=True, exist_ok=True)
+    lines = [CSV_HEADER]
+    for index, (bm, bc, lm, lc) in enumerate(rows):
+        lines.append(f"pos-example,com.positivity.example,Class{index},0,0,{bm},{bc},{lm},{lc},0,0,0,0")
+    (report / "jacoco.csv").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class TestFloorFor:
+    @pytest.mark.parametrize("name,line_pct,branch_pct,line_floor,branch_floor", BASELINE_6_1)
+    def test_reproduces_the_published_baseline(self, name, line_pct, branch_pct, line_floor, branch_floor):
+        assert cf.floor_for(line_pct / 100, 3.0) == pytest.approx(line_floor), name
+        assert cf.floor_for(branch_pct / 100, 3.0) == pytest.approx(branch_floor), name
+
+    def test_rounds_down_never_up(self):
+        # 0.809 - 0.03 = 0.779; rounding up would hand the gate a floor the
+        # module does not actually clear.
+        assert cf.floor_for(0.809, 3.0) == pytest.approx(0.77)
+
+    def test_survives_binary_float_dust(self):
+        # 0.80 - 0.03 evaluates to 0.7700000000000001 in IEEE 754; a naive
+        # floor() on a value that landed just under would give away a point.
+        assert cf.floor_for(0.80, 3.0) == pytest.approx(0.77)
+        assert cf.floor_for(0.50, 3.0) == pytest.approx(0.47)
+        assert cf.floor_for(1.00, 3.0) == pytest.approx(0.97)
+
+    def test_never_negative(self):
+        assert cf.floor_for(0.01, 3.0) == 0.0
+
+    def test_cushion_is_configurable(self):
+        assert cf.floor_for(0.873, 5.0) == pytest.approx(0.82)
+
+
+class TestCounter:
+    def test_ratio_of_empty_counter_is_none(self):
+        assert cf.Counter(0, 0).ratio is None
+
+    def test_ratio(self):
+        assert cf.Counter(missed=20, covered=80).ratio == pytest.approx(0.80)
+
+
+class TestReadCounters:
+    def test_sums_every_class_row(self, tmp_path):
+        write_csv(tmp_path, [(5, 15, 10, 90), (5, 5, 10, 10)])
+        line, branch = cf.read_counters(tmp_path)
+        assert (line.missed, line.covered) == (20, 100)
+        assert (branch.missed, branch.covered) == (10, 20)
+
+    def test_missing_report_is_none(self, tmp_path):
+        assert cf.read_counters(tmp_path) is None
+
+
+class TestHasItReports:
+    def test_detects_failsafe_output(self, tmp_path):
+        reports = tmp_path / "target" / "failsafe-reports"
+        reports.mkdir(parents=True)
+        (reports / "TEST-com.positivity.example.ThingIT.xml").write_text("<testsuite/>", encoding="utf-8")
+        assert cf.has_it_reports(tmp_path) is True
+
+    def test_empty_directory_is_the_skipits_case(self, tmp_path):
+        (tmp_path / "target" / "failsafe-reports").mkdir(parents=True)
+        assert cf.has_it_reports(tmp_path) is False
+
+    def test_absent_directory(self, tmp_path):
+        assert cf.has_it_reports(tmp_path) is False
+
+
+class TestEvaluate:
+    def test_healthy_cushion_is_ok(self):
+        target = module(line=(20, 80), floor_line=0.77, branch=(35, 65), floor_branch=0.62)
+        cf.evaluate(target, options())
+        assert target.status == cf.OK
+
+    def test_thin_cushion(self):
+        # pos-supplier's real state when this script was written: 1.0 pt over.
+        target = module(line=(15, 85), floor_line=0.84, branch=(29, 71), floor_branch=0.70)
+        cf.evaluate(target, options())
+        assert target.status == cf.THIN
+
+    def test_stale_floor(self):
+        target = module(line=(9, 91), floor_line=0.81, branch=(18, 82), floor_branch=0.75)
+        cf.evaluate(target, options())
+        assert target.status == cf.STALE
+
+    def test_breach(self):
+        target = module(line=(30, 70), floor_line=0.77)
+        cf.evaluate(target, options())
+        assert target.status == cf.BREACH
+
+    def test_unguarded_module_with_real_code(self):
+        target = module(floor_line=None, floor_branch=None)
+        cf.evaluate(target, options())
+        assert target.status == cf.UNGUARDED
+
+    def test_small_module_is_exempt(self):
+        target = module(line=(10, 20), floor_line=None, floor_branch=None)
+        cf.evaluate(target, options())
+        assert target.status == cf.EXEMPT
+
+    def test_module_without_coverage_data(self):
+        target = module(line=None, branch=None)
+        cf.evaluate(target, options())
+        assert target.status == cf.NO_DATA
+
+    def test_branchless_module_is_not_penalised(self):
+        target = module(branch=(0, 0), floor_branch=None)
+        cf.evaluate(target, options())
+        assert target.status == cf.OK
+
+    def test_branch_floor_set_on_a_branchless_module_is_reported(self):
+        target = module(branch=(0, 0), floor_branch=0.60)
+        cf.evaluate(target, options())
+        assert target.status == cf.NO_DATA
+
+    def test_status_is_the_worst_finding(self):
+        target = module(line=(9, 91), floor_line=0.81, branch=(50, 50), floor_branch=0.62)
+        cf.evaluate(target, options())
+        assert target.status == cf.BREACH
+
+
+class TestProposedFloors:
+    def test_raises_a_stale_floor(self):
+        target = module(line=(9, 91), floor_line=0.81, branch=(18, 82), floor_branch=0.75)
+        assert cf.proposed_floors(target, options()) == {"line": 0.88, "branch": 0.79}
+
+    def test_refuses_to_lower_by_default(self):
+        target = module(line=(30, 70), floor_line=0.77, branch=(50, 50), floor_branch=0.62)
+        assert cf.proposed_floors(target, options()) == {}
+
+    def test_records_refused_lowerings(self):
+        target = module(line=(30, 70), floor_line=0.77, branch=(50, 50), floor_branch=0.62)
+        dropped: list[str] = []
+        assert cf.proposed_floors(target, options(), dropped) == {}
+        assert dropped == [
+            "pos-example jacoco.line.min 0.77 -> 0.67",
+            "pos-example jacoco.branch.min 0.62 -> 0.47",
+        ]
+
+    def test_lowers_only_when_asked(self):
+        target = module(line=(30, 70), floor_line=0.77, branch=(50, 50), floor_branch=0.62)
+        assert cf.proposed_floors(target, options(allow_lower=True)) == {"line": 0.67, "branch": 0.47}
+
+    def test_no_change_when_already_correct(self):
+        target = module(line=(20, 80), floor_line=0.77, branch=(35, 65), floor_branch=0.62)
+        assert cf.proposed_floors(target, options()) == {}
+
+    def test_proposes_a_floor_for_an_unguarded_module(self):
+        target = module(floor_line=None, floor_branch=None)
+        assert cf.proposed_floors(target, options()) == {"line": 0.77, "branch": 0.62}
+
+    def test_never_proposes_a_zero_floor(self):
+        # "A 0.00 floor is not a gate" (§6.2) -- an all-zero module needs first
+        # tests, not a threshold.
+        target = module(line=(100, 0), branch=(100, 0), floor_line=None, floor_branch=None)
+        assert cf.proposed_floors(target, options()) == {}
+
+    def test_small_module_gets_nothing(self):
+        target = module(line=(10, 20), floor_line=None, floor_branch=None)
+        assert cf.proposed_floors(target, options()) == {}
+
+
+POM_WITH_FLOORS = """<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <artifactId>pos-example</artifactId>
+
+    <properties>
+        <!-- Coverage ratchet: measured 79.2% line / 64.1% branch by the gate's own
+             command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
+             Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
+             IT-inclusive measurement describes coverage the gate cannot see. -->
+        <jacoco.line.min>0.76</jacoco.line.min>
+        <jacoco.branch.min>0.61</jacoco.branch.min>
+    </properties>
+
+    <dependencies>
+    </dependencies>
+</project>
+"""
+
+POM_WITHOUT_PROPERTIES = """<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <artifactId>pos-web-common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-shared-dtos</artifactId>
+        </dependency>
+    </dependencies>
+</project>
+"""
+
+POM_WITH_EMPTY_PROPERTIES = """<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <artifactId>pos-example</artifactId>
+
+    <properties>
+        <java.version>25</java.version>
+    </properties>
+
+    <build>
+    </build>
+</project>
+"""
+
+
+class TestPomEditing:
+    def test_set_property_replaces_in_place(self):
+        result = cf.set_property(POM_WITH_FLOORS, cf.LINE_PROP, 0.81)
+        assert "<jacoco.line.min>0.81</jacoco.line.min>" in result
+        assert "<jacoco.branch.min>0.61</jacoco.branch.min>" in result
+
+    def test_set_property_is_none_when_absent(self):
+        assert cf.set_property(POM_WITHOUT_PROPERTIES, cf.LINE_PROP, 0.81) is None
+
+    def test_set_property_always_two_decimals(self):
+        result = cf.set_property(POM_WITH_FLOORS, cf.LINE_PROP, 0.8)
+        assert "<jacoco.line.min>0.80</jacoco.line.min>" in result
+
+    def test_insert_into_existing_properties(self):
+        result = cf.insert_properties(
+            POM_WITH_EMPTY_PROPERTIES,
+            {"line": 0.75, "branch": 0.63},
+            with_comment=True,
+            line_pct=78.1,
+            branch_pct=66.1,
+            cushion=3.0,
+        )
+        assert "        <jacoco.line.min>0.75</jacoco.line.min>" in result
+        assert "        <jacoco.branch.min>0.63</jacoco.branch.min>" in result
+        assert "measured 78.1% line / 66.1% branch" in result
+        assert result.count("<properties>") == 1
+        assert "<java.version>25</java.version>" in result
+
+    def test_insert_creates_properties_before_dependencies(self):
+        result = cf.insert_properties(
+            POM_WITHOUT_PROPERTIES,
+            {"line": 0.82, "branch": 0.62},
+            with_comment=True,
+            line_pct=85.6,
+            branch_pct=65.3,
+            cushion=3.0,
+        )
+        # POM 4.0.0 sequences <properties> before <dependencies>; inserting after
+        # would produce a document that fails schema validation.
+        assert result.index("<properties>") < result.index("<dependencies>")
+        assert "    <properties>" in result
+        assert "        <jacoco.line.min>0.82</jacoco.line.min>" in result
+        assert "    </properties>" in result
+
+    def test_detect_indent(self):
+        assert cf.detect_indent(POM_WITH_FLOORS) == "    "
+        assert cf.detect_indent("<project>\n\t<modules>\n\t</modules>\n</project>") == "\t"
+
+    def test_refresh_comment(self):
+        result = cf.refresh_comment(POM_WITH_FLOORS, 81.4, 66.2, 3.0)
+        assert "measured 81.4% line / 66.2% branch" in result
+        assert "measured 79.2% line / 64.1% branch" not in result
+        assert "Floors sit 3 points under" in result
+
+    def test_refresh_comment_tracks_a_non_default_cushion(self):
+        result = cf.refresh_comment(POM_WITH_FLOORS, 81.4, 66.2, 2.0)
+        assert "Floors sit 2 points under" in result
+        assert "Floors sit 3 points under" not in result
+
+
+class TestApplyModule:
+    def test_writes_floors_and_refreshes_the_comment(self, tmp_path):
+        pom = tmp_path / "pom.xml"
+        pom.write_text(POM_WITH_FLOORS, encoding="utf-8")
+        target = module(line=(15, 85), branch=(30, 70), floor_line=0.76, floor_branch=0.61, pom=pom)
+
+        assert cf.apply_module(target, cf.proposed_floors(target, options()), options()) is True
+
+        written = pom.read_text(encoding="utf-8")
+        assert "<jacoco.line.min>0.82</jacoco.line.min>" in written
+        assert "<jacoco.branch.min>0.67</jacoco.branch.min>" in written
+        assert "measured 85.0% line / 70.0% branch" in written
+
+    def test_no_write_when_nothing_changes(self, tmp_path):
+        pom = tmp_path / "pom.xml"
+        pom.write_text(POM_WITH_FLOORS, encoding="utf-8")
+        target = module(line=(21, 79), branch=(36, 64), floor_line=0.76, floor_branch=0.61, pom=pom)
+
+        assert cf.apply_module(target, {}, options()) is False
+        assert pom.read_text(encoding="utf-8") == POM_WITH_FLOORS
+
+    def test_adds_floors_to_a_pom_that_had_none(self, tmp_path):
+        pom = tmp_path / "pom.xml"
+        pom.write_text(POM_WITHOUT_PROPERTIES, encoding="utf-8")
+        target = module(line=(20, 80), branch=(35, 65), floor_line=None, floor_branch=None, pom=pom)
+
+        assert cf.apply_module(target, cf.proposed_floors(target, options()), options()) is True
+
+        written = pom.read_text(encoding="utf-8")
+        assert "<jacoco.line.min>0.77</jacoco.line.min>" in written
+        assert "<jacoco.branch.min>0.62</jacoco.branch.min>" in written
+        assert written.index("<properties>") < written.index("<dependencies>")
+
+
+class TestMain:
+    """End-to-end over a throwaway reactor, exercising the CLI contract."""
+
+    @pytest.fixture
+    def reactor(self, tmp_path, monkeypatch):
+        (tmp_path / "pom.xml").write_text(
+            "<project>\n  <modules>\n    <module>pos-example</module>\n  </modules>\n</project>\n",
+            encoding="utf-8",
+        )
+        module_dir = tmp_path / "pos-example"
+        module_dir.mkdir()
+        (module_dir / "pom.xml").write_text(POM_WITH_FLOORS, encoding="utf-8")
+        monkeypatch.setattr(cf, "ROOT", tmp_path)
+        return module_dir
+
+    def test_check_passes_on_a_healthy_cushion(self, reactor, capsys):
+        write_csv(reactor, [(36, 64, 21, 79)])
+        assert cf.main(["--check"]) == 0
+        assert "PASS" in capsys.readouterr().out
+
+    def test_check_fails_on_a_stale_floor(self, reactor, capsys):
+        write_csv(reactor, [(10, 90, 5, 95)])
+        assert cf.main(["--check"]) == 1
+        assert "STALE" in capsys.readouterr().out
+
+    def test_check_fails_on_a_breach(self, reactor, capsys):
+        write_csv(reactor, [(50, 50, 40, 60)])
+        assert cf.main(["--check"]) == 1
+        assert "BREACH" in capsys.readouterr().out
+
+    def test_refuses_it_contaminated_coverage(self, reactor, capsys):
+        write_csv(reactor, [(36, 64, 21, 79)])
+        failsafe = reactor / "target" / "failsafe-reports"
+        failsafe.mkdir(parents=True)
+        (failsafe / "TEST-com.positivity.example.ThingIT.xml").write_text("<testsuite/>", encoding="utf-8")
+
+        assert cf.main(["--check"]) == 1
+        assert "Failsafe reports found" in capsys.readouterr().out
+        assert cf.main(["--check", "--allow-its"]) == 0
+
+    def test_errors_when_nothing_was_built(self, reactor, capsys):
+        assert cf.main(["--check"]) == 1
+        assert "no module has target/site/jacoco/jacoco.csv" in capsys.readouterr().out
+
+    def test_dry_run_leaves_the_pom_alone(self, reactor, capsys):
+        write_csv(reactor, [(10, 90, 5, 95)])
+        before = (reactor / "pom.xml").read_text(encoding="utf-8")
+        assert cf.main(["--dry-run"]) == 0
+        assert (reactor / "pom.xml").read_text(encoding="utf-8") == before
+        assert "would change" in capsys.readouterr().out
+
+    def test_apply_writes_the_pom(self, reactor):
+        write_csv(reactor, [(10, 90, 5, 95)])
+        assert cf.main(["--apply"]) == 0
+        written = (reactor / "pom.xml").read_text(encoding="utf-8")
+        assert "<jacoco.line.min>0.92</jacoco.line.min>" in written
+        assert "<jacoco.branch.min>0.87</jacoco.branch.min>" in written
+
+    def test_dry_run_says_a_floor_would_drop(self, reactor, capsys):
+        write_csv(reactor, [(50, 50, 40, 60)])
+        assert cf.main(["--dry-run"]) == 0
+        out = capsys.readouterr().out
+        assert "--allow-lower" in out
+        assert "jacoco.line.min 0.76 -> 0.57" in out
+
+    def test_apply_then_check_is_clean(self, reactor):
+        write_csv(reactor, [(10, 90, 5, 95)])
+        assert cf.main(["--apply"]) == 0
+        assert cf.main(["--check"]) == 0

--- a/scripts/update-coverage-floors.sh
+++ b/scripts/update-coverage-floors.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Re-derive every module's JaCoCo coverage floors from the last -DskipITs build
+# and write them into the module poms.
+#
+# This is what makes the ratchet a ratchet. Section 6.2 of
+# docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md says "raise a module's floor when its
+# coverage rises", but nothing automated it, so floors only ever moved when
+# someone remembered. A floor left behind is slack: the module can shed every
+# point it gained without failing a build.
+#
+# Floors are raised, never lowered -- a proposal below the standing floor is
+# dropped unless --allow-lower is passed, and section 6.2 requires the reason to
+# go in the commit message.
+#
+# Measure first, with the command the gate itself runs. -DskipITs is not
+# optional: Failsafe shares the JaCoCo agent and the same jacoco.exec, so an
+# IT-inclusive run yields floors the gate can never reproduce (§6.1). The script
+# refuses to run if it finds Failsafe reports.
+#
+#   ./mvnw -pl pos-coverage-aggregate -am verify -DskipITs \
+#       -Darchunit.skipTests=true -T 1C
+#   scripts/update-coverage-floors.sh          # preview
+#   scripts/update-coverage-floors.sh --apply  # write the poms
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  cat <<'USAGE'
+Re-derive per-module JaCoCo coverage floors from the last -DskipITs build.
+
+Usage:
+  scripts/update-coverage-floors.sh [options] [module...]
+
+Options:
+  --apply          Write the new floors into the module poms (default: preview)
+  --cushion N      Points below measured coverage (default 3, per §6.2)
+  --allow-lower    Permit lowering a floor; say why in the commit message
+  --allow-its      Proceed even though Failsafe reports were found. The floors
+                   will describe coverage neither binding gate can reproduce.
+  -h, --help       Show this help
+
+Examples:
+  scripts/update-coverage-floors.sh
+  scripts/update-coverage-floors.sh --apply
+  scripts/update-coverage-floors.sh --apply pos-supplier
+USAGE
+}
+
+args=()
+mode="--dry-run"
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help) usage; exit 0 ;;
+    --apply) mode="--apply" ;;
+    --dry-run) mode="--dry-run" ;;
+    *) args+=("$arg") ;;
+  esac
+done
+
+exec python3 scripts/coverage_floors.py "$mode" ${args[@]+"${args[@]}"}


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — build/CI tooling, not capability work
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:build` (no runtime domain touched)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — no controllers, DTOs, `*Request`/`*Response` types, events, `openapi.yaml`, or validation/error models are touched. The diff is two shell wrappers, one Python core, its tests, one CI step, and two documents.

## Contract Chain (when a Controller changed)
Not applicable — no controller changed.

- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

**What changed:** the per-module JaCoCo coverage ratchet is now maintained and audited by tooling instead of by hand.

| file | |
|---|---|
| `scripts/coverage_floors.py` | shared core — derive, apply, audit |
| `scripts/update-coverage-floors.sh` | re-derives every floor from the last `-DskipITs` build and writes the module poms |
| `scripts/check-coverage-floor-drift.sh` | fails on `BREACH` / `THIN` / `STALE` / `UNGUARDED` |
| `scripts/tests/test_coverage_floors.py` | 82 tests |
| `.github/workflows/ci.yml` | binding step in the nightly `code-quality-full` job, right after the ratchet |
| `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` | new §6.5, §6.2 working rules, gate table row |
| `scripts/README.md` | index rows + a section per script |

**Why:** the floors have been hand-edited since Phase 4 landed, which made the ratchet one-directional in name only. `jacoco:check` fails a module that drops below its floor and says nothing about a floor sitting far under a module that improved, so §6.2's "raise a module's floor when its coverage rises" was advice with no enforcement behind it.

Summing every guarded module's distance from its own floor on `main`:

```
3,437 covered lines + 971 covered conditions may go uncovered before any floor trips
implied overall floor: 74.2%, against 78.2% measured
```

Four points of overall coverage can be given back without one build turning red, on a project whose gate target is 80%. The individual cases are specific: `pos-supplier` sits 1.0 point over both floors — the sub-2-point margin §6.2 itself calls a coin toss rather than a gate; `pos-domain-events` sits more than 10 points over its line floor; `pos-web-common` carries no floor at all despite 188 lines to cover, and is absent from the §6.1 table entirely.

**Design notes**

Both scripts inherit §6's existing constraints rather than restating them:

- They read each module's **own** `jacoco.csv`, never the aggregate — the aggregate credits a shared library with its consumers' coverage and is not what `jacoco:check` evaluates (§6.1).
- They refuse to score a build whose `target/failsafe-reports` shows Failsafe ran. Failsafe inherits the JaCoCo agent through `@{argLine}` (`pom.xml:526`) and appends to the same `jacoco.exec`, so an IT-inclusive measurement yields floors the gate can never reproduce — the exact bug §6.1 was rewritten to undo. `--allow-its` overrides, at the cost of that guarantee.
- The updater raises but never lowers: a lowering is reported and dropped unless `--allow-lower` is passed, and §6.2 still requires the reason in the commit message.
- It never writes a `0.00` floor — "a 0.00 floor is not a gate"; an all-zero module needs first tests, not a threshold.

`STALE` is set at 6 points, two full cushions rather than one. At 3 it would fire on the ordinary drift of a module that gained a test since the last re-derivation, and a gate that fires on healthy movement gets switched off.

**Expected on the first nightly.** The step is binding and the floors were derived 2026-08-16, so the first run will name whatever has drifted since. One command against that build's reports clears it:

```bash
./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C
scripts/update-coverage-floors.sh --apply
```

That full-reactor measurement could not be produced in this session, so the floors themselves are unchanged by this PR. If you would rather the first nightly report than fail, add `continue-on-error: true` to the step and drop it once the floors are re-derived.

## Tests
- [x] Unit tests added/updated — `scripts/tests/test_coverage_floors.py`, 82 tests
- [ ] Integration tests added/updated — n/a, no runtime code
- [ ] Provider behavioral contract tests added/updated — n/a, no contract surface

Coverage includes the floor arithmetic against **all 33 rows** of the published §6.1 baseline (not a sample), the classification of each drift kind, the raise-never-lower rule, and the pom rewriting — including inserting a `<properties>` block in POM-sequence position for a module that has none.

Also verified end-to-end against real JaCoCo output rather than fixtures alone: `pos-tax-common` was built with the gate's own command and scored at 89.4% line / 74.1% branch, reproducing its published §6.1 row exactly, which confirms the CSV summation matches how that table was produced. The updater was then applied to the real pom at `--cushion 2`, the diff inspected (0.86→0.87, 0.71→0.72, comment text refreshed), and reverted. The IT guard was confirmed to trip on a planted `TEST-*IT.xml`.

**How to run:**
```bash
python3 -m pytest scripts/tests/test_coverage_floors.py -q

# against a real build
./mvnw -pl pos-tax-common verify -DskipITs
scripts/check-coverage-floor-drift.sh pos-tax-common
```

All 167 tests under `scripts/tests` pass, the 85 pre-existing ones included.

## Risk & Rollback
- Risk level: **Low** — no production code, no runtime behavior, no module pom changed. The only binding change is one step in the nightly `code-quality-full` job, which does not run on pushes or pull requests.
- Rollback plan: revert the commit, or drop the `Enforce coverage floor drift` step from `.github/workflows/ci.yml` to keep the scripts available as manual tools without gating the nightly.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/sonarqube-line-count-jvos5g`; this is not capability work
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap id; title follows the conventional-commit form used by recent merges
- [ ] Links to parent + child issues are present — none; this came out of a coverage-gate investigation, not an issue
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFhFik3dXHVTHeB1NNgaEr)_