### PR TITLE
refactor: extract the duplicated string literals Sonar flags (java:S1192)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/JournalEntryController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/JournalEntryController.java
@@ -54,6 +54,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Journal Entries", description = "Manage journal entries including posting and reversal.")
 @Validated
 public class JournalEntryController {
+    private static final String UPDATED_AT = "updatedAt";
 
     private static final Logger log = LoggerFactory.getLogger(JournalEntryController.class);
 
@@ -62,16 +63,26 @@ public class JournalEntryController {
      * (see JournalEntryResponse) while the entity property is {@code updatedAt}.
      */
     private static final Map<String, String> SORTABLE_PROPERTIES = Map.of(
-            "createdAt", "createdAt",
-            "modifiedAt", "updatedAt",
-            "updatedAt", "updatedAt",
-            "transactionDate", "transactionDate",
-            "postedAt", "postedAt",
-            "status", "status",
-            "entryType", "entryType",
-            "description", "description",
-            "createdBy", "createdBy",
-            "journalEntryId", "journalEntryId");
+            "createdAt",
+            "createdAt",
+            "modifiedAt",
+            UPDATED_AT,
+            UPDATED_AT,
+            UPDATED_AT,
+            "transactionDate",
+            "transactionDate",
+            "postedAt",
+            "postedAt",
+            "status",
+            "status",
+            "entryType",
+            "entryType",
+            "description",
+            "description",
+            "createdBy",
+            "createdBy",
+            "journalEntryId",
+            "journalEntryId");
 
     private final JournalEntryService journalEntryService;
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/DefaultGLMapping.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/DefaultGLMapping.java
@@ -56,6 +56,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
             @Index(name = "idx_default_gl_mapping_active", columnList = "active")
         })
 public class DefaultGLMapping {
+    private static final String SYSTEM_SOURCE = "SYSTEM";
 
     @EqualsAndHashCode.Include
     @Id
@@ -67,8 +68,8 @@ public class DefaultGLMapping {
     @PrePersist
     public void onPrePersist() {
         String currentUser = SecurityContextHelper.isAuthenticated()
-                ? SecurityContextHelper.getCurrentUsernameOrDefault("SYSTEM")
-                : "SYSTEM";
+                ? SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_SOURCE)
+                : SYSTEM_SOURCE;
         this.createdBy = currentUser;
         this.modifiedBy = currentUser;
     }
@@ -76,8 +77,8 @@ public class DefaultGLMapping {
     @PreUpdate
     public void onPreUpdate() {
         String currentUser = SecurityContextHelper.isAuthenticated()
-                ? SecurityContextHelper.getCurrentUsernameOrDefault("SYSTEM")
-                : "SYSTEM";
+                ? SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_SOURCE)
+                : SYSTEM_SOURCE;
         this.modifiedBy = currentUser;
     }
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomy.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomy.java
@@ -22,6 +22,7 @@ import java.util.Map;
  * source classification carry a {@code null} cost type.
  */
 public final class LaborOverheadTaxonomy {
+    private static final String MAINTENANCE = "Maintenance";
 
     /** Synthetic codes for the section/grand total rows (the source form has no numeric code for these). */
     public static final String TOTAL_LABOR = "TOTAL_LABOR";
@@ -201,7 +202,7 @@ public final class LaborOverheadTaxonomy {
                         + " building-financing interest; land depreciation."));
         lines.add(leaf(
                 "2.1.2",
-                "Maintenance",
+                MAINTENANCE,
                 "2.1",
                 3,
                 CostType.FIXED,
@@ -241,7 +242,7 @@ public final class LaborOverheadTaxonomy {
                         + "warehousing vehicles; vehicle insurance (use 2.7.3); forklifts (use 2.11.5).",
                 List.of("2.4.1", "2.4.2", "2.4.3", "2.4.4", "2.4.5")));
         lines.add(leaf("2.4.1", "Gas & Oil", "2.4", 3, null, false, "Fuel/oil for plant vehicles."));
-        lines.add(leaf("2.4.2", "Maintenance", "2.4", 3, null, false, "Maintenance for plant vehicles."));
+        lines.add(leaf("2.4.2", MAINTENANCE, "2.4", 3, null, false, "Maintenance for plant vehicles."));
         lines.add(leaf("2.4.3", "Taxes", "2.4", 3, null, false, "Taxes on plant vehicles."));
         lines.add(leaf(
                 "2.4.4", "Depreciation", "2.4", 3, null, false, "Depreciation of plant vehicles (standard methods)."));
@@ -342,7 +343,7 @@ public final class LaborOverheadTaxonomy {
                 List.of("2.11.1", "2.11.2", "2.11.3", "2.11.4", "2.11.5", "2.11.6")));
         lines.add(leaf(
                 "2.11.1",
-                "Maintenance",
+                MAINTENANCE,
                 "2.11",
                 3,
                 CostType.FIXED_IF_LOW_VOLUME,

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/EventIngestionServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/EventIngestionServiceImpl.java
@@ -67,6 +67,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class EventIngestionServiceImpl implements EventIngestionService {
+    private static final String EVENT_NOT_FOUND_PREFIX = "Event not found: ";
+
     private final Clock clock;
 
     private static final String EVENT_SPACE = "Event ";
@@ -205,7 +207,7 @@ public class EventIngestionServiceImpl implements EventIngestionService {
     public AccountingEventResponse getEventById(@NonNull UUID eventId) {
         AccountingEvent event = accountingEventRepository
                 .findById(eventId)
-                .orElseThrow(() -> new EventNotFoundException("Event not found: " + eventId));
+                .orElseThrow(() -> new EventNotFoundException(EVENT_NOT_FOUND_PREFIX + eventId));
         return AccountingEventMapper.toEventResponse(event);
     }
 
@@ -217,7 +219,7 @@ public class EventIngestionServiceImpl implements EventIngestionService {
     public AccountingEventResponse retryEventProcessing(UUID eventId) {
         AccountingEvent accountingEvent = accountingEventRepository
                 .findById(eventId)
-                .orElseThrow(() -> new EventNotFoundException("Event not found: " + eventId));
+                .orElseThrow(() -> new EventNotFoundException(EVENT_NOT_FOUND_PREFIX + eventId));
         log.info("Retrying event {}", eventId);
 
         accountingEvent.setStatus(AccountingEventStatus.RECEIVED);
@@ -259,7 +261,7 @@ public class EventIngestionServiceImpl implements EventIngestionService {
         // Load the accounting event
         AccountingEvent event = accountingEventRepository
                 .findById(eventId)
-                .orElseThrow(() -> new EventNotFoundException("Event not found: " + eventId));
+                .orElseThrow(() -> new EventNotFoundException(EVENT_NOT_FOUND_PREFIX + eventId));
 
         // BR-3: Idempotency check - reject if already PROCESSED
         if (event.getStatus() == AccountingEventStatus.PROCESSED) {

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLAccountServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLAccountServiceImpl.java
@@ -42,6 +42,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class GLAccountServiceImpl implements GLAccountService {
+    private static final String UPDATED_AT = "updatedAt";
+
+    private static final String ACCOUNT_CODE = "accountCode";
+
     private final Clock clock;
 
     private static final String GL_ACCOUNT_NOT_FOUND = "GL account not found: ";
@@ -53,16 +57,26 @@ public class GLAccountServiceImpl implements GLAccountService {
      * (see GLAccountResponse) while the entity property is {@code updatedAt}.
      */
     private static final Map<String, String> SORTABLE_PROPERTIES = Map.of(
-            "accountCode", "accountCode",
-            "accountName", "accountName",
-            "accountType", "accountType",
-            "description", "description",
-            "activationDate", "activationDate",
-            "deactivationDate", "deactivationDate",
-            "createdAt", "createdAt",
-            "modifiedAt", "updatedAt",
-            "updatedAt", "updatedAt",
-            "glAccountId", "glAccountId");
+            ACCOUNT_CODE,
+            ACCOUNT_CODE,
+            "accountName",
+            "accountName",
+            "accountType",
+            "accountType",
+            "description",
+            "description",
+            "activationDate",
+            "activationDate",
+            "deactivationDate",
+            "deactivationDate",
+            "createdAt",
+            "createdAt",
+            "modifiedAt",
+            UPDATED_AT,
+            UPDATED_AT,
+            UPDATED_AT,
+            "glAccountId",
+            "glAccountId");
 
     private static final Logger log = LoggerFactory.getLogger(GLAccountServiceImpl.class);
 
@@ -346,7 +360,7 @@ public class GLAccountServiceImpl implements GLAccountService {
         // Build pageable with sorting; ascending default preserves the previous
         // Sort.by(property) behavior.
         Sort sortOrder =
-                SortParamParser.parse(sort != null ? sort : "accountCode", SORTABLE_PROPERTIES, Sort.Direction.ASC);
+                SortParamParser.parse(sort != null ? sort : ACCOUNT_CODE, SORTABLE_PROPERTIES, Sort.Direction.ASC);
         Pageable pageable = PageRequest.of(page, size, sortOrder);
 
         // Fetch all accounts (filtering by status requires derived field)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/MappingResolutionTestServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/MappingResolutionTestServiceImpl.java
@@ -56,6 +56,7 @@ import tools.jackson.databind.ObjectMapper;
 @Service
 @RequiredArgsConstructor
 public class MappingResolutionTestServiceImpl implements MappingResolutionTestService {
+    private static final String PAYLOAD_PATH_PREFIX = "payload.";
 
     /**
      * Placeholder organization used only to satisfy the evaluator's
@@ -378,7 +379,7 @@ public class MappingResolutionTestServiceImpl implements MappingResolutionTestSe
         if (clause.lhs() instanceof PredicateParser.EventTypeRef) {
             lhs = "eventType";
         } else if (clause.lhs() instanceof PredicateParser.PayloadPath path) {
-            lhs = "payload." + String.join(".", path.segments());
+            lhs = PAYLOAD_PATH_PREFIX + String.join(".", path.segments());
         } else {
             lhs = "?";
         }
@@ -418,8 +419,9 @@ public class MappingResolutionTestServiceImpl implements MappingResolutionTestSe
 
     @Nullable
     private Object navigatePayload(String amountField, @Nullable Map<String, Object> payload) {
-        String fieldPath =
-                amountField.startsWith("payload.") ? amountField.substring("payload.".length()) : amountField;
+        String fieldPath = amountField.startsWith(PAYLOAD_PATH_PREFIX)
+                ? amountField.substring(PAYLOAD_PATH_PREFIX.length())
+                : amountField;
         Object current = payload;
         for (String part : fieldPath.split("\\.")) {
             if (current instanceof Map<?, ?> map) {

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
@@ -60,6 +60,8 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 @Transactional
 public class PaymentApplicationServiceImpl implements com.positivity.accounting.service.PaymentApplicationService {
+    private static final String PAYMENT_APPLICATION_NOT_FOUND_PREFIX = "Payment application not found: ";
+
     private static final String PAYMENT_NOT_FOUND = "Payment not found: ";
 
     private final Clock clock;
@@ -405,7 +407,7 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
         PaymentApplication original = paymentApplicationRepository
                 .findById(paymentApplicationId)
                 .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Payment application not found: " + paymentApplicationId));
+                        HttpStatus.NOT_FOUND, PAYMENT_APPLICATION_NOT_FOUND_PREFIX + paymentApplicationId));
 
         // Block single-application reversal of a multi-application apply request (finding 3): the C1
         // cash-receipt JE and C2 reversing entry are both keyed per applicationRequestId, so reversing
@@ -445,7 +447,7 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
         PaymentApplication original = paymentApplicationRepository
                 .findById(paymentApplicationId)
                 .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Payment application not found: " + paymentApplicationId));
+                        HttpStatus.NOT_FOUND, PAYMENT_APPLICATION_NOT_FOUND_PREFIX + paymentApplicationId));
 
         // 3. Create reversal record
         PaymentApplicationReversal reversal = new PaymentApplicationReversal();
@@ -543,7 +545,7 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
         return paymentApplicationRepository
                 .findById(paymentApplicationId)
                 .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Payment application not found: " + paymentApplicationId));
+                        HttpStatus.NOT_FOUND, PAYMENT_APPLICATION_NOT_FOUND_PREFIX + paymentApplicationId));
     }
 
     /**

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PostingRuleDefinitionValidator.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PostingRuleDefinitionValidator.java
@@ -48,6 +48,11 @@ import tools.jackson.databind.ObjectMapper;
  * matching the existing empty-definition publish guard.
  */
 public final class PostingRuleDefinitionValidator {
+    private static final String FACTOR_PERCENT = "factorPercent";
+
+    private static final String CONDITIONS_PREFIX = "conditions[";
+
+    private static final String FACTOR_PERCENT_SUFFIX = ".factorPercent";
 
     /** Maximum decimal places allowed for {@code factorPercent}. */
     static final int MAX_FACTOR_SCALE = 4;
@@ -106,10 +111,10 @@ public final class PostingRuleDefinitionValidator {
 
         for (int i = 0; i < linesNode.size(); i++) {
             JsonNode lineNode = linesNode.get(i);
-            String lineField = "conditions[" + conditionIndex + "].lines[" + i + "]";
+            String lineField = CONDITIONS_PREFIX + conditionIndex + "].lines[" + i + "]";
 
             String splitGroup = textOrNull(lineNode, "splitGroup");
-            boolean hasFactor = lineNode.has("factorPercent");
+            boolean hasFactor = lineNode.has(FACTOR_PERCENT);
 
             if (splitGroup == null && !hasFactor) {
                 continue; // plain line — untouched by E1
@@ -122,7 +127,7 @@ public final class PostingRuleDefinitionValidator {
 
             if (splitGroup == null) {
                 violations.add(new RuleViolation(
-                        lineField + ".factorPercent",
+                        lineField + FACTOR_PERCENT_SUFFIX,
                         "factorPercent requires a splitGroup — a line cannot declare a split factor "
                                 + "outside a split group"));
                 continue;
@@ -130,27 +135,27 @@ public final class PostingRuleDefinitionValidator {
 
             if (!hasFactor) {
                 violations.add(new RuleViolation(
-                        lineField + ".factorPercent",
+                        lineField + FACTOR_PERCENT_SUFFIX,
                         "line in split group '" + splitGroup + "' must declare a factorPercent"));
                 groups.computeIfAbsent(splitGroup, g -> new ArrayList<>())
                         .add(new SplitLine(i, lineField, null, textOrNull(lineNode, "amountField"), sideOf(lineNode)));
                 continue;
             }
 
-            BigDecimal factor = parseFactor(lineNode.get("factorPercent"));
+            BigDecimal factor = parseFactor(lineNode.get(FACTOR_PERCENT));
             if (factor == null) {
                 violations.add(new RuleViolation(
-                        lineField + ".factorPercent", "factorPercent must be a decimal number between 0 and 100"));
+                        lineField + FACTOR_PERCENT_SUFFIX, "factorPercent must be a decimal number between 0 and 100"));
             } else if (factor.compareTo(BigDecimal.ZERO) < 0 || factor.compareTo(ONE_HUNDRED) > 0) {
                 violations.add(new RuleViolation(
-                        lineField + ".factorPercent",
+                        lineField + FACTOR_PERCENT_SUFFIX,
                         "factorPercent must be between 0 and 100 (was " + factor.toPlainString() + ")"));
                 factor = null;
             } else if (factor.stripTrailingZeros().scale() > MAX_FACTOR_SCALE) {
                 violations.add(new RuleViolation(
-                        lineField + ".factorPercent",
+                        lineField + FACTOR_PERCENT_SUFFIX,
                         "factorPercent supports at most " + MAX_FACTOR_SCALE + " decimal places (was "
-                                + lineNode.get("factorPercent").asString() + ")"));
+                                + lineNode.get(FACTOR_PERCENT).asString() + ")"));
                 factor = null;
             }
 
@@ -165,7 +170,7 @@ public final class PostingRuleDefinitionValidator {
 
     private static void validateGroup(
             String groupName, List<SplitLine> members, int conditionIndex, List<RuleViolation> violations) {
-        String groupField = "conditions[" + conditionIndex + "].splitGroup[" + groupName + "]";
+        String groupField = CONDITIONS_PREFIX + conditionIndex + "].splitGroup[" + groupName + "]";
 
         // Shared, non-blank amountField
         String firstAmountField = null;
@@ -220,7 +225,7 @@ public final class PostingRuleDefinitionValidator {
      */
     private static void validateConditionPredicate(
             @Nullable JsonNode conditionNode, int conditionIndex, List<RuleViolation> violations) {
-        String conditionField = "conditions[" + conditionIndex + "].condition";
+        String conditionField = CONDITIONS_PREFIX + conditionIndex + "].condition";
 
         if (conditionNode == null || conditionNode.isNull()) {
             return; // absent condition → catch-all

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PostingRuleEvaluatorImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PostingRuleEvaluatorImpl.java
@@ -101,6 +101,8 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PostingRuleEvaluatorImpl implements PostingRuleEvaluator {
+    private static final String FAILURE_STEP = "failureStep";
+
     private final Clock clock;
 
     private final PostingRuleVersionRepository versionRepository;
@@ -158,7 +160,7 @@ public class PostingRuleEvaluatorImpl implements PostingRuleEvaluator {
                         JournalEntry journalEntry = generateJournalEntryFromDefault(event, defaultMapping);
 
                         if (!isBalanced(journalEntry)) {
-                            evaluationDetails.put("failureStep", "balanceValidation");
+                            evaluationDetails.put(FAILURE_STEP, "balanceValidation");
                             evaluationDetails.put("debitTotal", calculateDebitTotal(journalEntry));
                             evaluationDetails.put("creditTotal", calculateCreditTotal(journalEntry));
                             return PostingResult.failure(
@@ -187,7 +189,7 @@ public class PostingRuleEvaluatorImpl implements PostingRuleEvaluator {
                         event.getEventType(),
                         event.getTransactionDate(),
                         defaultGLMappingProperties.isEnabled() ? "" : " (default mappings disabled)");
-                evaluationDetails.put("failureStep", "loadRuleVersion");
+                evaluationDetails.put(FAILURE_STEP, "loadRuleVersion");
                 return PostingResult.failure(PostingFailureReason.NO_RULE_VERSION, msg, evaluationDetails);
             }
 
@@ -197,7 +199,7 @@ public class PostingRuleEvaluatorImpl implements PostingRuleEvaluator {
             // 2. Evaluate mapping keys: parse rulesDefinition and resolve GL accounts
             MappingEvaluation mappingEval = evaluateMappingKeys(event, ruleVersion);
             if (!mappingEval.isSuccess()) {
-                evaluationDetails.put("failureStep", "evaluateMappingKeys");
+                evaluationDetails.put(FAILURE_STEP, "evaluateMappingKeys");
                 evaluationDetails.put("keysEvaluated", mappingEval.getKeysEvaluated());
                 return PostingResult.failure(
                         PostingFailureReason.UNMAPPED_EVENT_TYPE,
@@ -213,7 +215,7 @@ public class PostingRuleEvaluatorImpl implements PostingRuleEvaluator {
 
             // 4. Validate balance
             if (!isBalanced(journalEntry)) {
-                evaluationDetails.put("failureStep", "balanceValidation");
+                evaluationDetails.put(FAILURE_STEP, "balanceValidation");
                 evaluationDetails.put("debitTotal", calculateDebitTotal(journalEntry));
                 evaluationDetails.put("creditTotal", calculateCreditTotal(journalEntry));
                 return PostingResult.failure(

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PostingRuleServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PostingRuleServiceImpl.java
@@ -41,6 +41,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class PostingRuleServiceImpl implements PostingRuleService {
+    private static final String UPDATED_AT = "updatedAt";
+
     private static final String VERSION_NOT_FOUND = "Version not found: ";
 
     /**
@@ -48,15 +50,24 @@ public class PostingRuleServiceImpl implements PostingRuleService {
      * (see PostingRuleSetResponse) while the entity property is {@code updatedAt}.
      */
     private static final Map<String, String> SORTABLE_PROPERTIES = Map.of(
-            "createdAt", "createdAt",
-            "modifiedAt", "updatedAt",
-            "updatedAt", "updatedAt",
-            "name", "name",
-            "eventType", "eventType",
-            "description", "description",
-            "createdBy", "createdBy",
-            "modifiedBy", "modifiedBy",
-            "postingRuleSetId", "postingRuleSetId");
+            "createdAt",
+            "createdAt",
+            "modifiedAt",
+            UPDATED_AT,
+            UPDATED_AT,
+            UPDATED_AT,
+            "name",
+            "name",
+            "eventType",
+            "eventType",
+            "description",
+            "description",
+            "createdBy",
+            "createdBy",
+            "modifiedBy",
+            "modifiedBy",
+            "postingRuleSetId",
+            "postingRuleSetId");
 
     private final Clock clock;
 

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogExceptionHandler.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogExceptionHandler.java
@@ -27,6 +27,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice(basePackages = "com.positivity.catalog.internal.controller")
 @RequiredArgsConstructor
 public class CatalogExceptionHandler {
+    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
 
     private static final String X_CORRELATION_ID = "X-Correlation-Id";
     private final Clock clock;
@@ -51,7 +52,7 @@ public class CatalogExceptionHandler {
                 .findFirst()
                 .map(fieldError -> fieldError.getField() + " " + fieldError.getDefaultMessage())
                 .orElse("Validation failed");
-        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, correlationId);
+        return buildResponse(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, message, correlationId);
     }
 
     /**
@@ -66,7 +67,7 @@ public class CatalogExceptionHandler {
         String correlationId = resolveCorrelationId(request);
         return buildResponse(
                 HttpStatus.BAD_REQUEST,
-                "VALIDATION_ERROR",
+                VALIDATION_ERROR,
                 "Required parameter '" + ex.getParameterName() + "' is missing",
                 correlationId);
     }
@@ -79,7 +80,7 @@ public class CatalogExceptionHandler {
         // needs to see what the server read, and it is their own input.
         return buildResponse(
                 HttpStatus.BAD_REQUEST,
-                "VALIDATION_ERROR",
+                VALIDATION_ERROR,
                 "Parameter '" + ex.getName() + "' has an invalid value: " + ex.getValue(),
                 correlationId);
     }
@@ -98,7 +99,7 @@ public class CatalogExceptionHandler {
                 .findFirst()
                 .map(violation -> lastNode(violation) + " " + violation.getMessage())
                 .orElse("Validation failed");
-        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, correlationId);
+        return buildResponse(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, message, correlationId);
     }
 
     private static String lastNode(ConstraintViolation<?> violation) {
@@ -110,7 +111,7 @@ public class CatalogExceptionHandler {
     @ExceptionHandler(CatalogValidationException.class)
     public ResponseEntity<ApiError> handleBadRequest(CatalogValidationException ex, HttpServletRequest request) {
         String correlationId = resolveCorrelationId(request);
-        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), correlationId);
+        return buildResponse(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, ex.getMessage(), correlationId);
     }
 
     @ExceptionHandler(CatalogBusinessRuleException.class)

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/InventoryEventsListener.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/InventoryEventsListener.java
@@ -67,7 +67,7 @@ public class InventoryEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "inventory")
+                        .tag("owner", OWNER)
                         .tag("entity", "inventory-events")
                         .register(registry);
     }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierPriceCatalogEventsListener.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierPriceCatalogEventsListener.java
@@ -296,7 +296,7 @@ public class SupplierPriceCatalogEventsListener {
                 "applied " + tracker.getChunksApplied() + " of " + expected + " chunks");
 
         outboxEventWriter.publish(
-                DomainTopics.commands("supplier"),
+                DomainTopics.commands(OWNER),
                 new DomainEventEnvelope<>(
                         UUIDv7Generator.generate(),
                         SupplierPriceCatalogRepublishRequestedV1.EVENT_TYPE,

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
@@ -36,6 +36,7 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
 public class CustomerCommandListener {
+    private static final String PAYLOAD = "payload";
 
     /** Canonical dotted name normalized to command-type form: CUSTOMER_OUTBOX_REPLAY_REQUESTED. */
     private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "CUSTOMER_OUTBOX_REPLAY_REQUESTED";
@@ -110,7 +111,7 @@ public class CustomerCommandListener {
     }
 
     private void handleOutboxReplayRequested(@NonNull JsonNode root) {
-        JsonNode payloadNode = root.get("payload");
+        JsonNode payloadNode = root.get(PAYLOAD);
         Instant since = parseInstant(payloadNode, "since");
         if (since == null) {
             log.warn("Ignoring outbox replay command with missing/malformed payload.since: {}", root);

--- a/pos-customer/src/main/java/com/positivity/customer/internal/security/CrmPermissionRegistry.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/security/CrmPermissionRegistry.java
@@ -19,6 +19,13 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CrmPermissionRegistry {
+    private static final String MEDIUM_RISK = "MEDIUM";
+
+    private static final String ISSUE_169 = "Issue #169";
+
+    private static final String ISSUE_1137 = "Issue #1137";
+
+    private static final String ISSUE_1136 = "Issue #1136";
 
     // ==================== PERMISSION DEFINITIONS ====================
 
@@ -150,8 +157,8 @@ public class CrmPermissionRegistry {
                 // Party Management (6 permissions)
                 permission(PARTY_VIEW, "View party (person/organization) records and details", "LOW"),
                 permission(PARTY_SEARCH, "Search parties by name, email, phone, tax ID", "LOW"),
-                permission(PARTY_CREATE, "Create new commercial account (party)", "MEDIUM", "Issue #176"),
-                permission(PARTY_EDIT, "Edit party master data (name, tax ID, identifiers)", "MEDIUM"),
+                permission(PARTY_CREATE, "Create new commercial account (party)", MEDIUM_RISK, "Issue #176"),
+                permission(PARTY_EDIT, "Edit party master data (name, tax ID, identifiers)", MEDIUM_RISK),
                 permission(PARTY_DEACTIVATE, "Deactivate a party record (soft delete)", "HIGH"),
                 permission(PARTY_MERGE, "Merge two party records into one survivor", "CRITICAL", "Issue #173"),
                 permission(
@@ -161,24 +168,24 @@ public class CrmPermissionRegistry {
 
                 // Contact Management (8 permissions)
                 permission(CONTACT_VIEW, "View contact points (email, phone) for a party", "LOW"),
-                permission(CONTACT_CREATE, "Add new contact point (email/phone) to a party", "MEDIUM"),
-                permission(CONTACT_EDIT, "Edit contact point details (phone normalization, primary flag)", "MEDIUM"),
-                permission(CONTACT_DELETE, "Remove contact point from a party", "MEDIUM"),
+                permission(CONTACT_CREATE, "Add new contact point (email/phone) to a party", MEDIUM_RISK),
+                permission(CONTACT_EDIT, "Edit contact point details (phone normalization, primary flag)", MEDIUM_RISK),
+                permission(CONTACT_DELETE, "Remove contact point from a party", MEDIUM_RISK),
 
                 // Contact Roles (3 permissions)
                 permission(CONTACT_ROLE_VIEW, "View assigned roles for contacts on an account", "LOW", "Issue #172"),
                 permission(
                         CONTACT_ROLE_ASSIGN,
                         "Assign roles (BILLING, APPROVER, DRIVER) to contacts",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #172"),
-                permission(CONTACT_ROLE_REVOKE, "Revoke a role assignment from a contact", "MEDIUM"),
+                permission(CONTACT_ROLE_REVOKE, "Revoke a role assignment from a contact", MEDIUM_RISK),
 
                 // Contact Preferences (2 permissions)
                 permission(
                         CONTACT_PREFERENCE_VIEW,
                         "View communication preferences and consent flags for a party",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #171"),
                 permission(
                         CONTACT_PREFERENCE_EDIT,
@@ -187,20 +194,21 @@ public class CrmPermissionRegistry {
                         "Issue #171"),
 
                 // Vehicle Management (3 permissions; registry writes live in pos-vehicle-inventory)
-                permission(VEHICLE_VIEW, "View vehicle records (VIN, unit #, description, plate)", "LOW", "Issue #169"),
-                permission(VEHICLE_SEARCH, "Search vehicles by VIN, unit #, or plate", "LOW", "Issue #169"),
-                permission(VEHICLE_CREATE, "Associate a vehicle VIN with a party", "MEDIUM", "Issue #169"),
+                permission(VEHICLE_VIEW, "View vehicle records (VIN, unit #, description, plate)", "LOW", ISSUE_169),
+                permission(VEHICLE_SEARCH, "Search vehicles by VIN, unit #, or plate", "LOW", ISSUE_169),
+                permission(VEHICLE_CREATE, "Associate a vehicle VIN with a party", MEDIUM_RISK, ISSUE_169),
 
                 // Vehicle-Party Association (3 permissions)
                 permission(
                         VEHICLE_PARTY_ASSOC_CREATE,
                         "Associate party (owner/driver/lessee) to vehicle with effective dating",
-                        "MEDIUM"),
+                        MEDIUM_RISK),
                 permission(
                         VEHICLE_PARTY_ASSOC_VIEW,
                         "View party associations for a vehicle (current and historical)",
                         "LOW"),
-                permission(VEHICLE_PARTY_ASSOC_EDIT, "Adjust effective dates for party-vehicle associations", "MEDIUM"),
+                permission(
+                        VEHICLE_PARTY_ASSOC_EDIT, "Adjust effective dates for party-vehicle associations", MEDIUM_RISK),
 
                 // Vehicle Preferences (2 permissions)
                 permission(
@@ -210,31 +218,31 @@ public class CrmPermissionRegistry {
                 permission(
                         VEHICLE_PREFERENCE_EDIT,
                         "Update vehicle care preferences with audit history and optimistic locking",
-                        "MEDIUM"),
+                        MEDIUM_RISK),
 
                 // Party Tags (3 permissions, Story #1136)
-                permission(TAG_VIEW, "View the CRM tag catalog and tags attached to parties", "LOW", "Issue #1136"),
-                permission(TAG_MANAGE, "Create, edit, retire, or delete CRM tags", "MEDIUM", "Issue #1136"),
-                permission(TAG_ASSIGN, "Attach or detach tags on a party", "MEDIUM", "Issue #1136"),
+                permission(TAG_VIEW, "View the CRM tag catalog and tags attached to parties", "LOW", ISSUE_1136),
+                permission(TAG_MANAGE, "Create, edit, retire, or delete CRM tags", MEDIUM_RISK, ISSUE_1136),
+                permission(TAG_ASSIGN, "Attach or detach tags on a party", MEDIUM_RISK, ISSUE_1136),
 
                 // Segments (3 permissions, Story #1137)
-                permission(SEGMENT_VIEW, "View saved audience segments and their definitions", "LOW", "Issue #1137"),
+                permission(SEGMENT_VIEW, "View saved audience segments and their definitions", "LOW", ISSUE_1137),
                 permission(
                         SEGMENT_MANAGE,
                         "Create, edit, or delete audience segments and their membership",
-                        "MEDIUM",
-                        "Issue #1137"),
+                        MEDIUM_RISK,
+                        ISSUE_1137),
                 permission(
                         SEGMENT_RESOLVE,
                         "Resolve a segment to its matching parties (returns counts and a masked sample)",
                         "HIGH",
-                        "Issue #1137"),
+                        ISSUE_1137),
 
                 // Marketing Consent (2 permissions, Stories #1138/#1139)
                 permission(
                         CONSENT_VIEW,
                         "View per-channel marketing consent and the consent-change audit trail",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1138"),
                 permission(
                         CONSENT_MANAGE,
@@ -243,7 +251,7 @@ public class CrmPermissionRegistry {
                         "Issue #1138"),
 
                 // Suppression (2 permissions, Story #1140)
-                permission(SUPPRESSION_VIEW, "View the marketing suppression list", "MEDIUM", "Issue #1140"),
+                permission(SUPPRESSION_VIEW, "View the marketing suppression list", MEDIUM_RISK, "Issue #1140"),
                 permission(
                         SUPPRESSION_MANAGE,
                         "Add or remove hard address-level suppression entries",
@@ -254,12 +262,12 @@ public class CrmPermissionRegistry {
                 permission(
                         INTERACTION_VIEW,
                         "View a party's interaction and touch history (campaign sends, calls, notes)",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1141"),
                 permission(
                         INTERACTION_MANAGE,
                         "Record a CSR-initiated interaction on a party's timeline",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1141"),
 
                 // Follow-up Tasks (2 permissions, Story #1153)
@@ -267,7 +275,7 @@ public class CrmPermissionRegistry {
                 permission(
                         FOLLOWUP_MANAGE,
                         "Raise, assign, complete, or dismiss follow-up tasks",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1153"),
 
                 // Inquiries (2 permissions, Story #1154)
@@ -275,15 +283,15 @@ public class CrmPermissionRegistry {
                 permission(
                         INQUIRY_MANAGE,
                         "Capture, assign, triage, and convert inbound inquiries into parties",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1154"),
 
                 // Integration Monitoring (3 permissions, read-only)
                 permission(
                         PROCESSING_LOG_VIEW,
                         "View ingestion event processing outcomes (success/failure/retry state)",
-                        "MEDIUM"),
-                permission(SUSPENSE_VIEW, "View quarantined/unprocessable events requiring triage", "MEDIUM"),
+                        MEDIUM_RISK),
+                permission(SUSPENSE_VIEW, "View quarantined/unprocessable events requiring triage", MEDIUM_RISK),
                 permission(
                         INTEGRATION_AUDIT,
                         "View audit/attempt history for ingestion records and retry outcomes",
@@ -296,13 +304,13 @@ public class CrmPermissionRegistry {
                 // PermissionRegistration, which POSTs permissions.yaml — this payload builder has no
                 // callers. See the class javadoc.
                 permission(PERSON_READ, "View person records and their party linkage", "LOW"),
-                permission(PERSON_CREATE, "Create a person record", "MEDIUM"),
+                permission(PERSON_CREATE, "Create a person record", MEDIUM_RISK),
                 permission(RELATIONSHIP_READ, "View relationships between parties", "LOW"),
-                permission(RELATIONSHIP_CREATE, "Create a relationship between two parties", "MEDIUM"),
-                permission(RELATIONSHIP_UPDATE, "Change an existing party relationship", "MEDIUM"),
+                permission(RELATIONSHIP_CREATE, "Create a relationship between two parties", MEDIUM_RISK),
+                permission(RELATIONSHIP_UPDATE, "Change an existing party relationship", MEDIUM_RISK),
                 permission(RELATIONSHIP_DELETE, "Remove a relationship between two parties", "HIGH"),
                 permission(PROMOTION_REDEMPTION_VIEW, "View recorded promotion redemptions", "LOW"),
-                permission(PROMOTION_REDEMPTION_RECORD, "Record that a customer redeemed a promotion", "MEDIUM"));
+                permission(PROMOTION_REDEMPTION_RECORD, "Record that a customer redeemed a promotion", MEDIUM_RISK));
     }
 
     /**

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
@@ -69,7 +69,7 @@ public class PeopleContactEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description("Replica event payloads rejected due to Jackson databind failures"
                                 + " (e.g. omitted primitive fields)")
-                        .tag("owner", "people-contact")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-contact-events")
                         .register(registry);
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
@@ -38,6 +38,9 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
+    private static final String PAYLOAD = "payload";
+
+    private static final String AGGREGATE_VERSION = "aggregateVersion";
 
     static final String OWNER = "people-contact";
 
@@ -126,8 +129,8 @@ public class PeopleContactEventsListener {
     }
 
     private void applyPersonUpdated(JsonNode envelope) {
-        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtPersonReplica existing =
                 extPersonReplicaRepository.findById(payload.personId()).orElse(null);
         if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
@@ -171,15 +174,15 @@ public class PeopleContactEventsListener {
     }
 
     private void applyPersonDeleted(JsonNode envelope) {
-        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonDeletedV1.class);
+        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonDeletedV1.class);
         extPersonReplicaRepository.deleteById(payload.personId());
         log.info("Deleted ext_people_contact_person personId={}", payload.personId());
     }
 
     private void applyOrganizationAddressUpdated(JsonNode envelope) {
         OrganizationAddressUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), OrganizationAddressUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), OrganizationAddressUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtOrganizationPostalAddress existing = extOrganizationPostalAddressRepository
                 .findById(payload.organizationId())
                 .orElse(null);
@@ -213,8 +216,8 @@ public class PeopleContactEventsListener {
      */
     private void applyOrganizationAddressRemoved(JsonNode envelope) {
         OrganizationAddressRemovedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), OrganizationAddressRemovedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), OrganizationAddressRemovedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtOrganizationPostalAddress existing = extOrganizationPostalAddressRepository
                 .findById(payload.organizationId())
                 .orElse(null);

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
@@ -86,7 +86,7 @@ public class VehicleEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description("Replica event payloads rejected due to Jackson databind failures"
                                 + " (e.g. omitted primitive fields)")
-                        .tag("owner", "vehicle")
+                        .tag("owner", OWNER)
                         .tag("entity", "vehicle-events")
                         .register(registry);
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
@@ -79,7 +79,7 @@ public class WorkorderEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description("Replica event payloads rejected due to Jackson databind failures"
                                 + " (e.g. omitted primitive fields)")
-                        .tag("owner", "workorder")
+                        .tag("owner", OWNER)
                         .tag("entity", "workorder-events")
                         .register(registry);
     }

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImpl.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImpl.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class EventTypeServiceImpl implements EventTypeService {
+    private static final String TYPE_CODE = "typeCode";
+
     private static final Pattern TYPE_CODE_PATTERN = Pattern.compile("^[A-Z0-9_]+$");
     private static final Pattern API_VERSION_PATTERN = Pattern.compile("^[0-9]+$");
 
@@ -49,14 +51,14 @@ public class EventTypeServiceImpl implements EventTypeService {
 
     @Override
     public Optional<EventTypeResponse> getEventTypeByCode(@NonNull String typeCode) {
-        String normalizedTypeCode = normalizeTypeCode(typeCode, "typeCode");
+        String normalizedTypeCode = normalizeTypeCode(typeCode, TYPE_CODE);
         return eventDao.getEventTypeByCode(normalizedTypeCode).map(EventTypeMapper::toResponse);
     }
 
     @Override
     public Optional<EventTypeResponse> createEventType(@NonNull EventTypeRequest request) {
         validateRequest(request, true);
-        String normalizedTypeCode = normalizeTypeCode(request.getTypeCode(), "typeCode");
+        String normalizedTypeCode = normalizeTypeCode(request.getTypeCode(), TYPE_CODE);
 
         if (eventDao.getEventTypeByCode(normalizedTypeCode).isPresent()) {
             return Optional.empty();
@@ -70,12 +72,12 @@ public class EventTypeServiceImpl implements EventTypeService {
     @Override
     @NonNull
     public EventTypeResponse upsertEventType(@NonNull String typeCode, @NonNull EventTypeRequest request) {
-        String normalizedTypeCode = normalizeTypeCode(typeCode, "typeCode");
+        String normalizedTypeCode = normalizeTypeCode(typeCode, TYPE_CODE);
         validateRequest(request, false);
 
         String requestTypeCode = request.getTypeCode();
         if (requestTypeCode != null && !requestTypeCode.isBlank()) {
-            String normalizedRequestTypeCode = normalizeTypeCode(requestTypeCode, "typeCode");
+            String normalizedRequestTypeCode = normalizeTypeCode(requestTypeCode, TYPE_CODE);
             if (!normalizedTypeCode.equals(normalizedRequestTypeCode)) {
                 throw new IllegalArgumentException("Path typeCode must match request typeCode when provided");
             }
@@ -124,7 +126,7 @@ public class EventTypeServiceImpl implements EventTypeService {
             throw new IllegalArgumentException("request is required");
         }
         if (requireTypeCode) {
-            normalizeTypeCode(request.getTypeCode(), "typeCode");
+            normalizeTypeCode(request.getTypeCode(), TYPE_CODE);
         }
         validateDescription(request.getDescription());
         validateApiVersion(request.getApiVersion());

--- a/pos-events/src/main/java/com/positivity/events/outbox/OutboxHealthContributor.java
+++ b/pos-events/src/main/java/com/positivity/events/outbox/OutboxHealthContributor.java
@@ -63,6 +63,7 @@ import org.springframework.boot.health.contributor.HealthIndicator;
  */
 @Slf4j
 public final class OutboxHealthContributor implements HealthIndicator {
+    private static final String DRAIN_STATE = "drainState";
 
     /** Made legible in the payload so nobody "fixes" this into a DOWN. */
     static final String STATUS_POLICY = "always UP: a stalled outbox stales downstream replicas but"
@@ -148,13 +149,13 @@ public final class OutboxHealthContributor implements HealthIndicator {
         try {
             Optional<DrainHead> head = drainHead.get();
             if (head.isEmpty()) {
-                details.put("drainState", "drained");
+                details.put(DRAIN_STATE, "drained");
             } else {
                 describeHead(head.get(), details);
             }
         } catch (Exception e) {
             log.warn("Unable to read outbox drain head for health details", e);
-            details.put("drainState", "unknown");
+            details.put(DRAIN_STATE, "unknown");
             details.put("error", e.getClass().getSimpleName());
         }
         return Health.up().withDetails(details).build();
@@ -173,7 +174,7 @@ public final class OutboxHealthContributor implements HealthIndicator {
         } else {
             drainState = "stalled-retrying";
         }
-        details.put("drainState", drainState);
+        details.put(DRAIN_STATE, drainState);
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/InventoryCommandListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/InventoryCommandListener.java
@@ -68,6 +68,7 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
 public class InventoryCommandListener {
+    private static final String PICK_LIST_ID = "pickListId";
 
     /** Canonical dotted name normalized to command-type form: INVENTORY_OUTBOX_REPLAY_REQUESTED. */
     private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "INVENTORY_OUTBOX_REPLAY_REQUESTED";
@@ -215,7 +216,7 @@ public class InventoryCommandListener {
     }
 
     private void handlePickListReleaseRequested(@NonNull JsonNode payload) {
-        UUID pickListId = parseUuid(payload, "pickListId");
+        UUID pickListId = parseUuid(payload, PICK_LIST_ID);
         if (pickListId == null) {
             log.warn("Ignoring pick-list release command with missing pickListId: {}", payload);
             return;
@@ -285,7 +286,7 @@ public class InventoryCommandListener {
     }
 
     private void handlePickTaskConfirmRequested(@NonNull JsonNode payload) {
-        UUID pickListId = parseUuid(payload, "pickListId");
+        UUID pickListId = parseUuid(payload, PICK_LIST_ID);
         UUID pickTaskId = parseUuid(payload, "pickTaskId");
         UUID scannedSkuId = parseUuid(payload, "scannedSkuId");
         UUID scannedLocationId = parseUuid(payload, "scannedLocationId");
@@ -309,7 +310,7 @@ public class InventoryCommandListener {
             log.warn("Ignoring consume command with missing workorderId: {}", payload);
             return;
         }
-        UUID pickListId = parseUuid(payload, "pickListId");
+        UUID pickListId = parseUuid(payload, PICK_LIST_ID);
         List<ConsumeItemLine> items = new ArrayList<>();
         for (JsonNode line : payload.path("items")) {
             UUID pickTaskId = parseUuid(line, "pickTaskId");

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/PurchaseSuggestionConversionException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/PurchaseSuggestionConversionException.java
@@ -8,6 +8,7 @@ import java.util.UUID;
  * other guided-422 exceptions.
  */
 public class PurchaseSuggestionConversionException extends RuntimeException {
+    private static final String SUGGESTION_PREFIX = "Suggestion ";
 
     private final String errorCode;
 
@@ -24,7 +25,7 @@ public class PurchaseSuggestionConversionException extends RuntimeException {
     public static PurchaseSuggestionConversionException notAccepted(UUID suggestionId, String status) {
         return new PurchaseSuggestionConversionException(
                 "PURCHASE_SUGGESTION_NOT_ACCEPTED",
-                "Suggestion " + suggestionId + " is " + status + "; only ACCEPTED suggestions can be converted");
+                SUGGESTION_PREFIX + suggestionId + " is " + status + "; only ACCEPTED suggestions can be converted");
     }
 
     /** The listed suggestions do not all share one vendor (one convert = one single-vendor PO). */
@@ -39,7 +40,7 @@ public class PurchaseSuggestionConversionException extends RuntimeException {
     public static PurchaseSuggestionConversionException missingVendor(UUID suggestionId) {
         return new PurchaseSuggestionConversionException(
                 "PURCHASE_SUGGESTION_MISSING_VENDOR",
-                "Suggestion " + suggestionId + " has no selected vendor (no usable vendor feed data); create the"
+                SUGGESTION_PREFIX + suggestionId + " has no selected vendor (no usable vendor feed data); create the"
                         + " purchase order manually");
     }
 
@@ -47,7 +48,7 @@ public class PurchaseSuggestionConversionException extends RuntimeException {
     public static PurchaseSuggestionConversionException missingUnitCost(UUID suggestionId) {
         return new PurchaseSuggestionConversionException(
                 "PURCHASE_SUGGESTION_MISSING_UNIT_COST",
-                "Suggestion " + suggestionId + " carries no vendor feed price; purchase order lines require a"
+                SUGGESTION_PREFIX + suggestionId + " carries no vendor feed price; purchase order lines require a"
                         + " unit cost — create the purchase order manually");
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/security/InventoryPermissionRegistry.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/security/InventoryPermissionRegistry.java
@@ -23,6 +23,13 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class InventoryPermissionRegistry {
+    private static final String MEDIUM_RISK = "MEDIUM";
+
+    private static final String ISSUE_37 = "Issue #37";
+
+    private static final String ISSUE_1035 = "Issue #1035";
+
+    private static final String CLARIFICATION_229 = "Clarification #229";
 
     // ==================== ADJUSTMENT PERMISSIONS ====================
 
@@ -244,13 +251,13 @@ public class InventoryPermissionRegistry {
                 permission(
                         ADJUSTMENT_CREATE,
                         "Create an adjustment request (draft/pending), capture reason code, quantity, and supporting notes",
-                        "MEDIUM",
-                        "Issue #37"),
+                        MEDIUM_RISK,
+                        ISSUE_37),
                 permission(
                         ADJUSTMENT_APPROVE,
                         "Approve and post an adjustment to the ledger (creates ADJUSTMENT_IN/OUT events)",
                         "HIGH",
-                        "Issue #37"),
+                        ISSUE_37),
                 permission(ADJUSTMENT_VIEW, "View adjustment history and details", "LOW"),
 
                 // Stock movement permissions (1)
@@ -258,7 +265,7 @@ public class InventoryPermissionRegistry {
                         STOCK_MOVEMENT_CREATE,
                         "Record RECEIVE, PUT_AWAY, PICK, ISSUE, RETURN, or TRANSFER movements directly in the inventory ledger",
                         "HIGH",
-                        "Issue #37"),
+                        ISSUE_37),
 
                 // Location permissions (2)
                 permission(
@@ -271,7 +278,7 @@ public class InventoryPermissionRegistry {
                         "HIGH"),
 
                 // Pick list permissions (3)
-                permission(PICK_LIST_CREATE, "Create pick lists for workorders", "MEDIUM"),
+                permission(PICK_LIST_CREATE, "Create pick lists for workorders", MEDIUM_RISK),
                 permission(PICK_LIST_VIEW, "View pick lists and pick tasks", "LOW"),
                 permission(
                         PICK_LIST_EXECUTE,
@@ -279,9 +286,9 @@ public class InventoryPermissionRegistry {
                         "HIGH"),
 
                 // Putaway permissions (4)
-                permission(PUTAWAY_GENERATE, "Generate putaway tasks from received inventory", "MEDIUM"),
+                permission(PUTAWAY_GENERATE, "Generate putaway tasks from received inventory", MEDIUM_RISK),
                 permission(PUTAWAY_VIEW, "View putaway tasks and their assignment status", "LOW"),
-                permission(PUTAWAY_CLAIM, "Claim a putaway task for execution", "MEDIUM"),
+                permission(PUTAWAY_CLAIM, "Claim a putaway task for execution", MEDIUM_RISK),
                 permission(PUTAWAY_EXECUTE, "Execute a putaway task and move inventory into storage", "HIGH"),
 
                 // Putaway override permissions (2)
@@ -289,34 +296,34 @@ public class InventoryPermissionRegistry {
                         PUTAWAY_OVERRIDE_LOCATION_COMPATIBILITY,
                         "Override location compatibility rules when location is not valid for SKU",
                         "HIGH",
-                        "Clarification #229"),
+                        CLARIFICATION_229),
                 permission(
                         PUTAWAY_OVERRIDE_LOCATION_CAPACITY,
                         "Override location capacity limits when at or near full capacity",
                         "HIGH",
-                        "Clarification #229"),
+                        CLARIFICATION_229),
 
                 // Cycle count permissions (3)
                 permission(
                         CYCLE_COUNT_INITIATE,
                         "Initiate a cycle count for inventory reconciliation",
-                        "MEDIUM",
-                        "Clarification #229"),
+                        MEDIUM_RISK,
+                        CLARIFICATION_229),
                 permission(CYCLE_COUNT_VIEW, "View cycle count tasks and results", "LOW"),
-                permission(CYCLE_COUNT_COMPLETE, "Complete and submit cycle count results", "MEDIUM"),
+                permission(CYCLE_COUNT_COMPLETE, "Complete and submit cycle count results", MEDIUM_RISK),
 
                 // Transfer order permissions (5)
                 permission(
                         TRANSFER_CREATE,
                         "Create or cancel a cross-site transfer order (DRAFT; cancel only before dispatch)",
-                        "MEDIUM",
-                        "Issue #1035"),
+                        MEDIUM_RISK,
+                        ISSUE_1035),
                 permission(TRANSFER_VIEW, "View transfer orders, their lines, and lifecycle status", "LOW"),
                 permission(
                         TRANSFER_DISPATCH,
                         "Approve and dispatch a transfer order (posts TRANSFER_OUT at the source into transit)",
                         "HIGH",
-                        "Issue #1035"),
+                        ISSUE_1035),
                 permission(
                         TRANSFER_RECEIVE,
                         "Receive dispatched transfer quantities at the destination (posts TRANSFER_IN)",
@@ -326,20 +333,20 @@ public class InventoryPermissionRegistry {
                         TRANSFER_SHORT_CLOSE,
                         "Short-close a dispatched transfer order with a loss/return disposition (parity-C3)",
                         "HIGH",
-                        "Issue #1035"),
+                        ISSUE_1035),
 
                 // Replenishment permissions (1)
                 permission(
                         REPLENISHMENT_MANAGE,
                         "Manage replenishment policies and run the batch replenishment scan",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1025"),
 
                 // Lot permissions (1)
                 permission(
                         LOT_MANAGE,
                         "Manage lot lifecycle: quarantine/recall/release and set expiration/alert dates",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1047"),
 
                 // Inventory view permissions (2)
@@ -350,7 +357,7 @@ public class InventoryPermissionRegistry {
                 permission(
                         VALUATION_VIEW,
                         "View inventory valuation (on-hand x current unit cost) at SKU level, including as-of",
-                        "MEDIUM",
+                        MEDIUM_RISK,
                         "Issue #1052"),
                 permission(
                         VALUATION_ADJUST,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
@@ -48,6 +48,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AsnServiceImpl implements AsnService {
+    private static final String OCCURRED_AT = "occurredAt";
+
+    private static final String EVENT_TYPE = "eventType";
+
+    private static final String ASN_ID = "asnId";
+
     private final Clock clock;
     private final AsnRepository asnRepository;
     private final AsnLineRepository asnLineRepository;
@@ -141,15 +147,15 @@ public class AsnServiceImpl implements AsnService {
         eventPublisher.publishEvent(Map.of(
                 "type",
                 "ASNLoaded",
-                "eventType",
+                EVENT_TYPE,
                 "ASNLoaded",
-                "asnId",
+                ASN_ID,
                 persistedAsn.getAsnId().toString(),
                 "vendorId",
                 persistedAsn.getVendorId().toString(),
                 "actorId",
                 actorId,
-                "occurredAt",
+                OCCURRED_AT,
                 Instant.now(clock).toString()));
 
         return toAsnResponse(persistedAsn);
@@ -238,13 +244,13 @@ public class AsnServiceImpl implements AsnService {
         eventPublisher.publishEvent(Map.of(
                 "type",
                 "ReceiptCreated",
-                "eventType",
+                EVENT_TYPE,
                 "ReceiptCreated",
                 "receiptId",
                 persistedReceipt.getReceiptId().toString(),
                 "poId",
                 poId.toString(),
-                "asnId",
+                ASN_ID,
                 persistedReceipt.getAsn() == null
                         ? ""
                         : persistedReceipt.getAsn().getAsnId().toString(),
@@ -262,7 +268,7 @@ public class AsnServiceImpl implements AsnService {
                         .toList(),
                 "createdBy",
                 actorId,
-                "occurredAt",
+                OCCURRED_AT,
                 Instant.now(clock).toString()));
 
         for (ReceiptLineComputation computed : computedLines) {
@@ -314,13 +320,13 @@ public class AsnServiceImpl implements AsnService {
         eventPublisher.publishEvent(Map.of(
                 "type",
                 "ReceiptCompleted",
-                "eventType",
+                EVENT_TYPE,
                 "ReceiptCompleted",
                 "receiptId",
                 persistedReceipt.getReceiptId().toString(),
                 "poId",
                 poId.toString(),
-                "asnId",
+                ASN_ID,
                 persistedReceipt.getAsn() == null
                         ? ""
                         : persistedReceipt.getAsn().getAsnId().toString(),
@@ -328,7 +334,7 @@ public class AsnServiceImpl implements AsnService {
                 receiptTotalMinor,
                 "actorId",
                 actorId,
-                "occurredAt",
+                OCCURRED_AT,
                 Instant.now(clock).toString()));
 
         return toGoodsReceiptResponse(persistedReceipt);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CatalogEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CatalogEventsListener.java
@@ -91,7 +91,7 @@ public class CatalogEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "catalog")
+                        .tag("owner", OWNER)
                         .tag("entity", "catalog-events")
                         .register(registry);
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -37,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Slf4j
 public class InventoryAvailabilityServiceImpl implements InventoryAvailabilityService {
+    private static final String ON_HAND_QUANTITY = "onHandQuantity";
 
     private static final Pageable FIRST_ONLY = PageRequest.of(0, 1);
     private static final String DEFAULT_UOM = "EACH";
@@ -144,7 +145,7 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
                 .map(row -> LocationAvailabilityDto.builder()
                         .locationId(row.getLocationId())
                         .locationName(row.getLocationId().toString())
-                        .onHandQuantity(reportable(productId.toString(), "onHandQuantity", row.getQuantity()))
+                        .onHandQuantity(reportable(productId.toString(), ON_HAND_QUANTITY, row.getQuantity()))
                         .build())
                 .toList();
     }
@@ -208,7 +209,7 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
                 .productSku(productSku)
                 .locationId(locationId)
                 .storageLocationId(storageLocationId)
-                .onHandQuantity(reportable(productSku, "onHandQuantity", onHand))
+                .onHandQuantity(reportable(productSku, ON_HAND_QUANTITY, onHand))
                 .allocatedQuantity(reportable(productSku, "allocatedQuantity", allocated))
                 .availableToPromiseQuantity(reportable(
                         productSku,
@@ -247,7 +248,7 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
         return LocationAvailabilityDto.builder()
                 .locationId(row.getLocationId())
                 .locationName(row.getLocationId().toString())
-                .onHandQuantity(reportable(row.getStockItemId(), "onHandQuantity", row.getOnHand()))
+                .onHandQuantity(reportable(row.getStockItemId(), ON_HAND_QUANTITY, row.getOnHand()))
                 .availableToPromiseQuantity(
                         reportable(row.getStockItemId(), "availableToPromiseQuantity", atpWithReservations))
                 .incomingQty(forecast.incomingQty())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLeadTimeServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLeadTimeServiceImpl.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
+    private static final String BUSINESS_DAYS_SUFFIX = " business days";
+
     private final Clock clock;
 
     private final DistributorNormalizedInventoryRepository distributorNormalizedInventoryRepository;
@@ -116,12 +118,12 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
         }
         if (minDays != null && maxDays != null) {
             if (minDays.equals(maxDays)) {
-                return minDays + " business days";
+                return minDays + BUSINESS_DAYS_SUFFIX;
             }
-            return minDays + "-" + maxDays + " business days";
+            return minDays + "-" + maxDays + BUSINESS_DAYS_SUFFIX;
         }
         Integer value = minDays != null ? minDays : maxDays;
-        return value + " business days";
+        return value + BUSINESS_DAYS_SUFFIX;
     }
 
     private record LeadTimeCandidate(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class InventoryLotServiceImpl implements InventoryLotService {
+    private static final String INVENTORY_LOT = "InventoryLot";
 
     private final InventoryLotRepository lotRepository;
     private final InventoryStockSummaryRepository summaryRepository;
@@ -60,7 +61,7 @@ public class InventoryLotServiceImpl implements InventoryLotService {
     public @NonNull LotDetailResponse getLot(@NonNull UUID lotId) {
         InventoryLot lot = lotRepository
                 .findById(lotId)
-                .orElseThrow(() -> new ResourceNotFoundException("InventoryLot", lotId.toString()));
+                .orElseThrow(() -> new ResourceNotFoundException(INVENTORY_LOT, lotId.toString()));
         List<LotDetailResponse.LotLocationOnHand> locations = summaryRepository.findByLotId(lotId).stream()
                 .sorted(Comparator.comparing(row ->
                         row.getLocationId() == null ? "" : row.getLocationId().toString()))
@@ -84,7 +85,7 @@ public class InventoryLotServiceImpl implements InventoryLotService {
         }
         InventoryLot lot = lotRepository
                 .findById(lotId)
-                .orElseThrow(() -> new ResourceNotFoundException("InventoryLot", lotId.toString()));
+                .orElseThrow(() -> new ResourceNotFoundException(INVENTORY_LOT, lotId.toString()));
         if (lot.getStatus() == InventoryLotStatus.CONSUMED) {
             throw new IllegalArgumentException(
                     "lot " + lotId + " is CONSUMED (holds no stock); its status is reconciler-owned");
@@ -104,7 +105,7 @@ public class InventoryLotServiceImpl implements InventoryLotService {
     public @NonNull LotResponse updateExpiration(@NonNull UUID lotId, @NonNull LotExpirationUpdateRequest request) {
         InventoryLot lot = lotRepository
                 .findById(lotId)
-                .orElseThrow(() -> new ResourceNotFoundException("InventoryLot", lotId.toString()));
+                .orElseThrow(() -> new ResourceNotFoundException(INVENTORY_LOT, lotId.toString()));
         lot.setExpirationDate(request.getExpirationDate());
         lot.setAlertDate(request.getAlertDate());
         // Re-dating resets the emit-once bookkeeping so the daily scan can alert the new dates.

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationEventsListener.java
@@ -80,7 +80,7 @@ public class LocationEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "location")
+                        .tag("owner", OWNER)
                         .tag("entity", "location-events")
                         .register(registry);
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationEventsListener.java
@@ -48,6 +48,7 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
 public class LocationEventsListener {
+    private static final String PAYLOAD = "payload";
 
     static final String OWNER = "location";
     private static final String STATUS_DELETED = "DELETED";
@@ -134,7 +135,7 @@ public class LocationEventsListener {
     }
 
     private void applyLocationUpdated(JsonNode envelope) {
-        LocationUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), LocationUpdatedV1.class);
+        LocationUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), LocationUpdatedV1.class);
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
         LocationRefEntity ref =
                 locationRefRepository.findByLocationId(payload.locationId()).orElse(null);
@@ -188,7 +189,7 @@ public class LocationEventsListener {
     }
 
     private void applyLocationDeleted(JsonNode envelope) {
-        LocationDeletedV1 payload = objectMapper.treeToValue(envelope.path("payload"), LocationDeletedV1.class);
+        LocationDeletedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), LocationDeletedV1.class);
         locationRefRepository.findByLocationId(payload.locationId()).ifPresent(ref -> {
             ref.setActive(false);
             ref.setStatus(STATUS_DELETED);
@@ -201,7 +202,7 @@ public class LocationEventsListener {
 
     private void applyStorageLocationUpdated(JsonNode envelope) {
         StorageLocationUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), StorageLocationUpdatedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), StorageLocationUpdatedV1.class);
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
         ExtStorageLocationReplica existing = extStorageLocationReplicaRepository
                 .findById(payload.storageLocationId())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryRollupServiceImpl.java
@@ -38,7 +38,14 @@ public class LocationInventoryRollupServiceImpl implements LocationInventoryRoll
      * (ADR-0016). Kept in sync via the CAP-214 contract guide.
      */
     private static final Set<String> VALID_PARENT_TYPES = Set.of(
-            "HOME_OFFICE", "HEADQUARTERS", "REGION", "DISTRICT", "PHYSICAL", "ORGANIZATIONAL", "FINANCIAL", "SHIPPING");
+            "HOME_OFFICE",
+            "HEADQUARTERS",
+            "REGION",
+            "DISTRICT",
+            DEFAULT_PARENT_TYPE,
+            "ORGANIZATIONAL",
+            "FINANCIAL",
+            "SHIPPING");
 
     private final StorageLocationTopologyService topologyService;
     private final SiteInventoryRollupService siteInventoryRollupService;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
@@ -46,6 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class ReplenishmentServiceImpl implements ReplenishmentService {
+    private static final String NO_ACTION = "NO_ACTION";
 
     private static final List<ReplenishmentStatus> OPEN_STATUSES =
             List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS);
@@ -207,7 +208,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         if (policy.isEmpty()) {
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
-                    .status("NO_ACTION")
+                    .status(NO_ACTION)
                     .build();
         }
 
@@ -216,7 +217,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
             logSkip("Event evaluation", policy.get(), suspensionReason);
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
-                    .status("NO_ACTION")
+                    .status(NO_ACTION)
                     .build();
         }
 
@@ -227,13 +228,13 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
             if (!purchaseProjection.triggered()) {
                 return ReplenishmentTaskResponse.builder()
                         .taskId(null)
-                        .status("NO_ACTION")
+                        .status(NO_ACTION)
                         .build();
             }
             SuggestionOutcome outcome = evaluatePurchaseSuggestion(policy.get(), purchaseProjection, null);
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
-                    .status(outcome == SuggestionOutcome.NONE ? "NO_ACTION" : "PURCHASE_SUGGESTED")
+                    .status(outcome == SuggestionOutcome.NONE ? NO_ACTION : "PURCHASE_SUGGESTED")
                     .build();
         }
 
@@ -257,7 +258,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         if (!projection.triggered()) {
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
-                    .status("NO_ACTION")
+                    .status(NO_ACTION)
                     .build();
         }
 
@@ -265,7 +266,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         if (quantityNeeded == 0) {
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
-                    .status("NO_ACTION")
+                    .status(NO_ACTION)
                     .build();
         }
 
@@ -277,7 +278,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
             SuggestionOutcome outcome = evaluatePurchaseSuggestion(policy.get(), projection, null);
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
-                    .status(outcome == SuggestionOutcome.NONE ? "NO_ACTION" : "PURCHASE_SUGGESTED")
+                    .status(outcome == SuggestionOutcome.NONE ? NO_ACTION : "PURCHASE_SUGGESTED")
                     .build();
         }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class RevaluationServiceImpl implements RevaluationService {
+    private static final String REVALUATION = "Revaluation";
 
     /** Money scale for the value delta. */
     private static final int VALUE_SCALE = 4;
@@ -122,7 +123,7 @@ public class RevaluationServiceImpl implements RevaluationService {
         String actor = currentActor();
         RevaluationRecord record = revaluationRepository
                 .findById(revaluationId)
-                .orElseThrow(() -> new ResourceNotFoundException("Revaluation", revaluationId.toString()));
+                .orElseThrow(() -> new ResourceNotFoundException(REVALUATION, revaluationId.toString()));
 
         if (record.getStatus() != RevaluationStatus.PENDING_APPROVAL) {
             throw new IllegalStateException("Cannot approve revaluation in status: " + record.getStatus());
@@ -143,7 +144,7 @@ public class RevaluationServiceImpl implements RevaluationService {
         String actor = currentActor();
         RevaluationRecord record = revaluationRepository
                 .findById(revaluationId)
-                .orElseThrow(() -> new ResourceNotFoundException("Revaluation", revaluationId.toString()));
+                .orElseThrow(() -> new ResourceNotFoundException(REVALUATION, revaluationId.toString()));
 
         if (record.getStatus() != RevaluationStatus.PENDING_APPROVAL) {
             throw new IllegalStateException("Cannot reject revaluation in status: " + record.getStatus());
@@ -163,7 +164,7 @@ public class RevaluationServiceImpl implements RevaluationService {
     public @NonNull RevaluationResponse getRevaluation(@NonNull UUID revaluationId) {
         return toResponse(revaluationRepository
                 .findById(revaluationId)
-                .orElseThrow(() -> new ResourceNotFoundException("Revaluation", revaluationId.toString())));
+                .orElseThrow(() -> new ResourceNotFoundException(REVALUATION, revaluationId.toString())));
     }
 
     @Override

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ScrapServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ScrapServiceImpl.java
@@ -64,6 +64,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 @Slf4j
 public class ScrapServiceImpl implements ScrapService {
+    private static final String CREATED_AT = "createdAt";
 
     /** Permission required to post a scrap that drives on-hand negative. */
     static final String NEGATIVE_STOCK_OVERRIDE_PERMISSION = "inventory:adjustment:override";
@@ -233,12 +234,12 @@ public class ScrapServiceImpl implements ScrapService {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("locationId"), locationId));
         }
         if (createdFrom != null) {
-            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("createdAt"), createdFrom));
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get(CREATED_AT), createdFrom));
         }
         if (createdTo != null) {
-            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("createdAt"), createdTo));
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get(CREATED_AT), createdTo));
         }
-        return scrapRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "createdAt")).stream()
+        return scrapRepository.findAll(spec, Sort.by(Sort.Direction.DESC, CREATED_AT)).stream()
                 .map(this::toResponse)
                 .toList();
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
@@ -101,6 +101,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Slf4j
 public class TransferOrderServiceImpl implements TransferOrderService {
+    private static final String SOURCE = "source";
+
+    private static final String DESTINATION = "destination";
 
     private static final String ELIGIBLE_STATUS = "ACTIVE";
 
@@ -142,11 +145,11 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             throw new IllegalArgumentException("Source and destination must be different sites; intra-site bin moves"
                     + " use POST /v1/inventory/stock-movements");
         }
-        requireEligibleSite(request.getSourceLocationId(), "source");
-        requireEligibleSite(request.getDestinationLocationId(), "destination");
-        requireStorageLocationUnderSite(request.getSourceStorageLocationId(), request.getSourceLocationId(), "source");
+        requireEligibleSite(request.getSourceLocationId(), SOURCE);
+        requireEligibleSite(request.getDestinationLocationId(), DESTINATION);
+        requireStorageLocationUnderSite(request.getSourceStorageLocationId(), request.getSourceLocationId(), SOURCE);
         requireStorageLocationUnderSite(
-                request.getDestinationStorageLocationId(), request.getDestinationLocationId(), "destination");
+                request.getDestinationStorageLocationId(), request.getDestinationLocationId(), DESTINATION);
 
         TransferOrder order = TransferOrder.builder()
                 .sourceLocationId(request.getSourceLocationId())
@@ -249,8 +252,8 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         TransferOrder order = load(transferOrderId);
         requireDispatchableStatus(order);
         // Spec C5: both endpoints of the movement re-validated at posting time.
-        requireEligibleSite(order.getSourceLocationId(), "source");
-        requireEligibleSite(order.getDestinationLocationId(), "destination");
+        requireEligibleSite(order.getSourceLocationId(), SOURCE);
+        requireEligibleSite(order.getDestinationLocationId(), DESTINATION);
 
         Map<UUID, TransferQuantityLineRequest> explicit = explicitLines(request.getLines(), order);
         UUID sourcePosting = sourcePostingLocation(order);
@@ -318,7 +321,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             throw new IllegalStateException("Cannot receive transfer order in status: " + order.getStatus());
         }
         // Spec C5: the receiving end re-validated at posting time.
-        requireEligibleSite(order.getDestinationLocationId(), "destination");
+        requireEligibleSite(order.getDestinationLocationId(), DESTINATION);
 
         Map<UUID, TransferQuantityLineRequest> explicit = explicitLines(request.getLines(), order);
         UUID sourcePosting = sourcePostingLocation(order);
@@ -393,7 +396,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         // nothing anywhere — deliberately no eligibility check, so a transfer toward a
         // since-deactivated destination can still be resolved as a loss.
         if (request.getDisposition() == TransferShortCloseDisposition.RETURNED_TO_SOURCE) {
-            requireEligibleSite(order.getSourceLocationId(), "source");
+            requireEligibleSite(order.getSourceLocationId(), SOURCE);
         }
 
         UUID sourcePosting = sourcePostingLocation(order);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WarrantyEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WarrantyEventsListener.java
@@ -61,7 +61,7 @@ public class WarrantyEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "warranty")
+                        .tag("owner", OWNER)
                         .tag("entity", "warranty-events")
                         .register(registry);
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderEventsListener.java
@@ -67,7 +67,7 @@ public class WorkorderEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "workorder")
+                        .tag("owner", OWNER)
                         .tag("entity", "workorder-events")
                         .register(registry);
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/CustomerEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/CustomerEventsListener.java
@@ -58,7 +58,7 @@ public class CustomerEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "customer")
+                        .tag("owner", OWNER)
                         .tag("entity", "customer-events")
                         .register(registry);
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
@@ -40,6 +40,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class InvoiceServiceImpl implements InvoiceService {
+    private static final String INVOICE_ID_REQUIRED = "invoiceId is required";
+
     private final Clock clock;
 
     private final InvoiceRepository invoiceRepository;
@@ -163,7 +165,7 @@ public class InvoiceServiceImpl implements InvoiceService {
         Invoice saved = invoiceRepository.save(invoice);
         // Rebuild the persisted breakdown wholesale, then publish it (freeze-after-finalize:
         // reachable only while DRAFT, enforced by validateDraftState above and recalculateTotals).
-        taxBreakdownWriter.replace(Objects.requireNonNull(saved.getId(), "invoiceId is required"), taxResponse);
+        taxBreakdownWriter.replace(Objects.requireNonNull(saved.getId(), INVOICE_ID_REQUIRED), taxResponse);
         invoiceEventPublisher.publishInvoiceUpdated(saved);
         InvoiceDetailsResponse response = toDetailsResponse(saved);
         response.setWorkorderNumber(resolveWorkorderNumber(saved.getWorkorderId()));
@@ -216,7 +218,7 @@ public class InvoiceServiceImpl implements InvoiceService {
         }
         // Persist the per-line jurisdiction breakdown once the id is assigned, before the event
         // is built (the publisher reads these rows to populate taxBreakdown[]).
-        taxBreakdownWriter.replace(Objects.requireNonNull(saved.getId(), "invoiceId is required"), taxResponse);
+        taxBreakdownWriter.replace(Objects.requireNonNull(saved.getId(), INVOICE_ID_REQUIRED), taxResponse);
         invoiceEventPublisher.publishInvoiceUpdated(saved);
         return toGenerationResponse(saved);
     }
@@ -224,7 +226,7 @@ public class InvoiceServiceImpl implements InvoiceService {
     private void validateDraftState(@NonNull Invoice invoice) {
         if (invoice.getStatus() != InvoiceStatus.DRAFT) {
             throw new InvalidInvoiceStateException(
-                    Objects.requireNonNull(invoice.getId(), "invoiceId is required"),
+                    Objects.requireNonNull(invoice.getId(), INVOICE_ID_REQUIRED),
                     invoice.getStatus(),
                     InvoiceStatus.DRAFT);
         }
@@ -282,7 +284,7 @@ public class InvoiceServiceImpl implements InvoiceService {
     private void assertRepricingAllowed(@NonNull Invoice invoice) {
         if (invoice.getStatus() != InvoiceStatus.DRAFT) {
             throw new InvalidInvoiceStateException(
-                    Objects.requireNonNull(invoice.getId(), "invoiceId is required"),
+                    Objects.requireNonNull(invoice.getId(), INVOICE_ID_REQUIRED),
                     invoice.getStatus(),
                     InvoiceStatus.DRAFT);
         }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/LocationEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/LocationEventsListener.java
@@ -64,7 +64,7 @@ public class LocationEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "location")
+                        .tag("owner", OWNER)
                         .tag("entity", "location-events")
                         .register(registry);
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PeopleEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PeopleEventsListener.java
@@ -56,7 +56,7 @@ public class PeopleEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-events")
                         .register(registry);
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/WorkorderEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/WorkorderEventsListener.java
@@ -60,7 +60,7 @@ public class WorkorderEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "workorder")
+                        .tag("owner", OWNER)
                         .tag("entity", "workorder-events")
                         .register(registry);
     }

--- a/pos-location/src/main/java/com/positivity/location/internal/service/InventoryEventsListener.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/InventoryEventsListener.java
@@ -61,7 +61,7 @@ public class InventoryEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "inventory")
+                        .tag("owner", OWNER)
                         .tag("entity", "inventory-events")
                         .register(registry);
     }

--- a/pos-location/src/main/java/com/positivity/location/internal/service/PeopleContactEventsListener.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/PeopleContactEventsListener.java
@@ -62,7 +62,7 @@ public class PeopleContactEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people-contact")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-contact-events")
                         .register(registry);
     }

--- a/pos-location/src/main/java/com/positivity/location/internal/service/TravelBufferPolicyServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/TravelBufferPolicyServiceImpl.java
@@ -25,6 +25,11 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @Service
 public class TravelBufferPolicyServiceImpl implements TravelBufferPolicyService {
+    private static final String NOTES = "notes";
+
+    private static final String BUFFER_VALUE = "bufferValue";
+
+    private static final String BUFFER_TYPE = "bufferType";
 
     private static final String TRAVEL_BUFFER_POLICY_NAME_TAKEN = "TRAVEL_BUFFER_POLICY_NAME_TAKEN";
     private static final String TRAVEL_BUFFER_POLICY_CONFLICT = "TRAVEL_BUFFER_POLICY_CONFLICT";
@@ -92,14 +97,14 @@ public class TravelBufferPolicyServiceImpl implements TravelBufferPolicyService 
                 .findById(policyId)
                 .orElseThrow(() -> new ResourceNotFoundException("Travel buffer policy not found"));
 
-        if (patch.containsKey("bufferType")) {
-            entity.setBufferType(String.valueOf(patch.get("bufferType")));
+        if (patch.containsKey(BUFFER_TYPE)) {
+            entity.setBufferType(String.valueOf(patch.get(BUFFER_TYPE)));
         }
-        if (patch.containsKey("bufferValue")) {
-            entity.setBufferValue(parseBigDecimal(patch.get("bufferValue")));
+        if (patch.containsKey(BUFFER_VALUE)) {
+            entity.setBufferValue(parseBigDecimal(patch.get(BUFFER_VALUE)));
         }
-        if (patch.containsKey("notes")) {
-            entity.setNotes((String) patch.get("notes"));
+        if (patch.containsKey(NOTES)) {
+            entity.setNotes((String) patch.get(NOTES));
         }
 
         validateRequest(entity.getBufferType(), entity.getBufferValue(), false);
@@ -143,9 +148,9 @@ public class TravelBufferPolicyServiceImpl implements TravelBufferPolicyService 
     private TravelBufferPolicyRequest toRequest(Map<String, Object> map) {
         return TravelBufferPolicyRequest.builder()
                 .name((String) map.get("name"))
-                .bufferType(map.get("bufferType") == null ? null : String.valueOf(map.get("bufferType")))
-                .bufferValue(parseBigDecimal(map.get("bufferValue")))
-                .notes((String) map.get("notes"))
+                .bufferType(map.get(BUFFER_TYPE) == null ? null : String.valueOf(map.get(BUFFER_TYPE)))
+                .bufferValue(parseBigDecimal(map.get(BUFFER_VALUE)))
+                .notes((String) map.get(NOTES))
                 .build();
     }
 

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignReferenceValidator.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignReferenceValidator.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CampaignReferenceValidator {
+    private static final String PROMOTION_OFFER_PREFIX = "promotion offer ";
 
     private final Clock clock;
     private final PromotionOfferPort promotionOfferPort;
@@ -65,9 +66,10 @@ public class CampaignReferenceValidator {
         }
         PromotionOfferPort.OfferLookup lookup = promotionOfferPort.findOffer(promotionOfferId);
         return switch (lookup.outcome()) {
-            case NOT_FOUND -> Optional.of("promotion offer " + promotionOfferId + " does not exist");
+            case NOT_FOUND -> Optional.of(PROMOTION_OFFER_PREFIX + promotionOfferId + " does not exist");
             case UNAVAILABLE ->
-                Optional.of("promotion offer " + promotionOfferId + " could not be verified; pricing is unavailable");
+                Optional.of(
+                        PROMOTION_OFFER_PREFIX + promotionOfferId + " could not be verified; pricing is unavailable");
             case FOUND -> activeOfferProblem(promotionOfferId, lookup.offer());
         };
     }
@@ -75,17 +77,17 @@ public class CampaignReferenceValidator {
     private Optional<String> activeOfferProblem(UUID promotionOfferId, PromotionOfferPort.PromotionOffer offer) {
         if (offer == null) {
             return Optional.of(
-                    "promotion offer " + promotionOfferId + " could not be verified; pricing is unavailable");
+                    PROMOTION_OFFER_PREFIX + promotionOfferId + " could not be verified; pricing is unavailable");
         }
         if (!offer.isActive()) {
-            return Optional.of("promotion offer " + promotionOfferId + " is "
+            return Optional.of(PROMOTION_OFFER_PREFIX + promotionOfferId + " is "
                     + (offer.status() == null ? "in an unknown status" : offer.status()) + ", not ACTIVE");
         }
         // Offers run on calendar days and carry no zone; UTC is the only defensible reading of
         // "today" for a service that schedules across regions.
         LocalDate today = LocalDate.now(clock.withZone(ZoneOffset.UTC));
         if (!offer.runsOn(today)) {
-            return Optional.of("promotion offer " + promotionOfferId + " is ACTIVE but its window ("
+            return Optional.of(PROMOTION_OFFER_PREFIX + promotionOfferId + " is ACTIVE but its window ("
                     + describeWindow(offer) + ") does not include today");
         }
         return Optional.empty();

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -30,6 +30,7 @@ import reactor.util.retry.Retry;
 
 @Component
 public class OpenApiDocumentFetcher {
+    private static final String AGGREGATE = "aggregate";
 
     private static final Logger log = LoggerFactory.getLogger(OpenApiDocumentFetcher.class);
     private static final String GATEWAY_SERVICE_ID = "pos-api-gateway";
@@ -164,7 +165,7 @@ public class OpenApiDocumentFetcher {
                         specUri,
                         elapsedMs(fetchStartNanos),
                         raw.length()))
-                .map(raw -> deserialize("aggregate", raw))
+                .map(raw -> deserialize(AGGREGATE, raw))
                 .flatMap(result -> {
                     OpenAPI openAPI = result.getOpenAPI();
                     if (openAPI == null) {
@@ -178,7 +179,7 @@ public class OpenApiDocumentFetcher {
                                 specUri);
                         return aggregateViaSwaggerConfig(specUri, baseUri);
                     }
-                    return Mono.just(new DiscoveredOpenApi("aggregate", baseUri, openAPI));
+                    return Mono.just(new DiscoveredOpenApi(AGGREGATE, baseUri, openAPI));
                 })
                 .onErrorResume(ex -> {
                     log.warn("Could not fetch aggregate OpenAPI from {}: {}", specUri, ex.getMessage());
@@ -223,7 +224,7 @@ public class OpenApiDocumentFetcher {
                                         docs.size(),
                                         swaggerConfigUri,
                                         mergedPaths.size());
-                                return new DiscoveredOpenApi("aggregate", baseUri, merged);
+                                return new DiscoveredOpenApi(AGGREGATE, baseUri, merged);
                             });
                 })
                 .onErrorResume(ex -> {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
 
 @Component
 public class OpenApiToolMapper {
+    private static final String STRING_TYPE = "string";
 
     private static final String OBJECT = "object";
     private static final String DESCRIPTION = "description";
@@ -188,7 +189,7 @@ public class OpenApiToolMapper {
                     "type",
                     parameter.getSchema() != null && parameter.getSchema().getType() != null
                             ? parameter.getSchema().getType()
-                            : "string");
+                            : STRING_TYPE);
             entry.put("required", Boolean.TRUE.equals(parameter.getRequired()));
             query.add(entry);
         }
@@ -308,12 +309,13 @@ public class OpenApiToolMapper {
                 "httpMethod",
                 Map.of(
                         "type",
-                        "string",
+                        STRING_TYPE,
                         "const",
                         method.name(),
                         DESCRIPTION,
                         "HTTP method for the underlying API call"));
-        properties.put("path", Map.of("type", "string", "const", path, DESCRIPTION, "Path template for the API call"));
+        properties.put(
+                "path", Map.of("type", STRING_TYPE, "const", path, DESCRIPTION, "Path template for the API call"));
         properties.put("pathParams", Map.of("type", OBJECT, DESCRIPTION, "Path parameters keyed by template name"));
         properties.put("queryParams", Map.of("type", OBJECT, DESCRIPTION, "Query string parameters"));
         properties.put("headers", Map.of("type", OBJECT, DESCRIPTION, "Additional HTTP headers to include"));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 @Profile({"!test", "openapi"})
 public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
+    private static final String VARCHAR = "varchar";
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -55,7 +56,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
         return jdbcTemplate.query(
                 sql,
                 ps -> {
-                    ps.setArray(1, ps.getConnection().createArrayOf("varchar", permissionCodes.toArray()));
+                    ps.setArray(1, ps.getConnection().createArrayOf(VARCHAR, permissionCodes.toArray()));
                     ps.setString(2, workflowState);
                 },
                 this::mapRow);
@@ -118,7 +119,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 sql,
                 ps -> {
                     ps.setString(1, workflowState);
-                    ps.setArray(2, ps.getConnection().createArrayOf("varchar", permissionCodes.toArray()));
+                    ps.setArray(2, ps.getConnection().createArrayOf(VARCHAR, permissionCodes.toArray()));
                     ps.setObject(3, toVectorPGobject(embedding));
                     ps.setInt(4, limit);
                 },
@@ -151,7 +152,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 sql,
                 ps -> {
                     ps.setString(1, workflowState);
-                    ps.setArray(2, ps.getConnection().createArrayOf("varchar", permissionCodes.toArray()));
+                    ps.setArray(2, ps.getConnection().createArrayOf(VARCHAR, permissionCodes.toArray()));
                     ps.setObject(3, toVectorPGobject(embedding));
                     ps.setInt(4, limit);
                 },
@@ -210,7 +211,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
         Object[] keptArray = keptNames.toArray();
         List<UUID> orphanIds = jdbcTemplate.query(
                 "SELECT id FROM mcp_tool WHERE source = 'openapi' AND name <> ALL(?)",
-                ps -> ps.setArray(1, ps.getConnection().createArrayOf("varchar", keptArray)),
+                ps -> ps.setArray(1, ps.getConnection().createArrayOf(VARCHAR, keptArray)),
                 (rs, rowNum) -> rs.getObject("id", UUID.class));
         if (orphanIds.isEmpty()) {
             return 0;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/NltiWritePlanService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/NltiWritePlanService.java
@@ -67,6 +67,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class NltiWritePlanService {
+    private static final String TOOL_PREFIX = "tool=";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NltiWritePlanService.class);
 
@@ -342,7 +343,7 @@ public class NltiWritePlanService {
 
         transition(plan, request, NltiRequestStatus.EXECUTING);
         // Destructive audit events propagate write failures — a non-auditable execution never runs.
-        appendPlanAudit(plan, request, NltiAuditEventType.EXECUTION_STEP, "tool=" + plan.getTargetTool());
+        appendPlanAudit(plan, request, NltiAuditEventType.EXECUTION_STEP, TOOL_PREFIX + plan.getTargetTool());
 
         try {
             // The exact persisted args — never a re-parse of the user's text.
@@ -350,7 +351,7 @@ public class NltiWritePlanService {
             plan.setExecutedAt(OffsetDateTime.now(clock));
             plan.setExecutionResult(result);
             transition(plan, request, NltiRequestStatus.COMPLETE);
-            appendPlanAudit(plan, request, NltiAuditEventType.EXECUTION_COMPLETE, "tool=" + plan.getTargetTool());
+            appendPlanAudit(plan, request, NltiAuditEventType.EXECUTION_COMPLETE, TOOL_PREFIX + plan.getTargetTool());
             return toResponse(plan);
         } catch (RuntimeException executionFailure) {
             transition(plan, request, NltiRequestStatus.ERROR);
@@ -358,7 +359,7 @@ public class NltiWritePlanService {
                     plan,
                     request,
                     NltiAuditEventType.EXECUTION_FAILED,
-                    "tool=" + plan.getTargetTool() + " error="
+                    TOOL_PREFIX + plan.getTargetTool() + " error="
                             + executionFailure.getClass().getSimpleName());
             if (executionFailure instanceof WritePlanExecutionException) {
                 throw executionFailure;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
@@ -44,6 +44,13 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class OpenApiToolProvider {
+    private static final String STRING_TYPE = "string";
+
+    private static final String REQUIRED = "required";
+
+    private static final String PROPERTIES = "properties";
+
+    private static final String QUERY_STRING_PARAMETERS_DESCRIPTION = "Query-string parameters.";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiToolProvider.class);
 
@@ -60,17 +67,17 @@ public class OpenApiToolProvider {
         List<String> pathParams = extractPathParams(op.httpPath());
         Map<String, Object> pathParamsSchema = schemaObject("Path template parameters.");
         @SuppressWarnings("unchecked")
-        Map<String, Object> pathProperties = (Map<String, Object>) pathParamsSchema.get("properties");
+        Map<String, Object> pathProperties = (Map<String, Object>) pathParamsSchema.get(PROPERTIES);
         for (String name : pathParams) {
-            pathProperties.put(name, schemaProperty("string", "Path parameter " + name));
+            pathProperties.put(name, schemaProperty(STRING_TYPE, "Path parameter " + name));
         }
         if (!pathParams.isEmpty()) {
-            pathParamsSchema.put("required", pathParams);
+            pathParamsSchema.put(REQUIRED, pathParams);
         }
         Map<String, Object> schema =
                 schemaObject("Parameters for the gateway operation named in the tool description.");
         @SuppressWarnings("unchecked")
-        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        Map<String, Object> properties = (Map<String, Object>) schema.get(PROPERTIES);
         properties.put("pathParams", pathParamsSchema);
         properties.put("queryParams", buildQueryParamsSchema(op.inputSchema()));
         properties.put("headers", schemaObject("Extra HTTP headers (auth is relayed automatically)."));
@@ -89,16 +96,16 @@ public class OpenApiToolProvider {
      */
     private Map<String, Object> buildQueryParamsSchema(@Nullable String inputSchemaJson) {
         if (inputSchemaJson == null || inputSchemaJson.isBlank()) {
-            return schemaObject("Query-string parameters.");
+            return schemaObject(QUERY_STRING_PARAMETERS_DESCRIPTION);
         }
         try {
             JsonNode query = objectMapper.readTree(inputSchemaJson).get("query");
             if (query == null || !query.isArray() || query.isEmpty()) {
-                return schemaObject("Query-string parameters.");
+                return schemaObject(QUERY_STRING_PARAMETERS_DESCRIPTION);
             }
-            Map<String, Object> builder = schemaObject("Query-string parameters.");
+            Map<String, Object> builder = schemaObject(QUERY_STRING_PARAMETERS_DESCRIPTION);
             @SuppressWarnings("unchecked")
-            Map<String, Object> properties = (Map<String, Object>) builder.get("properties");
+            Map<String, Object> properties = (Map<String, Object>) builder.get(PROPERTIES);
             List<String> required = new ArrayList<>();
             for (JsonNode param : query) {
                 String name = param.path("name").asText(null);
@@ -106,18 +113,18 @@ public class OpenApiToolProvider {
                     continue;
                 }
                 String description = "Query parameter " + name;
-                properties.put(name, schemaProperty(param.path("type").asText("string"), description));
-                if (param.path("required").asBoolean(false)) {
+                properties.put(name, schemaProperty(param.path("type").asText(STRING_TYPE), description));
+                if (param.path(REQUIRED).asBoolean(false)) {
                     required.add(name);
                 }
             }
             if (!required.isEmpty()) {
-                builder.put("required", required);
+                builder.put(REQUIRED, required);
             }
             return builder;
         } catch (JsonProcessingException | RuntimeException e) {
             LOGGER.debug("MCP openapi query-param schema parse failed; using free-form object", e);
-            return schemaObject("Query-string parameters.");
+            return schemaObject(QUERY_STRING_PARAMETERS_DESCRIPTION);
         }
     }
 
@@ -125,7 +132,7 @@ public class OpenApiToolProvider {
         Map<String, Object> schema = new LinkedHashMap<>();
         schema.put("type", "object");
         schema.put("description", description);
-        schema.put("properties", new LinkedHashMap<String, Object>());
+        schema.put(PROPERTIES, new LinkedHashMap<String, Object>());
         return schema;
     }
 
@@ -137,7 +144,7 @@ public class OpenApiToolProvider {
                     case "integer" -> "integer";
                     case "number" -> "number";
                     case "boolean" -> "boolean";
-                    default -> "string";
+                    default -> STRING_TYPE;
                 });
         property.put("description", description);
         return property;

--- a/pos-order/src/main/java/com/positivity/order/internal/client/RestInvoicingPortAdapter.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/client/RestInvoicingPortAdapter.java
@@ -1,6 +1,7 @@
 package com.positivity.order.internal.client;
 
 import com.positivity.order.internal.exception.InvoicingUnavailableException;
+import com.positivity.security.common.GatewaySecurityConstants;
 import com.positivity.shared.dto.OrderInvoiceCreationRequest;
 import com.positivity.shared.dto.OrderInvoiceResponse;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.springframework.web.client.RestClient;
 @Component
 @Slf4j
 public class RestInvoicingPortAdapter implements InvoicingPort {
+    private static final String SERVICE_USER = "pos-order";
 
     private final RestClient invoiceServiceRestClient;
 
@@ -34,8 +36,8 @@ public class RestInvoicingPortAdapter implements InvoicingPort {
             OrderInvoiceResponse response = invoiceServiceRestClient
                     .post()
                     .uri("/v1/invoices/from-order")
-                    .header("X-User", "pos-order")
-                    .header("X-Authorities", "invoice:manage")
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, "invoice:manage")
                     .body(request)
                     .retrieve()
                     .body(OrderInvoiceResponse.class);
@@ -72,8 +74,10 @@ public class RestInvoicingPortAdapter implements InvoicingPort {
             invoiceServiceRestClient
                     .post()
                     .uri(path, invoiceId, paymentIntentId)
-                    .header("X-User", "pos-order")
-                    .header("X-Authorities", "invoice:manage," + (isVoid ? "VOID_PAYMENT" : "REFUND_PAYMENT"))
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(
+                            GatewaySecurityConstants.HEADER_AUTHORITIES,
+                            "invoice:manage," + (isVoid ? "VOID_PAYMENT" : "REFUND_PAYMENT"))
                     .body(body)
                     .retrieve()
                     .toBodilessEntity();
@@ -94,8 +98,8 @@ public class RestInvoicingPortAdapter implements InvoicingPort {
             invoiceServiceRestClient
                     .post()
                     .uri("/v1/invoices/{invoiceId}/cancel", invoiceId)
-                    .header("X-User", "pos-order")
-                    .header("X-Authorities", "invoice:manage")
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, "invoice:manage")
                     .retrieve()
                     .toBodilessEntity();
         } catch (Exception e) {

--- a/pos-order/src/main/java/com/positivity/order/internal/config/InventoryReplicaHealthIndicator.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/InventoryReplicaHealthIndicator.java
@@ -61,6 +61,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class InventoryReplicaHealthIndicator implements HealthIndicator {
+    private static final String REPLICA_STATE = "replicaState";
 
     private static final Logger log = LoggerFactory.getLogger(InventoryReplicaHealthIndicator.class);
 
@@ -114,17 +115,17 @@ public class InventoryReplicaHealthIndicator implements HealthIndicator {
         try {
             Optional<Instant> newest = newestUpdatedAt();
             if (newest.isEmpty()) {
-                details.put("replicaState", "never-fed");
+                details.put(REPLICA_STATE, "never-fed");
                 details.put("newestFactAt", null);
             } else {
                 Duration age = age(newest.get());
                 details.put("newestFactAt", newest.get().toString());
                 details.put("ageSeconds", age.toSeconds());
-                details.put("replicaState", age.compareTo(stalenessThreshold) > 0 ? "stale" : "fresh");
+                details.put(REPLICA_STATE, age.compareTo(stalenessThreshold) > 0 ? "stale" : "fresh");
             }
         } catch (Exception e) {
             log.warn("Unable to read availability replica staleness", e);
-            details.put("replicaState", "unknown");
+            details.put(REPLICA_STATE, "unknown");
             details.put("error", e.getClass().getSimpleName());
         }
         return Health.up().withDetails(details).build();

--- a/pos-order/src/main/java/com/positivity/order/internal/config/OrderDomainEventPublisher.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/OrderDomainEventPublisher.java
@@ -35,6 +35,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OrderDomainEventPublisher {
+    private static final String SYSTEM_ACTOR = "system";
+
+    private static final String ORDER_DOMAIN = "order";
 
     private static final String SOURCE_SERVICE = "pos-order";
     private static final String CURRENCY = "USD";
@@ -193,7 +196,7 @@ public class OrderDomainEventPublisher {
                 returnOrder.getReturnedAt() != null ? returnOrder.getReturnedAt() : Instant.now(clock));
         long aggregateVersion = returnOrder.getVersion() == null ? 0L : returnOrder.getVersion();
         writer.publish(
-                DomainTopics.events("order"),
+                DomainTopics.events(ORDER_DOMAIN),
                 DomainEventEnvelope.of(
                         OrderReturnedV1.EVENT_TYPE,
                         OrderReturnedV1.SCHEMA_VERSION,
@@ -201,7 +204,7 @@ public class OrderDomainEventPublisher {
                         aggregateVersion,
                         SOURCE_SERVICE,
                         null,
-                        SecurityContextHelper.getCurrentUsernameOrDefault("system"),
+                        SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR),
                         payload,
                         clock));
         log.debug("Queued order.order.returned returnOrderId={}", returnOrder.getReturnOrderId());
@@ -219,7 +222,7 @@ public class OrderDomainEventPublisher {
         }
         long aggregateVersion = session.getVersion() == null ? 0L : session.getVersion();
         writer.publish(
-                DomainTopics.events("order"),
+                DomainTopics.events(ORDER_DOMAIN),
                 DomainEventEnvelope.of(
                         RegisterSessionClosedV1.EVENT_TYPE,
                         RegisterSessionClosedV1.SCHEMA_VERSION,
@@ -227,7 +230,7 @@ public class OrderDomainEventPublisher {
                         aggregateVersion,
                         SOURCE_SERVICE,
                         null,
-                        SecurityContextHelper.getCurrentUsernameOrDefault("system"),
+                        SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR),
                         payload,
                         clock));
         log.debug("Queued order.session.closed sessionId={}", session.getSessionId());
@@ -236,7 +239,7 @@ public class OrderDomainEventPublisher {
     private void publish(
             OutboxEventWriter writer, String eventType, int schemaVersion, SalesOrder order, Object payload) {
         writer.publish(
-                DomainTopics.events("order"),
+                DomainTopics.events(ORDER_DOMAIN),
                 DomainEventEnvelope.of(
                         eventType,
                         schemaVersion,
@@ -244,7 +247,7 @@ public class OrderDomainEventPublisher {
                         aggregateVersion(order),
                         SOURCE_SERVICE,
                         null,
-                        SecurityContextHelper.getCurrentUsernameOrDefault("system"),
+                        SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR),
                         payload,
                         clock));
     }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/CustomerEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/CustomerEventsListener.java
@@ -35,6 +35,11 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
 public class CustomerEventsListener {
+    private static final String PAYLOAD = "payload";
+
+    private static final String PARTY_ID = "partyId";
+
+    private static final String CREDIT_LIMIT = "creditLimit";
 
     static final String OWNER = "customer";
 
@@ -95,8 +100,8 @@ public class CustomerEventsListener {
     }
 
     private void applyUpdate(JsonNode envelope) {
-        JsonNode payload = envelope.path("payload");
-        UUID partyId = UUID.fromString(payload.path("partyId").stringValue(null));
+        JsonNode payload = envelope.path(PAYLOAD);
+        UUID partyId = UUID.fromString(payload.path(PARTY_ID).stringValue(null));
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtCustomer existing = extCustomerRepository.findById(partyId).orElse(null);
@@ -121,8 +126,8 @@ public class CustomerEventsListener {
 
     /** Story C4 (spec R4.5): AR billing terms gate the on-account tender at checkout. */
     private void applyBillingRules(JsonNode envelope) {
-        JsonNode payload = envelope.path("payload");
-        UUID partyId = UUID.fromString(payload.path("partyId").stringValue(null));
+        JsonNode payload = envelope.path(PAYLOAD);
+        UUID partyId = UUID.fromString(payload.path(PARTY_ID).stringValue(null));
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtBillingRules existing = extBillingRulesRepository.findById(partyId).orElse(null);
@@ -134,10 +139,10 @@ public class CustomerEventsListener {
         replica.setPartyId(partyId);
         replica.setPaymentTerms(payload.path("paymentTerms").stringValue(null));
         replica.setCreditLimit(
-                payload.path("creditLimit").isMissingNode()
-                                || payload.path("creditLimit").isNull()
+                payload.path(CREDIT_LIMIT).isMissingNode()
+                                || payload.path(CREDIT_LIMIT).isNull()
                         ? null
-                        : payload.path("creditLimit").decimalValue());
+                        : payload.path(CREDIT_LIMIT).decimalValue());
         replica.setCreditHold(
                 payload.path("creditHold").isNull()
                         ? null
@@ -152,7 +157,7 @@ public class CustomerEventsListener {
     }
 
     private void applyDelete(JsonNode envelope) {
-        UUID partyId = UUID.fromString(envelope.path("payload").path("partyId").stringValue(null));
+        UUID partyId = UUID.fromString(envelope.path(PAYLOAD).path(PARTY_ID).stringValue(null));
         extCustomerRepository.deleteById(partyId);
     }
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/InventoryEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/InventoryEventsListener.java
@@ -78,6 +78,7 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
 public class InventoryEventsListener {
+    private static final String PAYLOAD = "payload";
 
     /** Producing domain, per the repo-wide {@code processed_events} convention. */
     static final String OWNER = "inventory";
@@ -164,7 +165,7 @@ public class InventoryEventsListener {
      * to someone else.
      */
     private void applyReservationOutcome(JsonNode envelope) {
-        ReservationOutcomeV1 outcome = objectMapper.treeToValue(envelope.path("payload"), ReservationOutcomeV1.class);
+        ReservationOutcomeV1 outcome = objectMapper.treeToValue(envelope.path(PAYLOAD), ReservationOutcomeV1.class);
         if (outcome.salesOrderLineId() == null) {
             return;
         }
@@ -200,7 +201,7 @@ public class InventoryEventsListener {
      */
     private void applyAvailabilityUpdated(JsonNode envelope) {
         InventoryAvailabilityUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), InventoryAvailabilityUpdatedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), InventoryAvailabilityUpdatedV1.class);
         String rawAggregateId = envelope.path("aggregateId").stringValue(null);
         if (rawAggregateId == null || rawAggregateId.isBlank()) {
             log.warn("Skipping availability fact without aggregateId for sku {}", payload.stockItemId());
@@ -235,8 +236,7 @@ public class InventoryEventsListener {
     }
 
     private void apply(JsonNode envelope) {
-        GoodsReceiptRecordedV1 receipt =
-                objectMapper.treeToValue(envelope.path("payload"), GoodsReceiptRecordedV1.class);
+        GoodsReceiptRecordedV1 receipt = objectMapper.treeToValue(envelope.path(PAYLOAD), GoodsReceiptRecordedV1.class);
 
         PurchaseOrderEntity order =
                 purchaseOrderRepository.findById(receipt.purchaseOrderId()).orElse(null);

--- a/pos-order/src/main/java/com/positivity/order/internal/service/OrderCancellationServiceImpl.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/OrderCancellationServiceImpl.java
@@ -35,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class OrderCancellationServiceImpl implements OrderCancellationService {
+    private static final String SYSTEM_ACTOR = "system";
 
     private static final String STATUS_CANCELLED = "CANCELLED";
 
@@ -74,7 +75,7 @@ public class OrderCancellationServiceImpl implements OrderCancellationService {
         String idempotencyKey = command.idempotencyKey() != null
                 ? command.idempotencyKey()
                 : UUIDv7Generator.generate().toString();
-        String actor = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        String actor = SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR);
 
         orderStateMachine.transition(order, SalesOrderStatus.CANCEL_REQUESTED, command.cancellationReason());
         order.setCancellationReason(command.cancellationReason());
@@ -119,7 +120,7 @@ public class OrderCancellationServiceImpl implements OrderCancellationService {
     public @NonNull CancellationResult retryCancellation(@NonNull UUID orderId, @NonNull String idempotencyKey) {
         SalesOrder order =
                 salesOrderRepository.findById(orderId).orElseThrow(() -> new SalesOrderNotFoundException(orderId));
-        String actor = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        String actor = SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR);
 
         if (order.getStatus() != SalesOrderStatus.CANCEL_FAILED_BILLING) {
             throw new IllegalStateException(
@@ -205,7 +206,7 @@ public class OrderCancellationServiceImpl implements OrderCancellationService {
 
     private void failTransition(SalesOrder order, SalesOrderStatus failureStatus, String reason) {
         orderStateMachine.transition(order, failureStatus, reason);
-        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
         salesOrderRepository.save(order);
     }
 

--- a/pos-order/src/main/java/com/positivity/order/internal/service/PaymentEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/PaymentEventsListener.java
@@ -47,6 +47,7 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
 public class PaymentEventsListener {
+    private static final String OTHER = "OTHER";
 
     static final String OWNER = "payment";
 
@@ -131,7 +132,7 @@ public class PaymentEventsListener {
                 .orderId(order.getOrderId())
                 .recordType(OrderPaymentRecord.RecordType.SETTLED)
                 .paymentIntentId(uuid(payload, "paymentIntentId"))
-                .methodType(payload.path("methodType").stringValue("OTHER"))
+                .methodType(payload.path("methodType").stringValue(OTHER))
                 .amount(money(payload, "amount"))
                 .reference(payload.path("gatewayReference").stringValue(null))
                 .occurredAt(instant(payload, "settledAt"))
@@ -151,7 +152,7 @@ public class PaymentEventsListener {
                 .recordType(OrderPaymentRecord.RecordType.REVERSED)
                 .paymentIntentId(uuid(payload, "paymentIntentId"))
                 .refundId(uuid(payload, "refundId"))
-                .methodType("OTHER")
+                .methodType(OTHER)
                 .amount(money(payload, "amount"))
                 .occurredAt(instant(payload, "reversedAt"))
                 .build());
@@ -201,14 +202,14 @@ public class PaymentEventsListener {
     /** A reversal inherits its settlement's method when the intent matches; OTHER otherwise. */
     private static String resolveReversalMethod(List<OrderPaymentRecord> records, OrderPaymentRecord reversal) {
         if (reversal.getPaymentIntentId() == null) {
-            return "OTHER";
+            return OTHER;
         }
         return records.stream()
                 .filter(r -> r.getRecordType() == OrderPaymentRecord.RecordType.SETTLED)
                 .filter(r -> reversal.getPaymentIntentId().equals(r.getPaymentIntentId()))
                 .map(OrderPaymentRecord::getMethodType)
                 .findFirst()
-                .orElse("OTHER");
+                .orElse(OTHER);
     }
 
     @Nullable

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ReplicaSourceDocumentAdapter.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ReplicaSourceDocumentAdapter.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ReplicaSourceDocumentAdapter implements SourceDocumentPort {
+    private static final String LABOR = "LABOR";
 
     private static final String APPROVED = "APPROVED";
 
@@ -80,7 +81,7 @@ public class ReplicaSourceDocumentAdapter implements SourceDocumentPort {
 
     private SourceDocumentLine toWorkorderLine(ExtWorkorderLine line) {
         String sku = line.getLineKind() == ExtWorkorderLine.LineKind.SERVICE
-                ? "LABOR"
+                ? LABOR
                 : resolveSku(line.getProductId(), line.getLineId());
         Quantities quantities = normalize(line.getQuantity(), line.getUnitPrice(), line.getLineTotal());
         return new SourceDocumentLine(
@@ -93,9 +94,8 @@ public class ReplicaSourceDocumentAdapter implements SourceDocumentPort {
     }
 
     private SourceDocumentLine toEstimateLine(ExtEstimateLine item) {
-        String sku = "LABOR".equalsIgnoreCase(item.getItemType())
-                ? "LABOR"
-                : resolveSku(item.getProductId(), item.getItemId());
+        String sku =
+                LABOR.equalsIgnoreCase(item.getItemType()) ? LABOR : resolveSku(item.getProductId(), item.getItemId());
         Quantities quantities = normalize(item.getQuantity(), item.getUnitPrice(), item.getLineTotal());
         // Estimate items are pre-work: returnability is decided at settlement (Q6), never here.
         return new SourceDocumentLine(

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ReturnOrderServiceImpl.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ReturnOrderServiceImpl.java
@@ -60,6 +60,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ReturnOrderServiceImpl implements ReturnOrderService {
+    private static final String SYSTEM_ACTOR = "system";
 
     /** Returns in these states do not reserve quantity against the cap. */
     static final List<ReturnOrderStatus> CAP_EXCLUDED_STATUSES =
@@ -108,7 +109,7 @@ public class ReturnOrderServiceImpl implements ReturnOrderService {
             soldLines.put(line.getOrderLineId(), line);
         }
 
-        String actor = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        String actor = SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR);
         ReturnOrder returnOrder = ReturnOrder.builder()
                 .originalOrderId(original.getOrderId())
                 .originalOrderNumber(original.getOrderNumber())
@@ -252,7 +253,7 @@ public class ReturnOrderServiceImpl implements ReturnOrderService {
         returnOrder.setStatus(ReturnOrderStatus.RETURN_REQUESTED);
         returnOrder.setApprovedByUserId(reviewerUserId);
         returnOrder.setApprovedAt(clock.instant());
-        returnOrder.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        returnOrder.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
         return toSummary(returnOrderRepository.save(returnOrder));
     }
 
@@ -266,7 +267,7 @@ public class ReturnOrderServiceImpl implements ReturnOrderService {
         }
         returnOrder.setStatus(ReturnOrderStatus.REJECTED);
         returnOrder.setRejectionReason(reason);
-        returnOrder.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        returnOrder.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
         return toSummary(returnOrderRepository.save(returnOrder));
     }
 
@@ -306,7 +307,7 @@ public class ReturnOrderServiceImpl implements ReturnOrderService {
      * call).
      */
     private ReturnOrderSummary runSaga(ReturnOrder returnOrder) {
-        String actor = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        String actor = SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR);
         issueRefund(returnOrder, actor);
 
         returnOrder.setStatus(ReturnOrderStatus.REFUND_ISSUED);

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SalesOrderServiceImpl.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SalesOrderServiceImpl.java
@@ -60,6 +60,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class SalesOrderServiceImpl implements SalesOrderService {
+    private static final String SYSTEM_ACTOR = "system";
+
+    private static final String ON_ACCOUNT = "ON_ACCOUNT";
 
     private final SalesOrderRepository salesOrderRepository;
     private final SalesOrderLineRepository salesOrderLineRepository;
@@ -139,7 +142,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
                     "locationId is required when no register session is open on the terminal");
         }
 
-        String actor = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        String actor = SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR);
         SalesOrder order = SalesOrder.builder()
                 .orderNumber(orderNumberService.nextNumber(locationId))
                 .locationId(locationId)
@@ -414,7 +417,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
         orderTaxService.recomputeTax(order);
         orderStateMachine.transition(order, SalesOrderStatus.QUOTED, "counter quote");
         order.setQuoteExpiresAt(Instant.now(clock).plus(quoteValidity));
-        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
         return toSummary(salesOrderRepository.save(order));
     }
 
@@ -441,7 +444,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
         }
         String tender =
                 normalizeBlank(tenderType) == null ? null : tenderType.trim().toUpperCase(java.util.Locale.ROOT);
-        boolean onAccount = "ON_ACCOUNT".equals(tender);
+        boolean onAccount = ON_ACCOUNT.equals(tender);
         if (!onAccount && tender != null && !"DEFAULT".equals(tender)) {
             throw new IllegalArgumentException("Unsupported tenderType: " + tenderType);
         }
@@ -481,7 +484,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
         order.setCheckoutIdempotencyKey(key);
         order.setAmountPaid(BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP));
         order.setBalanceDue(order.getGrandTotal());
-        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
         SalesOrder saved = salesOrderRepository.save(order);
 
         // Synchronous invoice handshake (stories C1/C2). A failure here throws and rolls the
@@ -598,7 +601,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
         paymentRecordRepository.save(OrderPaymentRecord.builder()
                 .orderId(order.getOrderId())
                 .recordType(OrderPaymentRecord.RecordType.SETTLED)
-                .methodType("ON_ACCOUNT")
+                .methodType(ON_ACCOUNT)
                 .amount(order.getGrandTotal())
                 .reference(order.getInvoiceNumber())
                 .occurredAt(Instant.now(clock))
@@ -609,7 +612,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
         domainEventPublisher.publishOrderCompleted(
                 order,
                 List.of(new com.positivity.domainevents.order.OrderCompletedV1.Tender(
-                        "ON_ACCOUNT", order.getGrandTotal())));
+                        ON_ACCOUNT, order.getGrandTotal())));
     }
 
     private static OrderInvoiceCreationRequest toInvoiceRequest(SalesOrder order) {
@@ -667,7 +670,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
             // Must fail loudly: a failed invoice cancel rolls the void back (atomic like checkout).
             invoicingPort.cancelInvoice(order.getInvoiceId());
         }
-        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
         return toSummary(salesOrderRepository.save(order));
     }
 
@@ -710,7 +713,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     private void recomputeAfterMutation(SalesOrder order) {
         totalsCalculator.recalculate(order);
         order.setTaxStale(true);
-        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        order.setUpdatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR));
     }
 
     private SalesOrderLineSummary replayAddItem(SalesOrder order, SalesOrderLine line, String itemSku, int quantity) {

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SupplierOrderResultListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SupplierOrderResultListener.java
@@ -57,6 +57,7 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
 public class SupplierOrderResultListener {
+    private static final String PAYLOAD = "payload";
 
     /** Producing domain, per the repo-wide {@code processed_events} convention. */
     static final String OWNER = "supplier";
@@ -119,7 +120,7 @@ public class SupplierOrderResultListener {
 
     private void applyConfirmed(JsonNode envelope) {
         SupplierOrderConfirmedV1 fact =
-                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderConfirmedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), SupplierOrderConfirmedV1.class);
         PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
         if (order == null) {
             return;
@@ -154,8 +155,7 @@ public class SupplierOrderResultListener {
     }
 
     private void applyRejected(JsonNode envelope) {
-        SupplierOrderRejectedV1 fact =
-                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderRejectedV1.class);
+        SupplierOrderRejectedV1 fact = objectMapper.treeToValue(envelope.path(PAYLOAD), SupplierOrderRejectedV1.class);
         PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
         if (order == null) {
             return;
@@ -197,7 +197,7 @@ public class SupplierOrderResultListener {
      */
     private void applyReviewRequired(JsonNode envelope) {
         SupplierOrderReviewRequiredV1 fact =
-                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderReviewRequiredV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), SupplierOrderReviewRequiredV1.class);
         PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
         if (order == null) {
             return;
@@ -239,7 +239,7 @@ public class SupplierOrderResultListener {
 
     private void applyStatusChanged(JsonNode envelope) {
         SupplierOrderStatusChangedV1 fact =
-                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderStatusChangedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), SupplierOrderStatusChangedV1.class);
         PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
         if (order == null) {
             return;

--- a/pos-order/src/main/java/com/positivity/order/internal/service/WorkorderEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/WorkorderEventsListener.java
@@ -41,6 +41,13 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
 public class WorkorderEventsListener {
+    private static final String UNIT_PRICE = "unitPrice";
+
+    private static final String QUANTITY = "quantity";
+
+    private static final String LINE_TOTAL = "lineTotal";
+
+    private static final String DESCRIPTION = "description";
 
     static final String OWNER = "workorder";
 
@@ -129,10 +136,10 @@ public class WorkorderEventsListener {
                     .workorderId(workorderId)
                     .lineKind(ExtWorkorderLine.LineKind.PART)
                     .productId(uuid(part, "productEntityId"))
-                    .description(part.path("description").stringValue(null))
-                    .quantity(decimal(part, "quantity"))
-                    .unitPrice(decimal(part, "unitPrice"))
-                    .lineTotal(decimal(part, "lineTotal"))
+                    .description(part.path(DESCRIPTION).stringValue(null))
+                    .quantity(decimal(part, QUANTITY))
+                    .unitPrice(decimal(part, UNIT_PRICE))
+                    .lineTotal(decimal(part, LINE_TOTAL))
                     .declined(bool(part, "declined"))
                     .returnable(bool(part, "returnable"))
                     .build());
@@ -142,10 +149,10 @@ public class WorkorderEventsListener {
                     .lineId(UUID.fromString(service.path("workorderLineId").stringValue(null)))
                     .workorderId(workorderId)
                     .lineKind(ExtWorkorderLine.LineKind.SERVICE)
-                    .description(service.path("description").stringValue(null))
-                    .quantity(decimal(service, "quantity"))
-                    .unitPrice(decimal(service, "unitPrice"))
-                    .lineTotal(decimal(service, "lineTotal"))
+                    .description(service.path(DESCRIPTION).stringValue(null))
+                    .quantity(decimal(service, QUANTITY))
+                    .unitPrice(decimal(service, UNIT_PRICE))
+                    .lineTotal(decimal(service, LINE_TOTAL))
                     .declined(bool(service, "declined"))
                     .build());
         }
@@ -178,10 +185,10 @@ public class WorkorderEventsListener {
                     .itemId(UUID.fromString(item.path("estimateItemId").stringValue(null)))
                     .estimateId(estimateId)
                     .itemType(item.path("itemType").stringValue(null))
-                    .description(item.path("description").stringValue(null))
-                    .quantity(decimal(item, "quantity"))
-                    .unitPrice(decimal(item, "unitPrice"))
-                    .lineTotal(decimal(item, "lineTotal"))
+                    .description(item.path(DESCRIPTION).stringValue(null))
+                    .quantity(decimal(item, QUANTITY))
+                    .unitPrice(decimal(item, UNIT_PRICE))
+                    .lineTotal(decimal(item, LINE_TOTAL))
                     .productId(uuid(item, "productId"))
                     .serviceId(uuid(item, "serviceId"))
                     .approvalStatus(item.path("approvalStatus").stringValue(null))

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PeopleContactCommandListener.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PeopleContactCommandListener.java
@@ -38,6 +38,7 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.people-contact.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactCommandListener {
+    private static final String EVENT_ID = "eventId";
 
     private static final String PAYLOAD = "payload";
 
@@ -120,7 +121,7 @@ public class PeopleContactCommandListener {
      * eventId via {@code processed_events} before applying (ADR-0044 §4).
      */
     private void handlePersonUpsertRequested(@NonNull JsonNode root) {
-        String eventId = root.path("eventId").stringValue(null);
+        String eventId = root.path(EVENT_ID).stringValue(null);
         if (eventId == null || eventId.isBlank()) {
             log.warn("Ignoring person upsert command without eventId: {}", root);
             return;
@@ -151,7 +152,7 @@ public class PeopleContactCommandListener {
      * reconciliation surfaces the unmatched projection.
      */
     private void handleLinkCreateRequested(@NonNull JsonNode root) {
-        String eventId = root.path("eventId").stringValue(null);
+        String eventId = root.path(EVENT_ID).stringValue(null);
         if (eventId == null || eventId.isBlank() || processedEventRepository.existsById(eventId)) {
             return;
         }
@@ -170,7 +171,7 @@ public class PeopleContactCommandListener {
     }
 
     private void handleLinkRemoveRequested(@NonNull JsonNode root) {
-        String eventId = root.path("eventId").stringValue(null);
+        String eventId = root.path(EVENT_ID).stringValue(null);
         if (eventId == null || eventId.isBlank() || processedEventRepository.existsById(eventId)) {
             return;
         }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/LocationEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/LocationEventsListener.java
@@ -65,7 +65,7 @@ public class LocationEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "location")
+                        .tag("owner", OWNER)
                         .tag("entity", "location-events")
                         .register(registry);
     }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PeopleContactEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PeopleContactEventsListener.java
@@ -75,7 +75,7 @@ public class PeopleContactEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people-contact")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-contact-events")
                         .register(registry);
     }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PeopleContactEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PeopleContactEventsListener.java
@@ -47,6 +47,7 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @ConditionalOnProperty(prefix = "pos.people.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
+    private static final String PAYLOAD = "payload";
 
     static final String OWNER = "people-contact";
 
@@ -134,7 +135,7 @@ public class PeopleContactEventsListener {
     }
 
     private void applyPersonUpdated(JsonNode envelope) {
-        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonUpdatedV1.class);
+        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonUpdatedV1.class);
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
 
         ExtPersonReplica existing =
@@ -167,14 +168,14 @@ public class PeopleContactEventsListener {
     }
 
     private void applyPersonDeleted(JsonNode envelope) {
-        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonDeletedV1.class);
+        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonDeletedV1.class);
         extPersonReplicaRepository.deleteById(payload.personId());
         log.info("Deleted ext_people_contact_person personId={}", payload.personId());
     }
 
     private void applyLinkUpdated(JsonNode envelope) {
         UserPersonLinkUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), UserPersonLinkUpdatedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), UserPersonLinkUpdatedV1.class);
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
 
         ExtUserLinkReplica existing =
@@ -195,7 +196,7 @@ public class PeopleContactEventsListener {
 
     private void applyLinkRemoved(JsonNode envelope) {
         UserPersonLinkRemovedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), UserPersonLinkRemovedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), UserPersonLinkRemovedV1.class);
         extUserLinkReplicaRepository.deleteById(payload.linkId());
         log.info("Deleted ext_people_contact_user_link linkId={}", payload.linkId());
     }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/TimeEntryServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/TimeEntryServiceImpl.java
@@ -39,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class TimeEntryServiceImpl implements TimeEntryService {
+    private static final String SYSTEM_ACTOR = "system";
 
     private static final String ENTRY_NOT_PENDING_CODE = "ENTRY_NOT_PENDING";
 
@@ -109,7 +110,7 @@ public class TimeEntryServiceImpl implements TimeEntryService {
             return new ArrayList<>();
         }
 
-        String approverUserId = "system";
+        String approverUserId = SYSTEM_ACTOR;
         java.util.Set<String> permissions = new java.util.HashSet<>();
         org.springframework.security.core.Authentication auth =
                 org.springframework.security.core.context.SecurityContextHolder.getContext()
@@ -124,7 +125,7 @@ public class TimeEntryServiceImpl implements TimeEntryService {
         String finalApproverUserId = approverUserId;
         java.util.Set<String> finalPermissions = permissions;
 
-        String auditActorId = SecurityContextHelper.getCurrentUsername().orElse("system");
+        String auditActorId = SecurityContextHelper.getCurrentUsername().orElse(SYSTEM_ACTOR);
 
         Map<String, TimeEntry> byId = fetchTimeEntriesById(timeEntryIds);
 
@@ -202,7 +203,7 @@ public class TimeEntryServiceImpl implements TimeEntryService {
             }
         }
 
-        String rejectorUserId = "system";
+        String rejectorUserId = SYSTEM_ACTOR;
         java.util.Set<String> permissions = new java.util.HashSet<>();
         org.springframework.security.core.Authentication auth =
                 org.springframework.security.core.context.SecurityContextHolder.getContext()
@@ -217,7 +218,7 @@ public class TimeEntryServiceImpl implements TimeEntryService {
         String finalRejectorUserId = rejectorUserId;
         java.util.Set<String> finalPermissions = permissions;
 
-        String auditActorId = SecurityContextHelper.getCurrentUsername().orElse("system");
+        String auditActorId = SecurityContextHelper.getCurrentUsername().orElse(SYSTEM_ACTOR);
 
         Map<String, TimeEntry> byId = fetchTimeEntriesById(timeEntryIds);
 

--- a/pos-people/src/main/java/com/positivity/people/internal/service/TimekeepingApprovalServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/TimekeepingApprovalServiceImpl.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class TimekeepingApprovalServiceImpl implements TimekeepingApprovalService {
+    private static final String TIME_PERIOD_NOT_FOUND_PREFIX = "TimePeriod not found: ";
 
     private final TimekeepingEntryRepository timekeepingEntryRepository;
     private final TimePeriodRepository timePeriodRepository;
@@ -70,7 +71,7 @@ public class TimekeepingApprovalServiceImpl implements TimekeepingApprovalServic
     public List<TimekeepingEntryDto> listTimekeepingEntries(UUID personId, UUID timePeriodId) {
         TimePeriod period = timePeriodRepository
                 .findById(timePeriodId)
-                .orElseThrow(() -> new EntityNotFoundException("TimePeriod not found: " + timePeriodId));
+                .orElseThrow(() -> new EntityNotFoundException(TIME_PERIOD_NOT_FOUND_PREFIX + timePeriodId));
         Instant start = toInstant(period.getStartDate());
         Instant end = toInstantEndOfDay(period.getEndDate());
         List<TimekeepingEntry> entries =
@@ -85,7 +86,7 @@ public class TimekeepingApprovalServiceImpl implements TimekeepingApprovalServic
     public TimePeriodApprovalDto getTimePeriodApproval(UUID personId, UUID timePeriodId) {
         TimePeriod period = timePeriodRepository
                 .findById(timePeriodId)
-                .orElseThrow(() -> new EntityNotFoundException("TimePeriod not found: " + timePeriodId));
+                .orElseThrow(() -> new EntityNotFoundException(TIME_PERIOD_NOT_FOUND_PREFIX + timePeriodId));
         Instant start = toInstant(period.getStartDate());
         Instant end = toInstantEndOfDay(period.getEndDate());
         List<TimekeepingEntry> entries =
@@ -126,7 +127,7 @@ public class TimekeepingApprovalServiceImpl implements TimekeepingApprovalServic
     public TimePeriodDecisionResponse approvePeriod(UUID timePeriodId, UUID personId) {
         TimePeriod period = timePeriodRepository
                 .findById(timePeriodId)
-                .orElseThrow(() -> new EntityNotFoundException("TimePeriod not found: " + timePeriodId));
+                .orElseThrow(() -> new EntityNotFoundException(TIME_PERIOD_NOT_FOUND_PREFIX + timePeriodId));
         Instant start = toInstant(period.getStartDate());
         Instant end = toInstantEndOfDay(period.getEndDate());
         List<TimekeepingEntry> pending =
@@ -152,7 +153,7 @@ public class TimekeepingApprovalServiceImpl implements TimekeepingApprovalServic
     public TimePeriodDecisionResponse rejectPeriod(UUID timePeriodId, UUID personId, String reason) {
         TimePeriod period = timePeriodRepository
                 .findById(timePeriodId)
-                .orElseThrow(() -> new EntityNotFoundException("TimePeriod not found: " + timePeriodId));
+                .orElseThrow(() -> new EntityNotFoundException(TIME_PERIOD_NOT_FOUND_PREFIX + timePeriodId));
         Instant start = toInstant(period.getStartDate());
         Instant end = toInstantEndOfDay(period.getEndDate());
         List<TimekeepingEntry> pending =

--- a/pos-people/src/main/java/com/positivity/people/internal/service/TimekeepingIngestionServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/TimekeepingIngestionServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class TimekeepingIngestionServiceImpl implements TimekeepingIngestionService {
+    private static final String SHOP_MANAGER_SOURCE = "shopmgr";
 
     private final Clock clock;
 
@@ -40,7 +41,7 @@ public class TimekeepingIngestionServiceImpl implements TimekeepingIngestionServ
         }
 
         boolean alreadyExists = timekeepingEntryRepository.existsByTenantIdAndSourceSystemAndSourceSessionId(
-                event.tenantId(), "shopmgr", event.sessionId());
+                event.tenantId(), SHOP_MANAGER_SOURCE, event.sessionId());
         if (alreadyExists) {
             log.debug(
                     "Duplicate work session ingestion ignored: tenantId={}, sessionId={}",
@@ -52,7 +53,7 @@ public class TimekeepingIngestionServiceImpl implements TimekeepingIngestionServ
         TimekeepingEntry entry = new TimekeepingEntry();
         entry.setTimekeepingEntryId(UUIDv7Generator.generate());
         entry.setTenantId(event.tenantId());
-        entry.setSourceSystem("shopmgr");
+        entry.setSourceSystem(SHOP_MANAGER_SOURCE);
         entry.setSourceSessionId(event.sessionId());
         entry.setEmployeeId(event.employeeId());
         entry.setSessionStartTime(event.startTime());
@@ -70,7 +71,7 @@ public class TimekeepingIngestionServiceImpl implements TimekeepingIngestionServ
         TimekeepingEntry correctionEntry = new TimekeepingEntry();
         correctionEntry.setTimekeepingEntryId(UUIDv7Generator.generate());
         correctionEntry.setTenantId(event.tenantId());
-        correctionEntry.setSourceSystem("shopmgr");
+        correctionEntry.setSourceSystem(SHOP_MANAGER_SOURCE);
         correctionEntry.setSourceSessionId(event.correctionId());
         correctionEntry.setOriginalSourceSessionId(event.originalSessionId());
         correctionEntry.setCorrectionId(event.correctionId());

--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class WorkSessionServiceImpl implements WorkSessionService {
+    private static final String SESSION_ID_REQUIRED = "sessionId must not be null";
 
     private final Clock clock;
 
@@ -115,7 +116,7 @@ public class WorkSessionServiceImpl implements WorkSessionService {
 
     @Override
     public BreakDto startBreak(@NonNull UUID sessionId) {
-        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(sessionId, SESSION_ID_REQUIRED);
         String resolvedActor = resolveActorFromSecurityContext();
 
         WorkSession session = workSessionRepository
@@ -146,7 +147,7 @@ public class WorkSessionServiceImpl implements WorkSessionService {
 
     @Override
     public BreakDto stopBreak(@NonNull UUID sessionId) {
-        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(sessionId, SESSION_ID_REQUIRED);
         String resolvedActor = resolveActorFromSecurityContext();
 
         WorkSessionBreak activeBreak = workSessionBreakRepository
@@ -161,7 +162,7 @@ public class WorkSessionServiceImpl implements WorkSessionService {
 
     @Override
     public WorkSessionDto submitSession(@NonNull UUID sessionId, @NonNull WorkSessionSubmitRequest request) {
-        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(sessionId, SESSION_ID_REQUIRED);
         Objects.requireNonNull(request, "request must not be null");
         String resolvedActor = resolveActorFromSecurityContext();
 

--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkorderEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkorderEventsListener.java
@@ -58,7 +58,7 @@ public class WorkorderEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "workorder")
+                        .tag("owner", OWNER)
                         .tag("entity", "workorder-events")
                         .register(registry);
     }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/CustomerEventsListener.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/CustomerEventsListener.java
@@ -58,7 +58,7 @@ public class CustomerEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "customer")
+                        .tag("owner", OWNER)
                         .tag("entity", "customer-events")
                         .register(registry);
     }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PeopleContactEventsListener.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PeopleContactEventsListener.java
@@ -71,7 +71,7 @@ public class PeopleContactEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people-contact")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-contact-events")
                         .register(registry);
     }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PeopleContactEventsListener.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PeopleContactEventsListener.java
@@ -43,6 +43,7 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @ConditionalOnProperty(prefix = "pos.security-service.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
+    private static final String PAYLOAD = "payload";
 
     static final String OWNER = "people-contact";
 
@@ -132,7 +133,7 @@ public class PeopleContactEventsListener {
 
     private void applyLinkUpdated(JsonNode envelope) {
         UserPersonLinkUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), UserPersonLinkUpdatedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), UserPersonLinkUpdatedV1.class);
         Optional<User> user = userRepository.findByUsername(payload.username());
         if (user.isEmpty()) {
             // Links can exist for people-module usernames that have no security account (or the
@@ -156,7 +157,7 @@ public class PeopleContactEventsListener {
 
     private void applyLinkRemoved(JsonNode envelope) {
         UserPersonLinkRemovedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), UserPersonLinkRemovedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), UserPersonLinkRemovedV1.class);
         userRepository.findByUsername(payload.username()).ifPresent(user -> {
             // Guard on the removed link's personId so a stale removal (redelivered after a new
             // link was applied) cannot clear the newer projection.
@@ -169,7 +170,7 @@ public class PeopleContactEventsListener {
     }
 
     private void applyPersonUpdated(JsonNode envelope) {
-        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonUpdatedV1.class);
+        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonUpdatedV1.class);
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
         ExtPersonReplica existing =
                 extPersonReplicaRepository.findById(payload.personId()).orElse(null);
@@ -194,7 +195,7 @@ public class PeopleContactEventsListener {
     }
 
     private void applyPersonDeleted(JsonNode envelope) {
-        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonDeletedV1.class);
+        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonDeletedV1.class);
         extPersonReplicaRepository.deleteById(payload.personId());
     }
 

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/UserServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/UserServiceImpl.java
@@ -24,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+    private static final String ROLE_NOT_FOUND_PREFIX = "Role not found: ";
+
     private final UserRepository userRepository;
 
     private final com.positivity.securityservice.internal.service.PeopleContactCommandEmitter
@@ -42,7 +44,7 @@ public class UserServiceImpl implements UserService {
         for (String roleName : roleNames) {
             Role role = roleRepository
                     .findByName(roleName)
-                    .orElseThrow(() -> new IllegalArgumentException("Role not found: " + roleName));
+                    .orElseThrow(() -> new IllegalArgumentException(ROLE_NOT_FOUND_PREFIX + roleName));
             roles.add(role);
         }
         User user = new User();
@@ -91,7 +93,7 @@ public class UserServiceImpl implements UserService {
         for (String roleName : roleNames) {
             Role role = roleRepository
                     .findByName(roleName)
-                    .orElseThrow(() -> new IllegalArgumentException("Role not found: " + roleName));
+                    .orElseThrow(() -> new IllegalArgumentException(ROLE_NOT_FOUND_PREFIX + roleName));
             roles.add(role);
         }
         user.setRoles(roles);
@@ -115,7 +117,7 @@ public class UserServiceImpl implements UserService {
             for (String roleName : request.getRoles()) {
                 Role role = roleRepository
                         .findByName(roleName)
-                        .orElseThrow(() -> new IllegalArgumentException("Role not found: " + roleName));
+                        .orElseThrow(() -> new IllegalArgumentException(ROLE_NOT_FOUND_PREFIX + roleName));
                 roles.add(role);
             }
             existingUser.setRoles(roles);

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/CustomerEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/CustomerEventsListener.java
@@ -58,7 +58,7 @@ public class CustomerEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "customer")
+                        .tag("owner", OWNER)
                         .tag("entity", "customer-events")
                         .register(registry);
     }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleContactEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleContactEventsListener.java
@@ -60,7 +60,7 @@ public class PeopleContactEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people-contact")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-contact-events")
                         .register(registry);
     }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleEventsListener.java
@@ -55,7 +55,7 @@ public class PeopleEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people")
+                        .tag("owner", OWNER)
                         .tag("entity", "people-events")
                         .register(registry);
     }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/VehicleEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/VehicleEventsListener.java
@@ -57,7 +57,7 @@ public class VehicleEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "vehicle")
+                        .tag("owner", OWNER)
                         .tag("entity", "vehicle-events")
                         .register(registry);
     }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/EdiwheelC12MktCatCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/EdiwheelC12MktCatCodec.java
@@ -36,6 +36,9 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @RequiredArgsConstructor
 public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
+    private static final String APPLICATION_JSON = "application/json";
+
+    private static final String TREAD_DESIGN_VARIANTS_PATH = "/treadDesignVariants/";
 
     private final ObjectMapper objectMapper;
 
@@ -60,7 +63,7 @@ public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
     /** Lists every tread design variant the catalogue publishes. */
     @NonNull
     public SupplierRequestSpec buildVariantListRequest() {
-        return new SupplierRequestSpec("GET", "/treadDesignVariants/", Map.of(), null, null, "application/json", true);
+        return new SupplierRequestSpec("GET", TREAD_DESIGN_VARIANTS_PATH, Map.of(), null, null, APPLICATION_JSON, true);
     }
 
     /** Reads one variant's detail. */
@@ -68,11 +71,11 @@ public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
     public SupplierRequestSpec buildVariantDetailRequest(@NonNull String variantId) {
         return new SupplierRequestSpec(
                 "GET",
-                "/treadDesignVariants/" + encode(variantId) + "/",
+                TREAD_DESIGN_VARIANTS_PATH + encode(variantId) + "/",
                 Map.of(),
                 null,
                 null,
-                "application/json",
+                APPLICATION_JSON,
                 true);
     }
 
@@ -81,11 +84,11 @@ public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
     public SupplierRequestSpec buildVariantImagesRequest(@NonNull String variantId) {
         return new SupplierRequestSpec(
                 "GET",
-                "/treadDesignVariants/" + encode(variantId) + "/images",
+                TREAD_DESIGN_VARIANTS_PATH + encode(variantId) + "/images",
                 Map.of(),
                 null,
                 null,
-                "application/json",
+                APPLICATION_JSON,
                 true);
     }
 
@@ -94,11 +97,11 @@ public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
     public SupplierRequestSpec buildVariantLanguageDataRequest(@NonNull String variantId) {
         return new SupplierRequestSpec(
                 "GET",
-                "/treadDesignVariants/" + encode(variantId) + "/languageDependentData",
+                TREAD_DESIGN_VARIANTS_PATH + encode(variantId) + "/languageDependentData",
                 Map.of(),
                 null,
                 null,
-                "application/json",
+                APPLICATION_JSON,
                 true);
     }
 
@@ -115,7 +118,7 @@ public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
         query.put("callbackUrl", callbackUrl);
         query.put("event", event);
         return new SupplierRequestSpec(
-                "POST", "/treadDesignVariants/subscribe/", query, "{}", "application/json", "application/json", false);
+                "POST", "/treadDesignVariants/subscribe/", query, "{}", APPLICATION_JSON, APPLICATION_JSON, false);
     }
 
     /** Cancels a change subscription. */
@@ -125,13 +128,13 @@ public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
         query.put("callbackUrl", callbackUrl);
         query.put("event", event);
         return new SupplierRequestSpec(
-                "DELETE", "/treadDesignVariants/subscribe/", query, null, null, "application/json", true);
+                "DELETE", "/treadDesignVariants/subscribe/", query, null, null, APPLICATION_JSON, true);
     }
 
     /** Lists supplier master data. */
     @NonNull
     public SupplierRequestSpec buildSupplierListRequest() {
-        return new SupplierRequestSpec("GET", "/suppliers/", Map.of(), null, null, "application/json", true);
+        return new SupplierRequestSpec("GET", "/suppliers/", Map.of(), null, null, APPLICATION_JSON, true);
     }
 
     /**

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SWorkorderAuthCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SWorkorderAuthCodec.java
@@ -51,6 +51,7 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @RequiredArgsConstructor
 public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
+    private static final String APPLICATION_JSON = "application/json";
 
     /**
      * Vendor words that mean the fleet said yes.
@@ -131,8 +132,8 @@ public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
                 "/api/v1/workOrders",
                 partnerQuery(partnerId),
                 objectMapper.writeValueAsString(body),
-                "application/json",
-                "application/json",
+                APPLICATION_JSON,
+                APPLICATION_JSON,
                 false,
                 apiVersionHeader(apiMajorVersion));
     }
@@ -153,8 +154,8 @@ public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
                 "/api/v1/workOrders/" + encodePathSegment(vendorAuthorizationId) + "/approve",
                 partnerQuery(partnerId),
                 "{}",
-                "application/json",
-                "application/json",
+                APPLICATION_JSON,
+                APPLICATION_JSON,
                 true,
                 apiVersionHeader(apiMajorVersion));
     }
@@ -162,7 +163,7 @@ public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
     /** Builds a re-read of an accepted-but-undecided authorization, from the 202's {@code Location}. */
     @NonNull
     public SupplierRequestSpec buildPollRequest(@NonNull String pollPath, @NonNull String partnerId) {
-        return new SupplierRequestSpec("GET", pollPath, partnerQuery(partnerId), null, null, "application/json", true);
+        return new SupplierRequestSpec("GET", pollPath, partnerQuery(partnerId), null, null, APPLICATION_JSON, true);
     }
 
     /** Builds the vehicle lookup. */
@@ -174,7 +175,7 @@ public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
                 partnerQuery(partnerId),
                 null,
                 null,
-                "application/json",
+                APPLICATION_JSON,
                 true);
     }
 
@@ -182,14 +183,14 @@ public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
     @NonNull
     public SupplierRequestSpec buildContractLookup(@NonNull String partnerId) {
         return new SupplierRequestSpec(
-                "GET", "/api/v1/contracts", partnerQuery(partnerId), null, null, "application/json", true);
+                "GET", "/api/v1/contracts", partnerQuery(partnerId), null, null, APPLICATION_JSON, true);
     }
 
     /** Builds the policy lookup. */
     @NonNull
     public SupplierRequestSpec buildPolicyLookup(@NonNull String partnerId) {
         return new SupplierRequestSpec(
-                "GET", "/api/v1/policies", partnerQuery(partnerId), null, null, "application/json", true);
+                "GET", "/api/v1/policies", partnerQuery(partnerId), null, null, APPLICATION_JSON, true);
     }
 
     /**

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierYamlBootstrap.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierYamlBootstrap.java
@@ -71,6 +71,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class SupplierYamlBootstrap implements ApplicationRunner {
+    private static final String PROFILE_PREFIX = "profile '";
 
     /** Audit actor of YAML reconciliation writes (ADR-0050 §6). */
     public static final String BOOTSTRAP_ACTOR = "system:yaml-bootstrap";
@@ -298,7 +299,7 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
                 throw invalid("supplier.profiles key '" + spec.key() + "' appears more than once");
             }
             if (spec.displayName() == null || spec.displayName().isBlank()) {
-                throw invalid("profile '" + spec.key() + "': displayName must not be blank");
+                throw invalid(PROFILE_PREFIX + spec.key() + "': displayName must not be blank");
             }
             validateProtocolDefaults(spec);
             Set<String> authNames = validateAuthSpecs(spec);
@@ -314,15 +315,15 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
         Integer connect = spec.protocolDefaults().connectTimeoutMs();
         Integer read = spec.protocolDefaults().readTimeoutMs();
         if (connect != null && connect <= 0) {
-            throw invalid("profile '" + spec.key() + "': protocolDefaults.connectTimeoutMs must be > 0");
+            throw invalid(PROFILE_PREFIX + spec.key() + "': protocolDefaults.connectTimeoutMs must be > 0");
         }
         if (read != null && read <= 0) {
-            throw invalid("profile '" + spec.key() + "': protocolDefaults.readTimeoutMs must be > 0");
+            throw invalid(PROFILE_PREFIX + spec.key() + "': protocolDefaults.readTimeoutMs must be > 0");
         }
         var retry = spec.protocolDefaults().retry();
         if (retry != null) {
             if (retry.maxAttempts() != null && retry.maxAttempts() < 0) {
-                throw invalid("profile '" + spec.key() + "': protocolDefaults.retry.maxAttempts must be >= 0");
+                throw invalid(PROFILE_PREFIX + spec.key() + "': protocolDefaults.retry.maxAttempts must be >= 0");
             }
             if (retry.backoff() != null) {
                 parseBackoffOrInvalid(spec.key(), retry.backoff());
@@ -336,16 +337,16 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
         List<AuthSpec> authSpecs = spec.auth() == null ? List.of() : spec.auth();
         for (AuthSpec authSpec : authSpecs) {
             if (authSpec.name() == null || authSpec.name().isBlank()) {
-                throw invalid("profile '" + spec.key() + "': auth[].name must not be blank");
+                throw invalid(PROFILE_PREFIX + spec.key() + "': auth[].name must not be blank");
             }
             if (!authNames.add(authSpec.name())) {
-                throw invalid("profile '" + spec.key() + "': auth config name '" + authSpec.name()
+                throw invalid(PROFILE_PREFIX + spec.key() + "': auth config name '" + authSpec.name()
                         + "' appears more than once");
             }
             SupplierAuthType type = parseEnumOrInvalid(
                     SupplierAuthType::valueOf,
                     authSpec.type(),
-                    "profile '" + spec.key() + "', auth '" + authSpec.name() + "': type '" + authSpec.type()
+                    PROFILE_PREFIX + spec.key() + "', auth '" + authSpec.name() + "': type '" + authSpec.type()
                             + "' is not a canonical auth type");
             try {
                 // Reuses the admin-side rules: required refs present, scheme:key shape in a
@@ -366,7 +367,7 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
                                 authSpec.bearerTokenRef()),
                         secretSchemeRegistry.supportedSchemes());
             } catch (SupplierValidationException ex) {
-                throw invalid("profile '" + spec.key() + "', auth '" + authSpec.name() + "': " + ex.getMessage());
+                throw invalid(PROFILE_PREFIX + spec.key() + "', auth '" + authSpec.name() + "': " + ex.getMessage());
             }
         }
         return authNames;
@@ -379,21 +380,21 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
         var billing = spec.accounts().billing();
         if (billing != null
                 && (billing.accountNumber() == null || billing.accountNumber().isBlank())) {
-            throw invalid("profile '" + spec.key() + "': accounts.billing.accountNumber must not be blank");
+            throw invalid(PROFILE_PREFIX + spec.key() + "': accounts.billing.accountNumber must not be blank");
         }
         Set<UUID> locations = new HashSet<>();
         List<Delivery> deliveries =
                 spec.accounts().delivery() == null ? List.of() : spec.accounts().delivery();
         for (Delivery delivery : deliveries) {
             if (delivery.locationId() == null) {
-                throw invalid("profile '" + spec.key() + "': accounts.delivery[].locationId is required");
+                throw invalid(PROFILE_PREFIX + spec.key() + "': accounts.delivery[].locationId is required");
             }
             if (delivery.accountNumber() == null || delivery.accountNumber().isBlank()) {
-                throw invalid("profile '" + spec.key() + "': accounts.delivery[].accountNumber must not be blank"
+                throw invalid(PROFILE_PREFIX + spec.key() + "': accounts.delivery[].accountNumber must not be blank"
                         + " (location " + delivery.locationId() + ")");
             }
             if (!locations.add(delivery.locationId())) {
-                throw invalid("profile '" + spec.key() + "': location " + delivery.locationId()
+                throw invalid(PROFILE_PREFIX + spec.key() + "': location " + delivery.locationId()
                         + " has more than one delivery account (one per location, ADR-0050 §5)");
             }
         }
@@ -405,11 +406,11 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
                 spec.protocolDefaults() == null ? null : spec.protocolDefaults().family();
         Set<String> capabilities = new HashSet<>();
         for (BindingSpec binding : bindingSpecs) {
-            String where = "profile '" + spec.key() + "', binding '" + binding.capability() + "': ";
+            String where = PROFILE_PREFIX + spec.key() + "', binding '" + binding.capability() + "': ";
             parseEnumOrInvalid(
                     SupplierCapability::valueOf,
                     binding.capability(),
-                    "profile '" + spec.key() + "': binding capability '" + binding.capability()
+                    PROFILE_PREFIX + spec.key() + "': binding capability '" + binding.capability()
                             + "' is not a canonical capability key");
             if (!capabilities.add(binding.capability())) {
                 throw invalid(where + "capability bound more than once (at most one binding per capability,"
@@ -487,7 +488,7 @@ public class SupplierYamlBootstrap implements ApplicationRunner {
         parseEnumOrInvalid(
                 RetryBackoff::valueOf,
                 backoff,
-                "profile '" + profileKey + "': protocolDefaults.retry.backoff '" + backoff
+                PROFILE_PREFIX + profileKey + "': protocolDefaults.retry.backoff '" + backoff
                         + "' is not FIXED or EXPONENTIAL");
     }
 

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
@@ -35,6 +35,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
  */
 @RestControllerAdvice(basePackages = "com.positivity.supplier.internal.controller")
 public class SupplierExceptionHandler {
+    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
 
     private static final Logger log = LoggerFactory.getLogger(SupplierExceptionHandler.class);
     private static final String X_CORRELATION_ID = "X-Correlation-Id";
@@ -228,7 +229,7 @@ public class SupplierExceptionHandler {
         headers.add(X_CORRELATION_ID, correlationId);
         return new ResponseEntity<>(
                 ApiError.withFieldErrors(
-                        "VALIDATION_ERROR",
+                        VALIDATION_ERROR,
                         "Request validation failed",
                         HttpStatus.BAD_REQUEST.value(),
                         Instant.now(clock).toString(),
@@ -241,7 +242,7 @@ public class SupplierExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiError> handleConstraintViolation(
             ConstraintViolationException ex, HttpServletRequest request) {
-        return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
+        return build(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, ex.getMessage(), request);
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
@@ -277,7 +278,7 @@ public class SupplierExceptionHandler {
         for (Throwable cause = ex.getCause(); cause != null; cause = cause.getCause()) {
             if (cause instanceof IllegalArgumentException || cause instanceof NullPointerException) {
                 String message = cause.getMessage() == null ? "Request validation failed" : cause.getMessage();
-                return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request);
+                return build(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, message, request);
             }
         }
         return build(HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "Request body could not be parsed", request);
@@ -285,7 +286,7 @@ public class SupplierExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
-        return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
+        return build(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, ex.getMessage(), request);
     }
 
     /** {@code @PreAuthorize} denials must not fall into the 500 catch-all below. */

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/service/AuthReferenceRules.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/service/AuthReferenceRules.java
@@ -23,6 +23,19 @@ import org.jspecify.annotations.Nullable;
  * unresolvable references out of the database entirely.
  */
 public final class AuthReferenceRules {
+    private static final String USERNAME_REF = "usernameRef";
+
+    private static final String TOKEN_URL_REF = "tokenUrlRef";
+
+    private static final String PASSWORD_REF = "passwordRef";
+
+    private static final String CLIENT_SECRET_REF = "clientSecretRef";
+
+    private static final String CLIENT_ID_REF = "clientIdRef";
+
+    private static final String BEARER_TOKEN_REF = "bearerTokenRef";
+
+    private static final String API_KEY_REF = "apiKeyRef";
 
     private AuthReferenceRules() {
         // static rules
@@ -44,31 +57,31 @@ public final class AuthReferenceRules {
         Objects.requireNonNull(supportedSchemes, "supportedSchemes must not be null");
         switch (request.type()) {
             case BASIC_PLUS_APIKEY -> {
-                requireRef(request.type(), "usernameRef", request.usernameRef(), supportedSchemes);
-                requireRef(request.type(), "passwordRef", request.passwordRef(), supportedSchemes);
-                requireRef(request.type(), "apiKeyRef", request.apiKeyRef(), supportedSchemes);
-                forbidRef(request.type(), "tokenUrlRef", request.tokenUrlRef());
-                forbidRef(request.type(), "clientIdRef", request.clientIdRef());
-                forbidRef(request.type(), "clientSecretRef", request.clientSecretRef());
-                forbidRef(request.type(), "bearerTokenRef", request.bearerTokenRef());
+                requireRef(request.type(), USERNAME_REF, request.usernameRef(), supportedSchemes);
+                requireRef(request.type(), PASSWORD_REF, request.passwordRef(), supportedSchemes);
+                requireRef(request.type(), API_KEY_REF, request.apiKeyRef(), supportedSchemes);
+                forbidRef(request.type(), TOKEN_URL_REF, request.tokenUrlRef());
+                forbidRef(request.type(), CLIENT_ID_REF, request.clientIdRef());
+                forbidRef(request.type(), CLIENT_SECRET_REF, request.clientSecretRef());
+                forbidRef(request.type(), BEARER_TOKEN_REF, request.bearerTokenRef());
             }
             case OAUTH2_CLIENT_CREDENTIALS -> {
-                requireRef(request.type(), "tokenUrlRef", request.tokenUrlRef(), supportedSchemes);
-                requireRef(request.type(), "clientIdRef", request.clientIdRef(), supportedSchemes);
-                requireRef(request.type(), "clientSecretRef", request.clientSecretRef(), supportedSchemes);
-                forbidRef(request.type(), "usernameRef", request.usernameRef());
-                forbidRef(request.type(), "passwordRef", request.passwordRef());
-                forbidRef(request.type(), "apiKeyRef", request.apiKeyRef());
-                forbidRef(request.type(), "bearerTokenRef", request.bearerTokenRef());
+                requireRef(request.type(), TOKEN_URL_REF, request.tokenUrlRef(), supportedSchemes);
+                requireRef(request.type(), CLIENT_ID_REF, request.clientIdRef(), supportedSchemes);
+                requireRef(request.type(), CLIENT_SECRET_REF, request.clientSecretRef(), supportedSchemes);
+                forbidRef(request.type(), USERNAME_REF, request.usernameRef());
+                forbidRef(request.type(), PASSWORD_REF, request.passwordRef());
+                forbidRef(request.type(), API_KEY_REF, request.apiKeyRef());
+                forbidRef(request.type(), BEARER_TOKEN_REF, request.bearerTokenRef());
             }
             case BEARER -> {
-                requireRef(request.type(), "bearerTokenRef", request.bearerTokenRef(), supportedSchemes);
-                forbidRef(request.type(), "usernameRef", request.usernameRef());
-                forbidRef(request.type(), "passwordRef", request.passwordRef());
-                forbidRef(request.type(), "apiKeyRef", request.apiKeyRef());
-                forbidRef(request.type(), "tokenUrlRef", request.tokenUrlRef());
-                forbidRef(request.type(), "clientIdRef", request.clientIdRef());
-                forbidRef(request.type(), "clientSecretRef", request.clientSecretRef());
+                requireRef(request.type(), BEARER_TOKEN_REF, request.bearerTokenRef(), supportedSchemes);
+                forbidRef(request.type(), USERNAME_REF, request.usernameRef());
+                forbidRef(request.type(), PASSWORD_REF, request.passwordRef());
+                forbidRef(request.type(), API_KEY_REF, request.apiKeyRef());
+                forbidRef(request.type(), TOKEN_URL_REF, request.tokenUrlRef());
+                forbidRef(request.type(), CLIENT_ID_REF, request.clientIdRef());
+                forbidRef(request.type(), CLIENT_SECRET_REF, request.clientSecretRef());
             }
         }
     }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/service/SupplierExchangeAuditServiceImpl.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/service/SupplierExchangeAuditServiceImpl.java
@@ -53,6 +53,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 public class SupplierExchangeAuditServiceImpl implements SupplierExchangeAuditService {
+    private static final String EXCHANGE_AUDIT_ID_REQUIRED = "exchangeAuditId must not be null";
 
     private final ExchangeAuditRepository exchangeAuditRepository;
     private final ExchangeAuditRawPayloadRepository rawPayloadRepository;
@@ -112,7 +113,7 @@ public class SupplierExchangeAuditServiceImpl implements SupplierExchangeAuditSe
     @Transactional(readOnly = true)
     @NonNull
     public ExchangeAuditSummary getExchange(@NonNull UUID exchangeAuditId) {
-        Objects.requireNonNull(exchangeAuditId, "exchangeAuditId must not be null");
+        Objects.requireNonNull(exchangeAuditId, EXCHANGE_AUDIT_ID_REQUIRED);
         return toSummary(requireMetadata(exchangeAuditId));
     }
 
@@ -120,7 +121,7 @@ public class SupplierExchangeAuditServiceImpl implements SupplierExchangeAuditSe
     @Transactional(readOnly = true)
     @NonNull
     public PagedResponse<ExchangeAuditAccessView> listAccesses(@NonNull UUID exchangeAuditId, int page, int size) {
-        Objects.requireNonNull(exchangeAuditId, "exchangeAuditId must not be null");
+        Objects.requireNonNull(exchangeAuditId, EXCHANGE_AUDIT_ID_REQUIRED);
         // Deliberately no existence check on the exchange: access records outlive nothing here, but they
         // are keyed by a plain UUID with no foreign key, so an exchange row that was never written and
         // one that has no reads are indistinguishable — and both correctly answer "nobody read it".
@@ -159,7 +160,7 @@ public class SupplierExchangeAuditServiceImpl implements SupplierExchangeAuditSe
     @Transactional(noRollbackFor = PayloadUnreadableException.class)
     @NonNull
     public ExchangeAuditPayloadView readPayload(@NonNull UUID exchangeAuditId) {
-        Objects.requireNonNull(exchangeAuditId, "exchangeAuditId must not be null");
+        Objects.requireNonNull(exchangeAuditId, EXCHANGE_AUDIT_ID_REQUIRED);
 
         // 1. Metadata first, so the access record can name the profile and capability even when the
         //    content turns out to be unreadable. Nothing here decrypts.

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/service/SupplierProfileAdminServiceImpl.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/service/SupplierProfileAdminServiceImpl.java
@@ -52,6 +52,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminService {
+    private static final String REQUEST_REQUIRED = "request must not be null";
+
+    private static final String NOT_ON_VENDOR_PROFILE = " does not exist on vendor profile ";
 
     private final SupplierProfileRepository profileRepository;
     private final SupplierAuthConfigRepository authConfigRepository;
@@ -82,7 +85,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @Override
     @NonNull
     public VendorProfileView createProfile(@NonNull VendorProfileRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         requireSupplierRefFree(request.supplierRef(), null);
         SupplierProfileEntity profile = new SupplierProfileEntity();
         applyProfile(profile, request);
@@ -93,7 +96,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @Override
     @NonNull
     public VendorProfileView updateProfile(@NonNull UUID vendorProfileId, @NonNull VendorProfileRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         SupplierProfileEntity profile = loadAdminManagedProfile(vendorProfileId);
         requireSupplierRefFree(request.supplierRef(), vendorProfileId);
         applyProfile(profile, request);
@@ -141,7 +144,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @Override
     @NonNull
     public AuthConfigView createAuthConfig(@NonNull UUID vendorProfileId, @NonNull AuthConfigRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         loadAdminManagedProfile(vendorProfileId);
         AuthReferenceRules.validate(request, secretSchemeRegistry.supportedSchemes());
         if (authConfigRepository
@@ -161,7 +164,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @NonNull
     public AuthConfigView updateAuthConfig(
             @NonNull UUID vendorProfileId, @NonNull UUID authConfigId, @NonNull AuthConfigRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         loadAdminManagedProfile(vendorProfileId);
         AuthReferenceRules.validate(request, secretSchemeRegistry.supportedSchemes());
         SupplierAuthConfigEntity authConfig = loadAuthConfig(vendorProfileId, authConfigId);
@@ -221,7 +224,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @NonNull
     public CommercialAccountView createAccount(
             @NonNull UUID vendorProfileId, @NonNull CommercialAccountRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         loadAdminManagedProfile(vendorProfileId);
         requireAccountSlotFree(vendorProfileId, request, null);
         SupplierAccountEntity account = new SupplierAccountEntity();
@@ -234,7 +237,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @NonNull
     public CommercialAccountView updateAccount(
             @NonNull UUID vendorProfileId, @NonNull UUID accountId, @NonNull CommercialAccountRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         loadAdminManagedProfile(vendorProfileId);
         SupplierAccountEntity account = loadAccount(vendorProfileId, accountId);
         requireAccountSlotFree(vendorProfileId, request, accountId);
@@ -263,7 +266,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @Override
     @NonNull
     public EndpointBindingView createBinding(@NonNull UUID vendorProfileId, @NonNull EndpointBindingRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         loadAdminManagedProfile(vendorProfileId);
         SupplierCapability capability = parseCapability(request.capability());
         ProtocolFamily family = parseProtocolFamily(request.protocolFamily());
@@ -286,7 +289,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
     @NonNull
     public EndpointBindingView updateBinding(
             @NonNull UUID vendorProfileId, @NonNull UUID bindingId, @NonNull EndpointBindingRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(request, REQUEST_REQUIRED);
         loadAdminManagedProfile(vendorProfileId);
         SupplierCapability capability = parseCapability(request.capability());
         ProtocolFamily family = parseProtocolFamily(request.protocolFamily());
@@ -364,7 +367,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
                 .findByIdAndVendorProfileId(authConfigId, vendorProfileId)
                 .orElseThrow(() -> new SupplierNotFoundException(
                         SupplierNotFoundException.AUTH_CONFIG_NOT_FOUND,
-                        "Auth config " + authConfigId + " does not exist on vendor profile " + vendorProfileId));
+                        "Auth config " + authConfigId + NOT_ON_VENDOR_PROFILE + vendorProfileId));
     }
 
     @NonNull
@@ -374,7 +377,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
                 .findByIdAndVendorProfileId(accountId, vendorProfileId)
                 .orElseThrow(() -> new SupplierNotFoundException(
                         SupplierNotFoundException.ACCOUNT_NOT_FOUND,
-                        "Commercial account " + accountId + " does not exist on vendor profile " + vendorProfileId));
+                        "Commercial account " + accountId + NOT_ON_VENDOR_PROFILE + vendorProfileId));
     }
 
     @NonNull
@@ -384,7 +387,7 @@ public class SupplierProfileAdminServiceImpl implements SupplierProfileAdminServ
                 .findByIdAndVendorProfileId(bindingId, vendorProfileId)
                 .orElseThrow(() -> new SupplierNotFoundException(
                         SupplierNotFoundException.BINDING_NOT_FOUND,
-                        "Endpoint binding " + bindingId + " does not exist on vendor profile " + vendorProfileId));
+                        "Endpoint binding " + bindingId + NOT_ON_VENDOR_PROFILE + vendorProfileId));
     }
 
     /**

--- a/pos-vehicle-reference-nhtsa/src/main/java/com/positivity/nhtsa/internal/service/VehicleReferenceService.java
+++ b/pos-vehicle-reference-nhtsa/src/main/java/com/positivity/nhtsa/internal/service/VehicleReferenceService.java
@@ -19,6 +19,10 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 @Service
 public class VehicleReferenceService {
+    private static final String RESULTS = "Results";
+
+    private static final String JSON_FORMAT_QUERY = "?format=json";
+
     private final Clock clock;
 
     private static final Duration CACHE_EXPIRY = Duration.ofHours(24);
@@ -42,7 +46,7 @@ public class VehicleReferenceService {
         String response = restClient.get().uri(url).retrieve().body(String.class);
         try {
             JsonNode root = objectMapper.readTree(response);
-            JsonNode results = root.get("Results");
+            JsonNode results = root.get(RESULTS);
             vehicleVariableRepository.deleteAll();
             for (JsonNode node : results) {
                 VehicleVariable variable = new VehicleVariable();
@@ -62,11 +66,11 @@ public class VehicleReferenceService {
         if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
-        String url = NHTSA_API_BASE + "/GetVehicleVariableValuesList/" + variableId + "?format=json";
+        String url = NHTSA_API_BASE + "/GetVehicleVariableValuesList/" + variableId + JSON_FORMAT_QUERY;
         String response = restClient.get().uri(url).retrieve().body(String.class);
         try {
             JsonNode root = objectMapper.readTree(response);
-            JsonNode results = root.get("Results");
+            JsonNode results = root.get(RESULTS);
             vehicleVariableValueRepository.deleteAll(cached);
             for (JsonNode node : results) {
                 VehicleVariableValue value = new VehicleVariableValue();
@@ -91,7 +95,7 @@ public class VehicleReferenceService {
         String response = restClient.get().uri(url).retrieve().body(String.class);
         try {
             JsonNode root = objectMapper.readTree(response);
-            JsonNode results = root.get("Results");
+            JsonNode results = root.get(RESULTS);
             manufacturerRepository.deleteAll();
             for (JsonNode node : results) {
                 Manufacturer m = new Manufacturer();
@@ -116,11 +120,11 @@ public class VehicleReferenceService {
         if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
-        String url = NHTSA_API_BASE + "/GetMakeForManufacturer/" + manufacturerId + "?format=json";
+        String url = NHTSA_API_BASE + "/GetMakeForManufacturer/" + manufacturerId + JSON_FORMAT_QUERY;
         String response = restClient.get().uri(url).retrieve().body(String.class);
         try {
             JsonNode root = objectMapper.readTree(response);
-            JsonNode results = root.get("Results");
+            JsonNode results = root.get(RESULTS);
             makeRepository.deleteAll(cached);
             for (JsonNode node : results) {
                 Make make = new Make();
@@ -146,11 +150,11 @@ public class VehicleReferenceService {
         if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
-        String url = NHTSA_API_BASE + "/GetModelsForMakeId/" + makeId + "?format=json";
+        String url = NHTSA_API_BASE + "/GetModelsForMakeId/" + makeId + JSON_FORMAT_QUERY;
         String response = restClient.get().uri(url).retrieve().body(String.class);
         try {
             JsonNode root = objectMapper.readTree(response);
-            JsonNode results = root.get("Results");
+            JsonNode results = root.get(RESULTS);
             modelRepository.deleteAll(cached);
             for (JsonNode node : results) {
                 Model model = new Model();
@@ -176,11 +180,11 @@ public class VehicleReferenceService {
         if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
-        String url = NHTSA_API_BASE + "/GetVehicleTypesForMakeId/" + makeId + "?format=json";
+        String url = NHTSA_API_BASE + "/GetVehicleTypesForMakeId/" + makeId + JSON_FORMAT_QUERY;
         String response = restClient.get().uri(url).retrieve().body(String.class);
         try {
             JsonNode root = objectMapper.readTree(response);
-            JsonNode results = root.get("Results");
+            JsonNode results = root.get(RESULTS);
             vehicleTypeRepository.deleteAll(cached);
             for (JsonNode node : results) {
                 VehicleType vt = new VehicleType();

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/client/InvoiceClientImpl.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/client/InvoiceClientImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.warranty.internal.client;
 
+import com.positivity.security.common.GatewaySecurityConstants;
 import com.positivity.warranty.internal.exception.WarrantyIntegrationException;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -56,8 +57,8 @@ public class InvoiceClientImpl implements InvoiceClient {
             InvoiceDetailsWire response = restClient
                     .get()
                     .uri(basePath + "/{invoiceId}", invoiceId)
-                    .header("X-User", SERVICE_USER)
-                    .header("X-Authorities", AUTHORITIES)
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, AUTHORITIES)
                     .retrieve()
                     .body(InvoiceDetailsWire.class);
             if (response == null) {
@@ -104,8 +105,8 @@ public class InvoiceClientImpl implements InvoiceClient {
             response = restClient
                     .get()
                     .uri(basePath + "/{invoiceId}", invoiceId)
-                    .header("X-User", SERVICE_USER)
-                    .header("X-Authorities", AUTHORITIES)
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, AUTHORITIES)
                     .retrieve()
                     .body(InvoiceDetailsWire.class);
         } catch (RestClientResponseException ex) {
@@ -141,8 +142,8 @@ public class InvoiceClientImpl implements InvoiceClient {
             List<RefundEntry> refunds = restClient
                     .get()
                     .uri(basePath + "/{invoiceId}/refunds", invoiceId)
-                    .header("X-User", SERVICE_USER)
-                    .header("X-Authorities", AUTHORITIES)
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, AUTHORITIES)
                     .retrieve()
                     .body(new ParameterizedTypeReference<List<RefundEntry>>() {});
             return Optional.of(refunds != null ? refunds : List.of());
@@ -177,8 +178,8 @@ public class InvoiceClientImpl implements InvoiceClient {
             response = restClient
                     .post()
                     .uri(basePath + "/{invoiceId}/adjustments", invoiceId)
-                    .header("X-User", SERVICE_USER)
-                    .header("X-Authorities", AUTHORITIES)
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, AUTHORITIES)
                     .body(body)
                     .retrieve()
                     .body(InvoiceDetailsWire.class);
@@ -224,8 +225,8 @@ public class InvoiceClientImpl implements InvoiceClient {
             response = restClient
                     .post()
                     .uri(basePath + "/{invoiceId}/payments/{paymentId}/refunds", invoiceId, paymentId)
-                    .header("X-User", SERVICE_USER)
-                    .header("X-Authorities", REFUND_AUTHORITIES)
+                    .header(GatewaySecurityConstants.HEADER_USER, SERVICE_USER)
+                    .header(GatewaySecurityConstants.HEADER_AUTHORITIES, REFUND_AUTHORITIES)
                     .body(body)
                     .retrieve()
                     .body(RefundResponseWire.class);

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/exception/WarrantyExceptionHandler.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/exception/WarrantyExceptionHandler.java
@@ -28,6 +28,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
  */
 @RestControllerAdvice(basePackages = "com.positivity.warranty.internal.controller")
 public class WarrantyExceptionHandler {
+    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
 
     private static final Logger log = LoggerFactory.getLogger(WarrantyExceptionHandler.class);
     private static final String X_CORRELATION_ID = "X-Correlation-Id";
@@ -93,7 +94,7 @@ public class WarrantyExceptionHandler {
         headers.add(X_CORRELATION_ID, correlationId);
         return new ResponseEntity<>(
                 ApiError.withFieldErrors(
-                        "VALIDATION_ERROR",
+                        VALIDATION_ERROR,
                         "Request validation failed",
                         HttpStatus.BAD_REQUEST.value(),
                         Instant.now(clock).toString(),
@@ -106,7 +107,7 @@ public class WarrantyExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiError> handleConstraintViolation(
             ConstraintViolationException ex, HttpServletRequest request) {
-        return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
+        return build(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, ex.getMessage(), request);
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
@@ -137,7 +138,7 @@ public class WarrantyExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
-        return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
+        return build(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, ex.getMessage(), request);
     }
 
     /** {@code @PreAuthorize} denials must not fall into the 500 catch-all below. */

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/CatalogEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/CatalogEventsListener.java
@@ -62,7 +62,7 @@ public class CatalogEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "catalog")
+                        .tag("owner", OWNER)
                         .tag("entity", "catalog-events")
                         .register(registry);
     }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/EligibilityServiceImpl.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/EligibilityServiceImpl.java
@@ -55,6 +55,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class EligibilityServiceImpl implements EligibilityService {
+    private static final String POLICY_MATCH = "policyMatch";
 
     static final String CLAIM_NOT_FOUND_CODE = "WARRANTY_CLAIM_NOT_FOUND";
 
@@ -103,7 +104,7 @@ public class EligibilityServiceImpl implements EligibilityService {
             if (candidates.isEmpty()) {
                 // Missing product facts (catalog unreachable) mean we cannot prove no policy
                 // applies — indeterminate rather than a hard fail.
-                reasons.add(reason("policyMatch", required, "none found", facts.incomplete() ? null : Boolean.FALSE));
+                reasons.add(reason(POLICY_MATCH, required, "none found", facts.incomplete() ? null : Boolean.FALSE));
             } else {
                 int topRank = specificityRank(candidates.get(0).getAppliesToType());
                 List<WarrantyPolicy> winners = candidates.stream()
@@ -115,7 +116,7 @@ public class EligibilityServiceImpl implements EligibilityService {
                     // the wrong policy, so the match is indeterminate rather than a silent
                     // specificity downgrade.
                     reasons.add(reason(
-                            "policyMatch",
+                            POLICY_MATCH,
                             required,
                             "product facts unavailable (pos-catalog unreachable); a more specific"
                                     + " policy may govern",
@@ -124,7 +125,7 @@ public class EligibilityServiceImpl implements EligibilityService {
                     // Specificity tie: no policy governs until a human resolves the ambiguity —
                     // never adjudicate terms or freeze amounts from an arbitrary tie-break.
                     reasons.add(reason(
-                            "policyMatch",
+                            POLICY_MATCH,
                             required,
                             "ambiguous — multiple policies tie at the same specificity: "
                                     + winners.stream()
@@ -134,7 +135,7 @@ public class EligibilityServiceImpl implements EligibilityService {
                 } else {
                     policy = winners.get(0);
                     reasons.add(reason(
-                            "policyMatch", required, policy.getName() + " (" + policy.getId() + ")", Boolean.TRUE));
+                            POLICY_MATCH, required, policy.getName() + " (" + policy.getId() + ")", Boolean.TRUE));
                     checkTerms(claim, policy, saleDate, reasons);
                 }
             }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/InvoiceEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/InvoiceEventsListener.java
@@ -69,7 +69,7 @@ public class InvoiceEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "invoice")
+                        .tag("owner", OWNER)
                         .tag("entity", "invoice-events")
                         .register(registry);
     }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/VehicleEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/VehicleEventsListener.java
@@ -61,7 +61,7 @@ public class VehicleEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "vehicle")
+                        .tag("owner", OWNER)
                         .tag("entity", "vehicle-events")
                         .register(registry);
     }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/WorkorderEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/WorkorderEventsListener.java
@@ -69,7 +69,7 @@ public class WorkorderEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "workorder")
+                        .tag("owner", OWNER)
                         .tag("entity", "workorder-events")
                         .register(registry);
     }

--- a/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
+++ b/pos-web-common/src/main/java/com/positivity/web/common/GlobalApiExceptionHandler.java
@@ -45,6 +45,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class GlobalApiExceptionHandler {
+    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
 
     private static final Logger log = LoggerFactory.getLogger(GlobalApiExceptionHandler.class);
 
@@ -182,7 +183,7 @@ public class GlobalApiExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiError.withFieldErrors(
-                        "VALIDATION_ERROR",
+                        VALIDATION_ERROR,
                         "Request validation failed",
                         HttpStatus.BAD_REQUEST.value(),
                         Instant.now(clock).toString(),
@@ -208,7 +209,7 @@ public class GlobalApiExceptionHandler {
                 "Unreadable request body on {} [correlationId={}]",
                 request != null ? request.getRequestURI() : "",
                 correlationId);
-        return envelope(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Malformed request body", correlationId);
+        return envelope(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, "Malformed request body", correlationId);
     }
 
     /**
@@ -232,7 +233,7 @@ public class GlobalApiExceptionHandler {
         // Same reasoning as handleMessageNotReadable: the exception message echoes the
         // user-supplied value, and a client 400 is DEBUG-level noise.
         log.debug("Parameter type mismatch on {} [correlationId={}]", path, correlationId);
-        return envelope(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Invalid parameter value", correlationId);
+        return envelope(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, "Invalid parameter value", correlationId);
     }
 
     /**
@@ -332,7 +333,7 @@ public class GlobalApiExceptionHandler {
      */
     private static String frameworkErrorCode(HttpStatusCode status) {
         return switch (status.value()) {
-            case 400 -> "VALIDATION_ERROR";
+            case 400 -> VALIDATION_ERROR;
             case 401 -> "UNAUTHORIZED";
             case 403 -> "FORBIDDEN";
             case 404 -> "NOT_FOUND";

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/InventoryReplicaHealthIndicator.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/InventoryReplicaHealthIndicator.java
@@ -59,6 +59,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class InventoryReplicaHealthIndicator implements HealthIndicator {
+    private static final String REPLICA_STATE = "replicaState";
 
     private static final Logger log = LoggerFactory.getLogger(InventoryReplicaHealthIndicator.class);
 
@@ -111,17 +112,17 @@ public class InventoryReplicaHealthIndicator implements HealthIndicator {
         try {
             Optional<Instant> newest = availabilityRepository.findNewestUpdatedAt();
             if (newest.isEmpty()) {
-                details.put("replicaState", "never-fed");
+                details.put(REPLICA_STATE, "never-fed");
                 details.put("newestFactAt", null);
             } else {
                 Duration age = age(newest.get());
                 details.put("newestFactAt", newest.get().toString());
                 details.put("ageSeconds", age.toSeconds());
-                details.put("replicaState", age.compareTo(stalenessThreshold) > 0 ? "stale" : "fresh");
+                details.put(REPLICA_STATE, age.compareTo(stalenessThreshold) > 0 ? "stale" : "fresh");
             }
         } catch (Exception e) {
             log.warn("Unable to read availability replica staleness", e);
-            details.put("replicaState", "unknown");
+            details.put(REPLICA_STATE, "unknown");
             details.put("error", e.getClass().getSimpleName());
         }
         return Health.up().withDetails(details).build();

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerEventsListener.java
@@ -58,7 +58,7 @@ public class CustomerEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "customer")
+                        .tag("owner", OWNER)
                         .tag("entity", "customer-events")
                         .register(registry);
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/DashboardServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/DashboardServiceImpl.java
@@ -41,6 +41,12 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class DashboardServiceImpl implements DashboardService {
+    private static final String WARNING = "WARNING";
+
+    private static final String MECHANIC_PREFIX = "Mechanic ";
+
+    private static final String BLOCKING = "BLOCKING";
+
     private final Clock clock;
 
     private final WorkorderRepository workorderRepository;
@@ -206,7 +212,7 @@ public class DashboardServiceImpl implements DashboardService {
             if (entry.getValue().size() > 1) {
                 conflicts.add(ConflictEntry.builder()
                         .conflictType("BAY_DOUBLE_BOOKED")
-                        .severity("BLOCKING")
+                        .severity(BLOCKING)
                         .message("Bay " + entry.getKey() + " is assigned to multiple workorders")
                         .affectedResourceId(entry.getKey().toString())
                         .build());
@@ -222,8 +228,8 @@ public class DashboardServiceImpl implements DashboardService {
             if (entry.getValue() > 1) {
                 conflicts.add(ConflictEntry.builder()
                         .conflictType("DOUBLE_BOOKED_MECHANIC")
-                        .severity("BLOCKING")
-                        .message("Mechanic " + entry.getKey() + " is assigned to multiple workorders")
+                        .severity(BLOCKING)
+                        .message(MECHANIC_PREFIX + entry.getKey() + " is assigned to multiple workorders")
                         .affectedResourceId(entry.getKey())
                         .build());
             }
@@ -258,8 +264,9 @@ public class DashboardServiceImpl implements DashboardService {
             if ("ON_JOB".equals(personAvailability.getCurrentStatus())) {
                 conflicts.add(ConflictEntry.builder()
                         .conflictType("CLOCK_OUT_MISMATCH")
-                        .severity("WARNING")
-                        .message("Mechanic " + mechanicId + " is clocked in for another job and has not clocked out")
+                        .severity(WARNING)
+                        .message(
+                                MECHANIC_PREFIX + mechanicId + " is clocked in for another job and has not clocked out")
                         .affectedResourceId(personAvailability.getPersonId())
                         .build());
             }
@@ -272,8 +279,8 @@ public class DashboardServiceImpl implements DashboardService {
                             && pto.getEnd().isAfter(dayStart)) {
                         conflicts.add(ConflictEntry.builder()
                                 .conflictType("MECHANIC_PTO_OVERLAP")
-                                .severity("BLOCKING")
-                                .message("Mechanic " + mechanicId + " has PTO on this date")
+                                .severity(BLOCKING)
+                                .message(MECHANIC_PREFIX + mechanicId + " has PTO on this date")
                                 .affectedResourceId(mechanicId)
                                 .build());
                         break;
@@ -293,7 +300,7 @@ public class DashboardServiceImpl implements DashboardService {
                     && breakInfo.getExpectedReturn().isBefore(fifteenMinFromNow)) {
                 conflicts.add(ConflictEntry.builder()
                         .conflictType("MECHANIC_BREAK_OVERLAP")
-                        .severity("WARNING")
+                        .severity(WARNING)
                         .message("Job overlaps with expected break time for mechanic " + mechanicId)
                         .affectedResourceId(mechanicId)
                         .build());
@@ -321,8 +328,8 @@ public class DashboardServiceImpl implements DashboardService {
                 if (!workorderLocationStr.equals(pa.getCurrentLocationId())) {
                     conflicts.add(ConflictEntry.builder()
                             .conflictType("LOCATION_MISMATCH")
-                            .severity("WARNING")
-                            .message("Mechanic " + mechanicId + " is at a different location than the workorder")
+                            .severity(WARNING)
+                            .message(MECHANIC_PREFIX + mechanicId + " is at a different location than the workorder")
                             .affectedResourceId(mechanicId)
                             .build());
                 }
@@ -352,8 +359,9 @@ public class DashboardServiceImpl implements DashboardService {
                     if (!mechanicCerts.contains(required)) {
                         conflicts.add(ConflictEntry.builder()
                                 .conflictType("MECHANIC_SKILL_MISMATCH")
-                                .severity("WARNING")
-                                .message("Mechanic " + mechanicId + " is missing required certification: " + required)
+                                .severity(WARNING)
+                                .message(MECHANIC_PREFIX + mechanicId + " is missing required certification: "
+                                        + required)
                                 .affectedResourceId(mechanicId)
                                 .build());
                         break;

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
@@ -49,6 +49,9 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class InventoryEventsListener {
+    private static final String PAYLOAD = "payload";
+
+    private static final String AGGREGATE_VERSION = "aggregateVersion";
 
     static final String OWNER = "inventory";
 
@@ -152,14 +155,14 @@ public class InventoryEventsListener {
      */
     private void applyAvailabilityUpdated(JsonNode envelope) {
         InventoryAvailabilityUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), InventoryAvailabilityUpdatedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), InventoryAvailabilityUpdatedV1.class);
         String rawAggregateId = envelope.path("aggregateId").stringValue(null);
         if (rawAggregateId == null || rawAggregateId.isBlank()) {
             log.warn("Skipping availability fact without aggregateId for item {}", payload.stockItemId());
             return;
         }
         UUID aggregateId = UUID.fromString(rawAggregateId);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
 
         ExtInventoryAvailabilityReplica existing =
                 availabilityReplicaRepository.findById(aggregateId).orElse(null);
@@ -203,7 +206,7 @@ public class InventoryEventsListener {
      * workorder line, or one this module does not hold, belongs to someone else.
      */
     private void applyReservationOutcome(JsonNode envelope) {
-        ReservationOutcomeV1 outcome = objectMapper.treeToValue(envelope.path("payload"), ReservationOutcomeV1.class);
+        ReservationOutcomeV1 outcome = objectMapper.treeToValue(envelope.path(PAYLOAD), ReservationOutcomeV1.class);
         if (outcome.workorderLineId() == null) {
             return;
         }
@@ -281,8 +284,8 @@ public class InventoryEventsListener {
     }
 
     private void applyPickListUpdated(JsonNode envelope) {
-        PickListUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PickListUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        PickListUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PickListUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtPickListReplica existing =
                 pickListReplicaRepository.findById(payload.pickListId()).orElse(null);
         if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
@@ -302,8 +305,8 @@ public class InventoryEventsListener {
     }
 
     private void applyPickTaskUpdated(JsonNode envelope) {
-        PickTaskUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PickTaskUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        PickTaskUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PickTaskUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtPickTaskReplica existing =
                 pickTaskReplicaRepository.findById(payload.pickTaskId()).orElse(null);
         if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
@@ -334,7 +337,7 @@ public class InventoryEventsListener {
     }
 
     private void applyConsumptionRecorded(JsonNode envelope) {
-        ConsumptionRecordedV1 payload = objectMapper.treeToValue(envelope.path("payload"), ConsumptionRecordedV1.class);
+        ConsumptionRecordedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), ConsumptionRecordedV1.class);
         // Occurrence fact, applied at most once (processed_events gate above): accumulate the
         // consumed quantity per pick task. No stale guard — occurrences are not snapshots.
         for (ConsumptionRecordedV1.Line line : payload.lines()) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
@@ -83,7 +83,7 @@ public class InventoryEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "inventory")
+                        .tag("owner", OWNER)
                         .tag("entity", "inventory-events")
                         .register(registry);
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InvoiceEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InvoiceEventsListener.java
@@ -75,7 +75,7 @@ public class InvoiceEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "invoice")
+                        .tag("owner", OWNER)
                         .tag("entity", "invoice-events")
                         .register(registry);
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/LocationEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/LocationEventsListener.java
@@ -64,7 +64,7 @@ public class LocationEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "location")
+                        .tag("owner", OWNER)
                         .tag("entity", "location-events")
                         .register(registry);
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OrderEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OrderEventsListener.java
@@ -63,7 +63,7 @@ public class OrderEventsListener {
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "order")
+                        .tag("owner", OWNER)
                         .tag("entity", "order-events")
                         .register(registry);
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PeopleReplicaEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PeopleReplicaEventsListener.java
@@ -40,6 +40,9 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class PeopleReplicaEventsListener {
+    private static final String PAYLOAD = "payload";
+
+    private static final String AGGREGATE_VERSION = "aggregateVersion";
 
     static final String OWNER_PEOPLE_CONTACT = "people-contact";
     static final String OWNER_PEOPLE = "people";
@@ -154,8 +157,8 @@ public class PeopleReplicaEventsListener {
     }
 
     private void applyPersonUpdated(JsonNode envelope) {
-        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        PersonUpdatedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtPersonReplica existing =
                 extPersonReplicaRepository.findById(payload.personId()).orElse(null);
         if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
@@ -171,14 +174,14 @@ public class PeopleReplicaEventsListener {
     }
 
     private void applyPersonDeleted(JsonNode envelope) {
-        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path("payload"), PersonDeletedV1.class);
+        PersonDeletedV1 payload = objectMapper.treeToValue(envelope.path(PAYLOAD), PersonDeletedV1.class);
         extPersonReplicaRepository.deleteById(payload.personId());
     }
 
     private void applyLinkUpdated(JsonNode envelope) {
         UserPersonLinkUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), UserPersonLinkUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), UserPersonLinkUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtUserLinkReplica existing =
                 extUserLinkReplicaRepository.findById(payload.linkId()).orElse(null);
         if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
@@ -196,14 +199,14 @@ public class PeopleReplicaEventsListener {
 
     private void applyLinkRemoved(JsonNode envelope) {
         UserPersonLinkRemovedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), UserPersonLinkRemovedV1.class);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), UserPersonLinkRemovedV1.class);
         extUserLinkReplicaRepository.deleteById(payload.linkId());
     }
 
     private void applyAssignmentUpdated(JsonNode envelope) {
         StaffingAssignmentUpdatedV1 payload =
-                objectMapper.treeToValue(envelope.path("payload"), StaffingAssignmentUpdatedV1.class);
-        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+                objectMapper.treeToValue(envelope.path(PAYLOAD), StaffingAssignmentUpdatedV1.class);
+        long aggregateVersion = envelope.path(AGGREGATE_VERSION).longValue(0);
         ExtStaffingAssignmentReplica existing = extStaffingAssignmentReplicaRepository
                 .findById(payload.assignmentId())
                 .orElse(null);


### PR DESCRIPTION
Phase 3.5 of `docs/SONARQUBE_REMEDIATION_PLAN.md` — the 148 `java:S1192` findings, the largest bucket in the plan. Follows #1487, #1488, #1490 and #1491.

## Capability & Traceability
- Capability: n/a — code-health work, not a capability slice
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: 19 modules; no domain behaviour changed

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no contract semantics change. Every edit replaces a string literal with a constant holding the identical value, so every wire payload, header name, event field name, metric tag and error code is byte-identical. Reference retained per the template so the Contract Sync Enforcement check can find `BACKEND_CONTRACT_GUIDE.md` in this body.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller logic changed. `JournalEntryController` and two exception handlers are touched only to name a literal they already used.

- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

**147 of 148 findings.** The rule has two distinct messages behind it, handled in two commits.

### `d4a75bb` — use the constant that already exists (34 findings)

A constant was already declared in the same class and its value typed out again a few lines below. Thirty-two are identical: an event listener declares `static final String OWNER`, then re-types that value as its metric's owner dimension. The rewrite was matched on **each file's own `OWNER` value** rather than applied by constant name, so a tag whose value merely happened to match could not be swept in.

Two needed a decision: `SupplierPriceCatalogEventsListener` published to `DomainTopics.commands("supplier")` while declaring `OWNER = "supplier"` (the command topic is domain-scoped, so the constant is the honest reference), and `LocationInventoryRollupServiceImpl` listed `"PHYSICAL"` inside `VALID_PARENT_TYPES` while declaring `DEFAULT_PARENT_TYPE = "PHYSICAL"` (same fact — the default parent type has to be a valid one — so naming it records the invariant).

### `d57f9be` — extract the literal (113 findings, 429 occurrences)

Note the gap: **113 findings, 429 actual occurrences.** `S1192` reports once per file at three or more uses, so the finding count understates the edit by nearly 4×. `"profile '"` alone appears 15 times in `SupplierYamlBootstrap`.

Constant names were chosen by hand rather than derived, because auto-deriving from punctuation produces noise — `" does not exist on vendor profile "` becomes `NOT_ON_VENDOR_PROFILE`, not `_DOES_NOT_EXIST_ON_VENDOR_PROFILE_`. Replacement matched the full quoted token and skipped comment and javadoc lines, so `"payload"` could not be substituted inside `"payload."`.

### Two literals routed to a shared home instead

`"X-User"` and `"X-Authorities"` in `RestInvoicingPortAdapter` (`pos-order`) and `InvoiceClientImpl` (`pos-warranty`) now use `GatewaySecurityConstants.HEADER_USER` / `HEADER_AUTHORITIES` from `pos-security-common`. Both modules already depended on it, so the shared home was one import away.

This is the part worth reviewing rather than skimming. These are gateway wire contract names, and minting a private `HEADER_USER` in each class would have satisfied Sonar just as well while leaving the contract undefined in two more places. **The rule is indifferent between the right answer and the wrong one here.**

### Deliberately not changed

**One finding is left open.** `pos-customer`'s `WorkorderEventsListener` tags a metric `.tag("entity", "workorder-events")` and separately declares `SYSTEM_ACTOR = "workorder-events"`. Those are a metrics dimension and an audit actor name that happen to spell the same. Substituting the constant would couple them, so renaming the audit actor would silently rename a metric tag and break a dashboard with nothing pointing at the cause. Equal strings are not a shared concept, and Sonar cannot tell the difference.

**Three cross-module literal families are also left alone, on purpose**, each given class-private constants here rather than a shared home:

- `"X-User"`/`"X-Authorities"` beyond the two files above — **24 files across the repo re-type these; only 7 use `GatewaySecurityConstants`.**
- Event envelope keys — **353 sites across 14 modules** read `path("payload")`, `path("aggregateVersion")` and friends, and `DomainEventEnvelope` in `pos-domain-events` exposes **no** key constants at all.
- `"VALIDATION_ERROR"` — spans 4 modules; arguably belongs with `ApiError` in `pos-shared-dtos`.

Consolidating these means creating new shared API and touching ~380 sites, most of which `S1192` never flags — it is a per-file rule, so a literal used once per file across fourteen modules is invisible to it. That is contract consolidation, not literal extraction, and burying it inside a cleanup PR would make it unreviewable. Recommended as separate work.

## Tests

No new tests. Every change substitutes a constant for a literal of identical value; the existing suites are the guard that nothing moved.

- [ ] Unit tests added/updated — n/a, no behaviour to pin
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a, no contract changed

**How to run** (19 modules; splits into batches to stay under a reasonable wall clock):

```bash
./mvnw -pl pos-accounting,pos-catalog,pos-customer,pos-event-receiver,pos-events,pos-inventory,pos-invoice -DskipTests=false test
./mvnw -pl pos-location,pos-marketing,pos-mcp-server,pos-order,pos-people,pos-people-contact -DskipTests=false test
./mvnw -pl pos-security-service,pos-supplier,pos-vehicle-reference-nhtsa,pos-warranty,pos-web-common,pos-workorder -DskipTests=false test
```

**9,130 tests green across all 19 touched modules**, zero failures, with Spotless, Checkstyle and SpotBugs enabled throughout. The whole reactor also compiles.

Worth noting which tests were real checks rather than formalities: `pos-web-common`'s handler tests assert on the literal `"VALIDATION_ERROR"` in JSON paths, and the two permission registries carrying the highest-occurrence extractions (`"MEDIUM"` ×27 in `CrmPermissionRegistry`, ×10 in `InventoryPermissionRegistry`) are validated by the `Validate Permission Catalog` CI job.

## Risk & Rollback
- Risk level: **Low**, but broad — 19 modules and 463 substituted occurrences. No behaviour is intended to change anywhere; the exposure is a mis-substitution rather than a design error, which is why the replacement skipped comment lines and matched whole quoted tokens.
- Rollback plan: revert the two commits. No schema change, no migration, no new dependency, no new shared API.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no; `claude/*` branch, consistent with recently merged PRs
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap id for code-health work
- [ ] Links to parent + child issues are present — no tracking issue exists for this work
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending first run

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKBxAj3zreJqYprAGvtXnS)_