### PR TITLE
fix: make the 409 conflict payload serializable and reach two statics by their declarer

### DIFF
--- a/docs/SONARQUBE_REMEDIATION_PLAN.md
+++ b/docs/SONARQUBE_REMEDIATION_PLAN.md
@@ -1,7 +1,7 @@
 # SonarQube Remediation Plan
 
-Status: Phases 1, 2, 3.1 and 3.4 implemented. Phases 3.2, 3.3, 3.5 and 3.6 not
-started.
+Status: Phases 1, 2, 3.1, 3.2, 3.3 and 3.4 implemented. Phases 3.5 (`S1192`,
+148 findings) and 3.6 (`S3776`, 62 findings) not started.
 The `new_reliability_rating` fix is in, so the next analysis should return the
 quality gate to green — confirm against §7 before treating §1's table as stale.
 Date: 2026-08-24
@@ -299,31 +299,45 @@ No code change is proposed for these 25. Removing the callee's `@Transactional`
 is not available either: in every case above the callee is a public API method
 that external callers reach through the proxy, where the annotation is load-bearing.
 
-### 3.2 `java:S1948` (1 issue)
+### 3.2 `java:S1948` (1 issue) — DONE
 
 `pos-shop-manager/…/internal/exception/SchedulingConflictException.java:11` —
-`SchedulingConflictException extends RuntimeException` (hence `Serializable`)
-but holds a non-serializable `ConflictResponse conflictResponse`.
+`SchedulingConflictException extends RuntimeException` (hence `Serializable`) but
+held a non-serializable `ConflictResponse conflictResponse`.
 
-Fix: make `ConflictResponse` implement `Serializable`, or mark the field
-`transient` and have `getConflictResponse()` cope with a null after
-deserialisation. Prefer the former — the exception is mapped to an HTTP 409
-body (`docs/ERROR_ENVELOPE.md`), so losing the payload on deserialisation would
-silently degrade the response. Confirm the exception is never actually
-serialised across a boundary first; if it never is, `transient` is the smaller
-change.
+The plan called for confirming first whether the exception is ever serialized
+across a boundary, and preferring `Serializable` over `transient` if the payload
+matters. It is never serialized — it is thrown by `ConflictDetectionServiceImpl`
+and handled in-process, mapped to an HTTP 409 body. By the letter of the rule that
+makes `transient` the smaller change, but `transient` would leave
+`getConflictResponse()` able to return null after a deserialization that never
+happens: a footgun guarding a case that does not exist.
 
-### 3.3 `java:S3252` (4 issues)
+So: `ConflictResponse` and its two nested types, `Conflict` and
+`SuggestedAlternative`, now implement `Serializable` with explicit
+`serialVersionUID`. They hold only `String`, `Instant` and `List` of each other,
+so nothing else was needed, the accessor stays total, and the 409 payload would
+survive a round trip if one ever occurred.
 
-Mechanical.
+### 3.3 `java:S3252` (4 issues) — DONE
 
-- `pos-customer/…/internal/service/PartyServiceImpl.java:721,733,735` — access
-  `PARTY_ID` via `AbstractParty_` rather than a subclass metamodel.
+Mechanical, and both cases were static members reached through a subtype rather
+than their declaring class.
+
+- `pos-customer/…/internal/service/PartyServiceImpl.java:721,733,735` —
+  `PARTY_ID` is declared on `AbstractParty_`, not on the `CommercialParty_`
+  metamodel the code went through. Now `AbstractParty_.PARTY_ID`. The
+  neighbouring `LEGAL_NAME` uses are untouched: that constant really is declared
+  on `CommercialParty_`, which is why Sonar flagged three of the five references
+  in that method and not the other two.
 - `pos-security-service/…/internal/config/HttpToHttpsRedirectConfig.java:46` —
-  access `DEFAULT_PROTOCOL` via `TomcatWebServerFactory`.
+  `DEFAULT_PROTOCOL` is declared on `TomcatWebServerFactory` in Spring Boot 4, and
+  was reached through `TomcatServletWebServerFactory`. Now references the
+  declaring class; the `TomcatServletWebServerFactory` import stays, since
+  `@ConditionalOnClass` and the customizer's type parameter still need it.
 
-No behaviour change, no tests needed beyond the existing suite. Good
-first commit of Phase 3 if a warm-up is wanted.
+Verified: `pos-customer` 660, `pos-security-service` 488, `pos-shop-manager` 229
+tests green with Spotless, Checkstyle and SpotBugs enabled.
 
 ### 3.4 `java:S1186` — empty methods (15 issues) — DONE
 
@@ -466,7 +480,7 @@ This is the only bucket that changes real control flow, so it is scheduled
 | 1 | Reliability `S2637` | 2 | 0.5 h | **Red → Green** | done |
 | 2 | BLOCKER `S2699` | 1 | 0.2 h | none | done |
 | 3.1 | `S6809` transactional self-invocation | 34 | 2.8 h | none (real runtime risk) | done: 9 fixed, 25 no-action |
-| 3.2–3.3 | `S1948`, `S3252` | 5 | 0.8 h | none | not started |
+| 3.2–3.3 | `S1948`, `S3252` | 5 | 0.8 h | none | done |
 | 3.4 | `S1186` empty methods | 15 | 1.2 h | none | done: 8 deleted, 2 fixed, 5 documented |
 | 3.5 | `S1192` literals | 148 | 21.0 h | none | not started |
 | 3.6 | `S3776` complexity | 62 | 11.6 h | none | not started |

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -22,6 +22,7 @@ import com.positivity.customer.internal.dto.snapshot.BillingRuleRef;
 import com.positivity.customer.internal.dto.snapshot.ContactSummary;
 import com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO;
 import com.positivity.customer.internal.dto.snapshot.SnapshotMetadata;
+import com.positivity.customer.internal.entity.AbstractParty_;
 import com.positivity.customer.internal.entity.BillingRulesEmbeddable;
 import com.positivity.customer.internal.entity.CommercialParty;
 import com.positivity.customer.internal.entity.CommercialParty_;
@@ -717,8 +718,7 @@ public class PartyServiceImpl implements PartyService {
     private Sort normalizeBrowseSort(@NonNull Sort requestedSort) {
         if (requestedSort.isUnsorted()) {
             return Sort.by(
-                    Sort.Order.asc(CommercialParty_.LEGAL_NAME).ignoreCase(),
-                    Sort.Order.asc(CommercialParty_.PARTY_ID));
+                    Sort.Order.asc(CommercialParty_.LEGAL_NAME).ignoreCase(), Sort.Order.asc(AbstractParty_.PARTY_ID));
         }
 
         List<Sort.Order> orders = new ArrayList<>();
@@ -729,10 +729,9 @@ public class PartyServiceImpl implements PartyService {
                 orders.add(order);
             }
         });
-        boolean hasPartyIdSort =
-                orders.stream().anyMatch(order -> CommercialParty_.PARTY_ID.equals(order.getProperty()));
+        boolean hasPartyIdSort = orders.stream().anyMatch(order -> AbstractParty_.PARTY_ID.equals(order.getProperty()));
         if (!hasPartyIdSort) {
-            orders.add(Sort.Order.asc(CommercialParty_.PARTY_ID));
+            orders.add(Sort.Order.asc(AbstractParty_.PARTY_ID));
         }
         return Sort.by(orders);
     }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/HttpToHttpsRedirectConfig.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/HttpToHttpsRedirectConfig.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.tomcat.TomcatWebServerFactory;
 import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -43,7 +44,7 @@ public class HttpToHttpsRedirectConfig {
                 return;
             }
 
-            Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
+            Connector connector = new Connector(TomcatWebServerFactory.DEFAULT_PROTOCOL);
             connector.setScheme("http");
             connector.setPort(httpPort);
             connector.setSecure(false);

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/dto/ConflictResponse.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/dto/ConflictResponse.java
@@ -4,6 +4,8 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.List;
 
@@ -14,7 +16,10 @@ import java.util.List;
  * timestamp.
  */
 @Schema(description = "Error envelope returned when an appointment scheduling conflict is detected (HTTP 409)")
-public class ConflictResponse {
+public class ConflictResponse implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Schema(description = "Machine-readable error code", example = "SCHEDULING_CONFLICT", requiredMode = REQUIRED)
     private String errorCode; // Always "SCHEDULING_CONFLICT"
@@ -123,7 +128,10 @@ public class ConflictResponse {
      * SOFT conflicts can be overridden with permission and reason.
      */
     @Schema(description = "A single detected scheduling conflict")
-    public static class Conflict {
+    public static class Conflict implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Schema(description = "Conflict severity (HARD or SOFT)", example = "SOFT", requiredMode = REQUIRED)
         private String severity; // HARD | SOFT (enum)
@@ -208,7 +216,10 @@ public class ConflictResponse {
      * Provided as a convenience; client can ignore and choose own time.
      */
     @Schema(description = "A suggested alternative appointment slot that avoids detected conflicts")
-    public static class SuggestedAlternative {
+    public static class SuggestedAlternative implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @Schema(
                 description = "Suggested start time (ISO-8601 with offset)",


### PR DESCRIPTION
Phases 3.2 and 3.3 of `docs/SONARQUBE_REMEDIATION_PLAN.md` — the five mechanical HIGH findings sitting between the transaction work and the literal extraction.

**Stacked on #1490.** Based on that PR's branch so this diff is only the 3.2/3.3 work; both touch the plan doc, and stacking avoids a guaranteed conflict. It retargets to `main` when #1490 merges.

## Capability & Traceability
- Capability: n/a — code-health work, not a capability slice
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:shop-manager`, `domain:customer`, `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no contract semantics change. `ConflictResponse` is the HTTP 409 body, but the change adds only `implements Serializable` and a `serialVersionUID`; no field, type, name, or annotation changes, so the serialized JSON is byte-identical. Reference retained per the template so the Contract Sync Enforcement check can find `BACKEND_CONTRACT_GUIDE.md` in this body.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

### 3.2 — `java:S1948` (1 finding)

`SchedulingConflictException extends RuntimeException` and so is `Serializable`, but held a non-serializable `ConflictResponse`.

The plan asked to establish first whether the exception ever crosses a serialization boundary. **It does not** — it is thrown by `ConflictDetectionServiceImpl` and handled in-process on its way to an HTTP 409 body. By the letter of the plan's rule that makes `transient` the smaller change, but `transient` buys a `getConflictResponse()` that can return null after a deserialization that never happens: a footgun guarding a case that does not exist.

So `ConflictResponse` and its nested `Conflict` and `SuggestedAlternative` implement `Serializable` with explicit `serialVersionUID` instead. They hold only `String`, `Instant` and `List`s of each other, so nothing else was required, the accessor stays total, and the payload would survive a round trip if one ever occurred.

### 3.3 — `java:S3252` (4 findings)

Both cases are a static member reached through a subtype rather than its declaring class.

- **`PartyServiceImpl:721,733,735`** went through the `CommercialParty_` metamodel for `PARTY_ID`, which is declared on `AbstractParty_`. The three references now name `AbstractParty_`. The neighbouring `LEGAL_NAME` uses are deliberately untouched — that constant really is declared on `CommercialParty_`, which is why Sonar flagged three of the five metamodel references in that method and not the other two.
- **`HttpToHttpsRedirectConfig:46`** reached `DEFAULT_PROTOCOL` through `TomcatServletWebServerFactory`; in Spring Boot 4 it is declared on `TomcatWebServerFactory`. The `TomcatServletWebServerFactory` import stays, because `@ConditionalOnClass` and the customizer's type parameter still need it.

## Tests

No new tests. Every change here is a reference or a marker interface with no reachable behaviour change: the metamodel constants resolve to the same `"partyId"` string, `DEFAULT_PROTOCOL` to the same protocol string, and `implements Serializable` adds no behaviour to a type nothing currently serializes. The existing suites are the guard that none of it moved.

- [ ] Unit tests added/updated — n/a, no behaviour to pin
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a, no contract changed

**How to run:**

```bash
./mvnw -pl pos-customer,pos-security-service,pos-shop-manager -DskipTests=false test
```

`pos-customer` 660, `pos-security-service` 488, `pos-shop-manager` 229 tests green with Spotless, Checkstyle and SpotBugs enabled.

## Risk & Rollback
- Risk level: **Low.** No behavioural change is intended or expected; the riskiest element is the `PartyServiceImpl` sort, which resolves to the identical property name.
- Rollback plan: revert the commit. No schema change, no migration, no new dependency.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no; `claude/*` branch, consistent with recently merged PRs
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap id for code-health work
- [ ] Links to parent + child issues are present — no tracking issue exists for this work
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending first run

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKBxAj3zreJqYprAGvtXnS)_