### PR TITLE
refactor: reduce cognitive complexity in the five worst methods, raising branch coverage as we go

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PredicateParser.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PredicateParser.java
@@ -391,47 +391,21 @@ public final class PredicateParser {
             if (Character.isWhitespace(c)) {
                 i++;
             } else if (isIdentifierStart(c)) {
-                int start = i;
-                while (i < length && isIdentifierPart(input.charAt(i))) {
-                    i++;
-                }
-                tokens.add(new Token(TokenType.IDENT, input.substring(start, i), start));
+                i = lexIdentifier(input, i, tokens);
             } else if (c == '.') {
                 tokens.add(new Token(TokenType.DOT, ".", i));
                 i++;
             } else if (c == '\'') {
-                int start = i;
-                int end = input.indexOf('\'', i + 1);
-                if (end < 0) {
-                    throw new ParseException("unterminated string literal", start);
-                }
-                tokens.add(new Token(TokenType.STRING, input.substring(i + 1, end), start));
-                i = end + 1;
+                i = lexString(input, i, tokens);
             } else if (Character.isDigit(c)
                     || ((c == '+' || c == '-') && i + 1 < length && Character.isDigit(input.charAt(i + 1)))) {
                 i = lexNumber(input, i, tokens);
             } else if (c == '=' || c == '!') {
-                if (i + 1 < length && input.charAt(i + 1) == '=') {
-                    tokens.add(new Token(TokenType.OP, input.substring(i, i + 2), i));
-                    i += 2;
-                } else {
-                    throw new ParseException("unsupported operator '" + c + "' (did you mean '" + c + "='?)", i);
-                }
+                i = lexEqualityOperator(input, i, tokens);
             } else if (c == '>' || c == '<') {
-                if (i + 1 < length && input.charAt(i + 1) == '=') {
-                    tokens.add(new Token(TokenType.OP, input.substring(i, i + 2), i));
-                    i += 2;
-                } else {
-                    tokens.add(new Token(TokenType.OP, String.valueOf(c), i));
-                    i++;
-                }
+                i = lexOrderingOperator(input, i, tokens);
             } else if (c == '&') {
-                if (i + 1 < length && input.charAt(i + 1) == '&') {
-                    tokens.add(new Token(TokenType.AND, "&&", i));
-                    i += 2;
-                } else {
-                    throw new ParseException("single '&' is not a valid operator (did you mean '&&'?)", i);
-                }
+                i = lexAnd(input, i, tokens);
             } else {
                 throw new ParseException("unexpected character '" + c + "'", i);
             }
@@ -439,6 +413,62 @@ public final class PredicateParser {
 
         tokens.add(new Token(TokenType.EOF, "", length));
         return tokens;
+    }
+
+    /** Lexes an identifier: {@code identifierStart identifierPart*}. */
+    private static int lexIdentifier(String input, int start, List<Token> tokens) {
+        int i = start;
+        while (i < input.length() && isIdentifierPart(input.charAt(i))) {
+            i++;
+        }
+        tokens.add(new Token(TokenType.IDENT, input.substring(start, i), start));
+        return i;
+    }
+
+    /** Lexes a single-quoted string literal. The quotes are stripped; there are no escapes. */
+    private static int lexString(String input, int start, List<Token> tokens) {
+        int end = input.indexOf('\'', start + 1);
+        if (end < 0) {
+            throw new ParseException("unterminated string literal", start);
+        }
+        tokens.add(new Token(TokenType.STRING, input.substring(start + 1, end), start));
+        return end + 1;
+    }
+
+    /**
+     * Lexes {@code ==} or {@code !=}.
+     *
+     * <p>A bare {@code =} or {@code !} is rejected rather than assumed: a rule author writing
+     * {@code x = 1} means equality, and silently accepting it would let two spellings of the same
+     * operator diverge.
+     */
+    private static int lexEqualityOperator(String input, int start, List<Token> tokens) {
+        char c = input.charAt(start);
+        if (start + 1 < input.length() && input.charAt(start + 1) == '=') {
+            tokens.add(new Token(TokenType.OP, input.substring(start, start + 2), start));
+            return start + 2;
+        }
+        throw new ParseException("unsupported operator '" + c + "' (did you mean '" + c + "='?)", start);
+    }
+
+    /** Lexes {@code >}, {@code <}, {@code >=} or {@code <=}, preferring the two-character form. */
+    private static int lexOrderingOperator(String input, int start, List<Token> tokens) {
+        char c = input.charAt(start);
+        if (start + 1 < input.length() && input.charAt(start + 1) == '=') {
+            tokens.add(new Token(TokenType.OP, input.substring(start, start + 2), start));
+            return start + 2;
+        }
+        tokens.add(new Token(TokenType.OP, String.valueOf(c), start));
+        return start + 1;
+    }
+
+    /** Lexes {@code &&}. A single {@code &} is an error, not a synonym. */
+    private static int lexAnd(String input, int start, List<Token> tokens) {
+        if (start + 1 < input.length() && input.charAt(start + 1) == '&') {
+            tokens.add(new Token(TokenType.AND, "&&", start));
+            return start + 2;
+        }
+        throw new ParseException("single '&' is not a valid operator (did you mean '&&'?)", start);
     }
 
     /** Lexes {@code ['+'|'-'] digits ['.' digits]} starting at {@code start}. */

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PredicateParserTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PredicateParserTest.java
@@ -341,4 +341,39 @@ class PredicateParserTest {
         assertThat(eval("eventType=='billing.invoicePosted'&&payload.amount>100", payload))
                 .isTrue();
     }
+
+    @Nested
+    @DisplayName("Comparison-operator coverage (Phase 3.6)")
+    class ComparisonOperatorCoverage {
+
+        // Closing the last branches the tokenizer split left uncovered. These are real semantics,
+        // not coverage filler: string ordering and numeric equality are both reachable from a rule
+        // an author can write, and neither was asserted anywhere.
+
+        @Test
+        @DisplayName("Ordering operators are rejected against a string literal at parse time")
+        void stringOrderingIsRejectedByTheGrammar() {
+            // Worth recording why compareString's ordering arm shows as uncovered: it is not a
+            // testing gap, it is unreachable. The parser refuses `>=` against a quoted string
+            // before evaluation is ever reached, so that arm is defensive depth behind a guard.
+            // Lexicographic ordering of grades is exactly the kind of thing a rule author might
+            // assume works, and the grammar says so plainly rather than comparing strings by
+            // accident.
+            assertThatThrownBy(() -> eval("payload.grade >= 'B'", payload("grade", "C")))
+                    .isInstanceOf(ParseException.class)
+                    .hasMessageContaining("requires a numeric literal");
+        }
+
+        @Test
+        @DisplayName("Numeric equality compares by value, not by scale or boxed type")
+        void numericEqualityComparesByValue() {
+            // 5 and 5.00 are equal numerically; a BigDecimal.equals() would say otherwise, and a
+            // posting rule keyed on an amount must not depend on how the payload spelled it.
+            assertThat(eval("payload.amount == 5", payload("amount", new BigDecimal("5.00"))))
+                    .isTrue();
+            assertThat(eval("payload.amount == 5", payload("amount", 5))).isTrue();
+            assertThat(eval("payload.amount == 5", payload("amount", new BigDecimal("5.01"))))
+                    .isFalse();
+        }
+    }
 }

--- a/pos-inventory/pom.xml
+++ b/pos-inventory/pom.xml
@@ -14,12 +14,12 @@
     <description>POS Inventory module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 79.2% line / 64.1% branch by the gate's own
+        <!-- Coverage ratchet: measured 80.4% line / 65.5% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.76</jacoco.line.min>
-        <jacoco.branch.min>0.61</jacoco.branch.min>
+        <jacoco.line.min>0.77</jacoco.line.min>
+        <jacoco.branch.min>0.62</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
@@ -279,12 +279,36 @@ public class InventoryFactPublisher {
         return pending;
     }
 
+    /**
+     * Drains every pending fact kind to the outbox at beforeCommit.
+     *
+     * <p>One emitter per fact kind rather than one long method: each is independently
+     * readable and independently testable, and a failure in one kind must not stop the
+     * others — which is why every emitter keeps its own try/catch rather than sharing one.
+     */
     private void publishPending() {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         Pending pending = (Pending) TransactionSynchronizationManager.getResource(TX_RESOURCE_KEY);
         if (writer == null || pending == null) {
             return;
         }
+        publishAvailabilityKeys(writer, pending);
+        publishStorageLocationIds(writer, pending);
+        publishPickListIds(writer, pending);
+        publishPickTaskIds(writer, pending);
+        publishConsumptions(writer, pending);
+        publishExpectedSupplyDrops(writer, pending);
+        publishScrapPosts(writer, pending);
+        publishProductValueChanges(writer, pending);
+        publishTransferOrderUpdates(writer, pending);
+        publishBackorderCreations(writer, pending);
+        publishBackorderResolutions(writer, pending);
+        publishReservationOutcomes(writer, pending);
+        publishLotExpiryAlerts(writer, pending);
+        publishLeadTimeProductIds(writer, pending);
+    }
+
+    private void publishAvailabilityKeys(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (AvailabilityKey key : pending.availabilityKeys) {
             try {
                 AvailabilityView view =
@@ -310,6 +334,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping availability fact for {}: {}", key, e.getMessage());
             }
         }
+    }
+
+    private void publishStorageLocationIds(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (UUID storageLocationId : pending.storageLocationIds) {
             try {
                 LocationInventoryInquiryResponse inquiry =
@@ -325,6 +352,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping storage-location on-hand fact for {}: {}", storageLocationId, e.getMessage());
             }
         }
+    }
+
+    private void publishPickListIds(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (UUID pickListId : pending.pickListIds) {
             try {
                 PickListEntity pickList =
@@ -348,6 +378,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping pick-list fact for {}: {}", pickListId, e.getMessage());
             }
         }
+    }
+
+    private void publishPickTaskIds(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (UUID pickTaskId : pending.pickTaskIds) {
             try {
                 PickTaskEntity task = pickTaskRepository.findById(pickTaskId).orElse(null);
@@ -378,6 +411,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping pick-task fact for {}: {}", pickTaskId, e.getMessage());
             }
         }
+    }
+
+    private void publishConsumptions(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (ConsumptionRecordedV1 consumption : pending.consumptions) {
             try {
                 publish(
@@ -390,6 +426,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping consumption fact for {}: {}", consumption.consumptionId(), e.getMessage());
             }
         }
+    }
+
+    private void publishExpectedSupplyDrops(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (ExpectedSupplyDroppedV1 drop : pending.expectedSupplyDrops) {
             try {
                 publish(
@@ -402,6 +441,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping expected-supply-dropped fact for {}: {}", drop.poId(), e.getMessage());
             }
         }
+    }
+
+    private void publishScrapPosts(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (ScrapPostedV1 scrapPost : pending.scrapPosts) {
             try {
                 publish(writer, ScrapPostedV1.EVENT_TYPE, ScrapPostedV1.SCHEMA_VERSION, scrapPost.scrapId(), scrapPost);
@@ -409,6 +451,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping scrap-posted fact for {}: {}", scrapPost.scrapId(), e.getMessage());
             }
         }
+    }
+
+    private void publishProductValueChanges(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (ProductValueChangedV1 valueChange : pending.productValueChanges) {
             try {
                 publish(
@@ -421,6 +466,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping product-value-changed fact for {}: {}", valueChange.revaluationId(), e.getMessage());
             }
         }
+    }
+
+    private void publishTransferOrderUpdates(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (TransferOrderUpdatedV1 transferUpdate : pending.transferOrderUpdates) {
             try {
                 publish(
@@ -433,6 +481,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping transfer-order fact for {}: {}", transferUpdate.transferOrderId(), e.getMessage());
             }
         }
+    }
+
+    private void publishBackorderCreations(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (BackorderCreatedV1 backorderCreated : pending.backorderCreations) {
             try {
                 publish(
@@ -445,6 +496,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping backorder-created fact for {}: {}", backorderCreated.backorderId(), e.getMessage());
             }
         }
+    }
+
+    private void publishBackorderResolutions(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (BackorderResolvedV1 backorderResolved : pending.backorderResolutions) {
             try {
                 publish(
@@ -458,6 +512,9 @@ public class InventoryFactPublisher {
                         "Skipping backorder-resolved fact for {}: {}", backorderResolved.backorderId(), e.getMessage());
             }
         }
+    }
+
+    private void publishReservationOutcomes(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (ReservationOutcomeV1 reservationOutcome : pending.reservationOutcomes) {
             try {
                 publish(
@@ -473,6 +530,9 @@ public class InventoryFactPublisher {
                         e.getMessage());
             }
         }
+    }
+
+    private void publishLotExpiryAlerts(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (LotExpiryAlertV1 lotExpiryAlert : pending.lotExpiryAlerts) {
             try {
                 publish(
@@ -485,6 +545,9 @@ public class InventoryFactPublisher {
                 log.warn("Skipping lot-expiry-alert fact for {}: {}", lotExpiryAlert.lotId(), e.getMessage());
             }
         }
+    }
+
+    private void publishLeadTimeProductIds(@NonNull OutboxEventWriter writer, @NonNull Pending pending) {
         for (UUID productId : pending.leadTimeProductIds) {
             try {
                 LeadTimeView view = inventoryLeadTimeService.queryLeadTime(productId, null, null);

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryFactPublisherTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryFactPublisherTest.java
@@ -10,8 +10,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.inventory.BackorderCreatedV1;
+import com.positivity.domainevents.inventory.BackorderResolvedV1;
+import com.positivity.domainevents.inventory.ConsumptionRecordedV1;
 import com.positivity.domainevents.inventory.InventoryAvailabilityUpdatedV1;
+import com.positivity.domainevents.inventory.LotExpiryAlertV1;
+import com.positivity.domainevents.inventory.ProductValueChangedV1;
+import com.positivity.domainevents.inventory.ReservationOutcomeV1;
+import com.positivity.domainevents.inventory.ScrapPostedV1;
 import com.positivity.domainevents.inventory.StorageLocationOnHandUpdatedV1;
+import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
 import com.positivity.inventory.internal.config.OutboxEventWriter;
 import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
@@ -20,6 +28,7 @@ import com.positivity.inventory.internal.service.InventoryFactPublisher;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
@@ -172,5 +181,216 @@ class InventoryFactPublisherTest {
         fireBeforeCommit();
 
         verify(writer, never()).publish(any(), any());
+    }
+
+    // ── Fact→event characterisation (Phase 3.6) ────────────────────────────────────
+    //
+    // Written before publishPending was split into per-fact emitters. That method scored 52
+    // cognitive complexity and sat at 47.5% branch coverage: of the fourteen fact types it
+    // emits, only expected-supply-dropped had a publish test. Every one of these events is
+    // consumed by other modules, so the mapping each block performs — which event type, which
+    // schema version, which aggregate id — is a contract, and it was almost entirely unpinned.
+    //
+    // Each test seeds one pending fact and asserts the envelope it produces. Together they are
+    // the evidence that the split preserved every mapping.
+
+    @Test
+    @DisplayName("A recorded consumption is published keyed on its consumption id")
+    void publishesConsumptionFact() {
+        UUID consumptionId = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+        ConsumptionRecordedV1 fact = new ConsumptionRecordedV1(
+                consumptionId,
+                UUID.fromString("00000000-0000-0000-0000-0000000000c2"),
+                null,
+                2,
+                Instant.parse("2026-07-13T12:00:00Z"),
+                List.of(),
+                "STANDARD");
+
+        publisher.recordConsumption(fact);
+        fireBeforeCommit();
+
+        assertPublished(ConsumptionRecordedV1.EVENT_TYPE, ConsumptionRecordedV1.SCHEMA_VERSION, consumptionId, fact);
+    }
+
+    @Test
+    @DisplayName("A recorded scrap posting is published keyed on its scrap id")
+    void publishesScrapPostedFact() {
+        UUID scrapId = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+        ScrapPostedV1 fact = new ScrapPostedV1(
+                scrapId,
+                "SKU-SCRAP",
+                UUID.fromString("00000000-0000-0000-0000-0000000000d2"),
+                null,
+                3,
+                "DAMAGED",
+                new BigDecimal("4.25"),
+                "STANDARD",
+                null,
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordScrapPosted(fact);
+        fireBeforeCommit();
+
+        assertPublished(ScrapPostedV1.EVENT_TYPE, ScrapPostedV1.SCHEMA_VERSION, scrapId, fact);
+    }
+
+    @Test
+    @DisplayName("A product revaluation is published keyed on its revaluation id")
+    void publishesProductValueChangedFact() {
+        UUID revaluationId = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+        ProductValueChangedV1 fact = new ProductValueChangedV1(
+                revaluationId,
+                "SKU-VAL",
+                "WEIGHTED_AVERAGE",
+                new BigDecimal("10.00"),
+                new BigDecimal("12.50"),
+                new BigDecimal("40"),
+                new BigDecimal("100.00"),
+                "MARKET_ADJUSTMENT",
+                "system",
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordProductValueChanged(fact);
+        fireBeforeCommit();
+
+        assertPublished(ProductValueChangedV1.EVENT_TYPE, ProductValueChangedV1.SCHEMA_VERSION, revaluationId, fact);
+    }
+
+    @Test
+    @DisplayName("A transfer-order update is published keyed on its transfer-order id")
+    void publishesTransferOrderUpdatedFact() {
+        UUID transferOrderId = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+        TransferOrderUpdatedV1 fact = new TransferOrderUpdatedV1(
+                transferOrderId,
+                "IN_TRANSIT",
+                UUID.fromString("00000000-0000-0000-0000-0000000000f2"),
+                null,
+                UUID.fromString("00000000-0000-0000-0000-0000000000f3"),
+                null,
+                List.of(new TransferOrderUpdatedV1.LineSummary("SKU-XFER", 4, 4, 0)),
+                null,
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordTransferOrderUpdated(fact);
+        fireBeforeCommit();
+
+        assertPublished(
+                TransferOrderUpdatedV1.EVENT_TYPE, TransferOrderUpdatedV1.SCHEMA_VERSION, transferOrderId, fact);
+    }
+
+    @Test
+    @DisplayName("A created backorder is published keyed on its backorder id")
+    void publishesBackorderCreatedFact() {
+        UUID backorderId = UUID.fromString("00000000-0000-0000-0000-000000000101");
+        BackorderCreatedV1 fact = new BackorderCreatedV1(
+                backorderId,
+                UUID.fromString("00000000-0000-0000-0000-000000000103"),
+                null,
+                "SKU-SHORT",
+                new BigDecimal("2"),
+                UUID.fromString("00000000-0000-0000-0000-000000000102"),
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordBackorderCreated(fact);
+        fireBeforeCommit();
+
+        assertPublished(BackorderCreatedV1.EVENT_TYPE, BackorderCreatedV1.SCHEMA_VERSION, backorderId, fact);
+    }
+
+    @Test
+    @DisplayName("A resolved backorder is published keyed on the same backorder id as its creation")
+    void publishesBackorderResolvedFact() {
+        UUID backorderId = UUID.fromString("00000000-0000-0000-0000-000000000111");
+        BackorderResolvedV1 fact = new BackorderResolvedV1(
+                backorderId,
+                UUID.fromString("00000000-0000-0000-0000-000000000112"),
+                null,
+                "SKU-SHORT",
+                new BigDecimal("2"),
+                "RECEIPT",
+                null,
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordBackorderResolved(fact);
+        fireBeforeCommit();
+
+        // Same aggregate id as the creation fact above: created and resolved must land on one
+        // partition in order, or a consumer can see the resolution before the creation.
+        assertPublished(BackorderResolvedV1.EVENT_TYPE, BackorderResolvedV1.SCHEMA_VERSION, backorderId, fact);
+    }
+
+    @Test
+    @DisplayName("A reservation outcome is published keyed on its reservation id")
+    void publishesReservationOutcomeFact() {
+        UUID reservationId = UUID.fromString("00000000-0000-0000-0000-000000000121");
+        ReservationOutcomeV1 fact = new ReservationOutcomeV1(
+                reservationId,
+                UUID.fromString("00000000-0000-0000-0000-000000000123"),
+                null,
+                "SKU-RES",
+                new BigDecimal("1"),
+                false,
+                UUID.fromString("00000000-0000-0000-0000-000000000122"),
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordReservationOutcome(fact);
+        fireBeforeCommit();
+
+        assertPublished(ReservationOutcomeV1.EVENT_TYPE, ReservationOutcomeV1.SCHEMA_VERSION, reservationId, fact);
+    }
+
+    @Test
+    @DisplayName("A lot-expiry alert is published keyed on its lot id")
+    void publishesLotExpiryAlertFact() {
+        UUID lotId = UUID.fromString("00000000-0000-0000-0000-000000000131");
+        LotExpiryAlertV1 fact = new LotExpiryAlertV1(
+                lotId,
+                "SKU-LOT",
+                "LOT-42",
+                LocalDate.parse("2026-09-01"),
+                "EXPIRING_SOON",
+                Instant.parse("2026-07-13T12:00:00Z"));
+
+        publisher.recordLotExpiryAlert(fact);
+        fireBeforeCommit();
+
+        assertPublished(LotExpiryAlertV1.EVENT_TYPE, LotExpiryAlertV1.SCHEMA_VERSION, lotId, fact);
+    }
+
+    @Test
+    @DisplayName("Facts of different kinds recorded in one transaction all reach the outbox")
+    void publishesEveryPendingFactKindInOneTransaction() {
+        UUID scrapId = UUID.fromString("00000000-0000-0000-0000-000000000141");
+        UUID lotId = UUID.fromString("00000000-0000-0000-0000-000000000142");
+        publisher.recordScrapPosted(new ScrapPostedV1(
+                scrapId,
+                "SKU-A",
+                null,
+                null,
+                1,
+                "DAMAGED",
+                null,
+                "STANDARD",
+                null,
+                Instant.parse("2026-07-13T12:00:00Z")));
+        publisher.recordLotExpiryAlert(
+                new LotExpiryAlertV1(lotId, "SKU-B", "LOT-1", null, "EXPIRED", Instant.parse("2026-07-13T12:00:00Z")));
+
+        fireBeforeCommit();
+
+        // The emitters are independent: one kind being pending must not suppress another.
+        verify(writer, times(2)).publish(eq("inventory.events.v1"), any());
+    }
+
+    private void assertPublished(String eventType, int schemaVersion, UUID aggregateId, Object fact) {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<DomainEventEnvelope<Object>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("inventory.events.v1"), captor.capture());
+        DomainEventEnvelope<Object> envelope = captor.getValue();
+        assertThat(envelope.eventType()).isEqualTo(eventType);
+        assertThat(envelope.schemaVersion()).isEqualTo(schemaVersion);
+        assertThat(envelope.aggregateId()).isEqualTo(aggregateId);
+        assertThat(envelope.payload()).isSameAs(fact);
     }
 }

--- a/pos-price/pom.xml
+++ b/pos-price/pom.xml
@@ -14,12 +14,12 @@
     <description>POS Price module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 94.4% line / 80.4% branch by the gate's own
+        <!-- Coverage ratchet: measured 94.9% line / 85.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
         <jacoco.line.min>0.91</jacoco.line.min>
-        <jacoco.branch.min>0.77</jacoco.branch.min>
+        <jacoco.branch.min>0.81</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-price/src/main/java/com/positivity/price/internal/service/EligibilityEvaluationServiceImpl.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/service/EligibilityEvaluationServiceImpl.java
@@ -127,6 +127,14 @@ public class EligibilityEvaluationServiceImpl implements EligibilityEvaluationSe
         return new EligibilityDecision(true, EligibilityReasonCode.ELIGIBLE);
     }
 
+    /**
+     * Dispatches one rule to the handler for its condition type.
+     *
+     * <p>The switch is exhaustive over {@link ConditionType} rather than an {@code if/else} chain
+     * with a fall-through. For every condition type that exists today the outcome is identical, but
+     * adding a new one now fails to compile instead of silently returning ELIGIBLE — which is the
+     * safe direction for a rule engine whose job is to withhold discounts.
+     */
     @NonNull
     private EligibilityDecision evaluateSingleRule(
             @NonNull PromotionEligibilityRule rule,
@@ -142,81 +150,118 @@ public class EligibilityEvaluationServiceImpl implements EligibilityEvaluationSe
             return new EligibilityDecision(false, EligibilityReasonCode.EVALUATION_ERROR);
         }
 
-        if (conditionType == ConditionType.ACCOUNT_ID_LIST || conditionType == ConditionType.ACCOUNT_FLEET_SIZE) {
-            if (accountId == null) {
-                return new EligibilityDecision(false, EligibilityReasonCode.MISSING_ACCOUNT_CONTEXT);
-            }
-            Optional<AccountContext> accountContext = accountDataProvider.getAccountContext(accountId);
-            if (accountContext.isEmpty()) {
-                return new EligibilityDecision(false, EligibilityReasonCode.MISSING_ACCOUNT_CONTEXT);
-            }
+        return switch (conditionType) {
+            case ACCOUNT_ID_LIST, ACCOUNT_FLEET_SIZE -> evaluateAccountRule(conditionType, operator, value, accountId);
+            case VEHICLE_TAG -> evaluateVehicleTagRule(operator, value, vehicleId);
+            case AUDIENCE_TYPE -> evaluateAudienceTypeRule(operator, value, audienceType);
+            case CAMPAIGN_CODE -> evaluateCampaignCodeRule(operator, value, campaignCode);
+        };
+    }
 
-            if (conditionType == ConditionType.ACCOUNT_ID_LIST) {
-                List<String> accountIds =
-                        Arrays.stream(value.split(",")).map(String::trim).toList();
-                boolean inList = accountIds.contains(accountId.toString());
-                if (operator == RuleOperator.IN && !inList) {
-                    return new EligibilityDecision(false, EligibilityReasonCode.ACCOUNT_NOT_IN_LIST);
-                }
-                if (operator == RuleOperator.NOT_IN && inList) {
-                    return new EligibilityDecision(false, EligibilityReasonCode.ACCOUNT_IN_EXCLUSION_LIST);
-                }
-            } else {
-                int threshold;
-                try {
-                    threshold = Integer.parseInt(value.trim());
-                } catch (NumberFormatException ex) {
-                    return new EligibilityDecision(false, EligibilityReasonCode.EVALUATION_ERROR);
-                }
-                if (operator == RuleOperator.GREATER_THAN_OR_EQUAL_TO
-                        && accountContext.get().fleetSize() < threshold) {
-                    return new EligibilityDecision(false, EligibilityReasonCode.FLEET_SIZE_TOO_SMALL);
-                }
-            }
-        } else if (conditionType == ConditionType.VEHICLE_TAG) {
-            if (vehicleId == null) {
-                return new EligibilityDecision(false, EligibilityReasonCode.MISSING_VEHICLE_CONTEXT);
-            }
-            Optional<VehicleContext> vehicleContext = vehicleDataProvider.getVehicleContext(vehicleId);
-            if (vehicleContext.isEmpty()) {
-                return new EligibilityDecision(false, EligibilityReasonCode.MISSING_VEHICLE_CONTEXT);
-            }
-
-            boolean tagPresent = vehicleContext.get().tags().contains(value);
-            if (operator == RuleOperator.EQUALS && !tagPresent) {
-                return new EligibilityDecision(false, EligibilityReasonCode.VEHICLE_TAG_NOT_PRESENT);
-            }
-            if (operator == RuleOperator.NOT_IN && tagPresent) {
-                return new EligibilityDecision(false, EligibilityReasonCode.VEHICLE_TAG_EXCLUDED);
-            }
-        } else if (conditionType == ConditionType.AUDIENCE_TYPE) {
-            if (audienceType == null || audienceType.isBlank()) {
-                return new EligibilityDecision(false, EligibilityReasonCode.MISSING_AUDIENCE_CONTEXT);
-            }
-            // Audience types are enum-like names (COMMERCIAL, INDIVIDUAL); compare
-            // case-insensitively so client casing does not affect the outcome.
-            boolean matches = value.trim().equalsIgnoreCase(audienceType.trim());
-            if (operator == RuleOperator.EQUALS && !matches) {
-                return new EligibilityDecision(false, EligibilityReasonCode.AUDIENCE_TYPE_NOT_MATCHED);
-            }
-            if (operator == RuleOperator.NOT_IN && matches) {
-                return new EligibilityDecision(false, EligibilityReasonCode.AUDIENCE_TYPE_EXCLUDED);
-            }
-        } else if (conditionType == ConditionType.CAMPAIGN_CODE) {
-            if (campaignCode == null || campaignCode.isBlank()) {
-                return new EligibilityDecision(false, EligibilityReasonCode.MISSING_CAMPAIGN_CONTEXT);
-            }
-            List<String> campaignCodes =
-                    Arrays.stream(value.split(",")).map(String::trim).toList();
-            boolean inList = campaignCodes.contains(campaignCode.trim());
-            if ((operator == RuleOperator.EQUALS || operator == RuleOperator.IN) && !inList) {
-                return new EligibilityDecision(false, EligibilityReasonCode.CAMPAIGN_CODE_NOT_MATCHED);
-            }
-            if (operator == RuleOperator.NOT_IN && inList) {
-                return new EligibilityDecision(false, EligibilityReasonCode.CAMPAIGN_CODE_EXCLUDED);
-            }
+    /** Both account-scoped condition types need the same context lookup before they diverge. */
+    @NonNull
+    private EligibilityDecision evaluateAccountRule(
+            @NonNull ConditionType conditionType,
+            @NonNull RuleOperator operator,
+            @NonNull String value,
+            @Nullable UUID accountId) {
+        if (accountId == null) {
+            return new EligibilityDecision(false, EligibilityReasonCode.MISSING_ACCOUNT_CONTEXT);
+        }
+        Optional<AccountContext> accountContext = accountDataProvider.getAccountContext(accountId);
+        if (accountContext.isEmpty()) {
+            return new EligibilityDecision(false, EligibilityReasonCode.MISSING_ACCOUNT_CONTEXT);
         }
 
+        return conditionType == ConditionType.ACCOUNT_ID_LIST
+                ? evaluateAccountIdList(operator, value, accountId)
+                : evaluateFleetSize(operator, value, accountContext.get());
+    }
+
+    @NonNull
+    private EligibilityDecision evaluateAccountIdList(
+            @NonNull RuleOperator operator, @NonNull String value, @NonNull UUID accountId) {
+        List<String> accountIds =
+                Arrays.stream(value.split(",")).map(String::trim).toList();
+        boolean inList = accountIds.contains(accountId.toString());
+        if (operator == RuleOperator.IN && !inList) {
+            return new EligibilityDecision(false, EligibilityReasonCode.ACCOUNT_NOT_IN_LIST);
+        }
+        if (operator == RuleOperator.NOT_IN && inList) {
+            return new EligibilityDecision(false, EligibilityReasonCode.ACCOUNT_IN_EXCLUSION_LIST);
+        }
+        return new EligibilityDecision(true, EligibilityReasonCode.ELIGIBLE);
+    }
+
+    @NonNull
+    private EligibilityDecision evaluateFleetSize(
+            @NonNull RuleOperator operator, @NonNull String value, @NonNull AccountContext accountContext) {
+        int threshold;
+        try {
+            threshold = Integer.parseInt(value.trim());
+        } catch (NumberFormatException ex) {
+            return new EligibilityDecision(false, EligibilityReasonCode.EVALUATION_ERROR);
+        }
+        if (operator == RuleOperator.GREATER_THAN_OR_EQUAL_TO && accountContext.fleetSize() < threshold) {
+            return new EligibilityDecision(false, EligibilityReasonCode.FLEET_SIZE_TOO_SMALL);
+        }
+        return new EligibilityDecision(true, EligibilityReasonCode.ELIGIBLE);
+    }
+
+    @NonNull
+    private EligibilityDecision evaluateVehicleTagRule(
+            @NonNull RuleOperator operator, @NonNull String value, @Nullable UUID vehicleId) {
+        if (vehicleId == null) {
+            return new EligibilityDecision(false, EligibilityReasonCode.MISSING_VEHICLE_CONTEXT);
+        }
+        Optional<VehicleContext> vehicleContext = vehicleDataProvider.getVehicleContext(vehicleId);
+        if (vehicleContext.isEmpty()) {
+            return new EligibilityDecision(false, EligibilityReasonCode.MISSING_VEHICLE_CONTEXT);
+        }
+
+        boolean tagPresent = vehicleContext.get().tags().contains(value);
+        if (operator == RuleOperator.EQUALS && !tagPresent) {
+            return new EligibilityDecision(false, EligibilityReasonCode.VEHICLE_TAG_NOT_PRESENT);
+        }
+        if (operator == RuleOperator.NOT_IN && tagPresent) {
+            return new EligibilityDecision(false, EligibilityReasonCode.VEHICLE_TAG_EXCLUDED);
+        }
+        return new EligibilityDecision(true, EligibilityReasonCode.ELIGIBLE);
+    }
+
+    @NonNull
+    private EligibilityDecision evaluateAudienceTypeRule(
+            @NonNull RuleOperator operator, @NonNull String value, @Nullable String audienceType) {
+        if (audienceType == null || audienceType.isBlank()) {
+            return new EligibilityDecision(false, EligibilityReasonCode.MISSING_AUDIENCE_CONTEXT);
+        }
+        // Audience types are enum-like names (COMMERCIAL, INDIVIDUAL); compare
+        // case-insensitively so client casing does not affect the outcome.
+        boolean matches = value.trim().equalsIgnoreCase(audienceType.trim());
+        if (operator == RuleOperator.EQUALS && !matches) {
+            return new EligibilityDecision(false, EligibilityReasonCode.AUDIENCE_TYPE_NOT_MATCHED);
+        }
+        if (operator == RuleOperator.NOT_IN && matches) {
+            return new EligibilityDecision(false, EligibilityReasonCode.AUDIENCE_TYPE_EXCLUDED);
+        }
+        return new EligibilityDecision(true, EligibilityReasonCode.ELIGIBLE);
+    }
+
+    @NonNull
+    private EligibilityDecision evaluateCampaignCodeRule(
+            @NonNull RuleOperator operator, @NonNull String value, @Nullable String campaignCode) {
+        if (campaignCode == null || campaignCode.isBlank()) {
+            return new EligibilityDecision(false, EligibilityReasonCode.MISSING_CAMPAIGN_CONTEXT);
+        }
+        List<String> campaignCodes =
+                Arrays.stream(value.split(",")).map(String::trim).toList();
+        boolean inList = campaignCodes.contains(campaignCode.trim());
+        if ((operator == RuleOperator.EQUALS || operator == RuleOperator.IN) && !inList) {
+            return new EligibilityDecision(false, EligibilityReasonCode.CAMPAIGN_CODE_NOT_MATCHED);
+        }
+        if (operator == RuleOperator.NOT_IN && inList) {
+            return new EligibilityDecision(false, EligibilityReasonCode.CAMPAIGN_CODE_EXCLUDED);
+        }
         return new EligibilityDecision(true, EligibilityReasonCode.ELIGIBLE);
     }
 

--- a/pos-price/src/test/java/com/positivity/price/internal/service/EligibilityEvaluationServiceImplTest.java
+++ b/pos-price/src/test/java/com/positivity/price/internal/service/EligibilityEvaluationServiceImplTest.java
@@ -442,6 +442,221 @@ class EligibilityEvaluationServiceImplTest {
                 .hasMessageContaining(ruleId.toString());
     }
 
+    // ── Branch-coverage characterisation (Phase 3.6) ────────────────────────────────
+    //
+    // Written against evaluateSingleRule BEFORE it was split into per-condition handlers,
+    // and covering the branches JaCoCo reported unexercised (79.4% branch on that method).
+    // The cluster that mattered: NOT_IN — the exclusion operator — was barely covered on any
+    // condition type, and those are exactly the rules that DENY a promotion. A defect there
+    // grants a discount that should have been refused, which is the expensive direction.
+
+    @Test
+    void givenAccountIdListNotIn_andAccountInList_whenEvaluate_thenExcluded() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+        UUID accountId = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.ACCOUNT_ID_LIST, RuleOperator.NOT_IN, accountId.toString())));
+        when(accountProvider.getAccountContext(any())).thenReturn(Optional.of(new AccountContext(accountId, 5)));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, accountId, null, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.ACCOUNT_IN_EXCLUSION_LIST);
+    }
+
+    @Test
+    void givenFleetSizeRule_andFleetBelowThreshold_whenEvaluate_thenTooSmall() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+        UUID accountId = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(
+                        List.of(rule(ConditionType.ACCOUNT_FLEET_SIZE, RuleOperator.GREATER_THAN_OR_EQUAL_TO, "10")));
+        when(accountProvider.getAccountContext(any())).thenReturn(Optional.of(new AccountContext(accountId, 4)));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, accountId, null, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.FLEET_SIZE_TOO_SMALL);
+    }
+
+    @Test
+    void givenVehicleTagRule_andNoVehicleId_whenEvaluate_thenMissingVehicleContext() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.VEHICLE_TAG, RuleOperator.EQUALS, "FLEET")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.MISSING_VEHICLE_CONTEXT);
+    }
+
+    @Test
+    void givenVehicleTagRule_andUnknownVehicle_whenEvaluate_thenMissingVehicleContext() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000c3");
+        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-0000000000c4");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.VEHICLE_TAG, RuleOperator.EQUALS, "FLEET")));
+        when(vehicleProvider.getVehicleContext(any())).thenReturn(Optional.empty());
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, vehicleId, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.MISSING_VEHICLE_CONTEXT);
+    }
+
+    @Test
+    void givenVehicleTagNotIn_andTagPresent_whenEvaluate_thenExcluded() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000c5");
+        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-0000000000c6");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.VEHICLE_TAG, RuleOperator.NOT_IN, "SALVAGE")));
+        when(vehicleProvider.getVehicleContext(any()))
+                .thenReturn(Optional.of(new VehicleContext(vehicleId, List.of("SALVAGE"))));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, vehicleId, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.VEHICLE_TAG_EXCLUDED);
+    }
+
+    @Test
+    void givenAudienceTypeRule_andBlankAudience_whenEvaluate_thenMissingAudienceContext() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.AUDIENCE_TYPE, RuleOperator.EQUALS, "COMMERCIAL")));
+
+        // Blank, not null: the guard is `audienceType == null || audienceType.isBlank()`, and only
+        // the null half was reached before.
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, "   ", null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.MISSING_AUDIENCE_CONTEXT);
+    }
+
+    @Test
+    void givenAudienceTypeNotIn_andAudienceMatches_whenEvaluate_thenExcluded() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000d2");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.AUDIENCE_TYPE, RuleOperator.NOT_IN, "COMMERCIAL")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, "commercial", null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.AUDIENCE_TYPE_EXCLUDED);
+    }
+
+    @Test
+    void givenCampaignCodeRule_andBlankCampaignCode_whenEvaluate_thenMissingCampaignContext() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.CAMPAIGN_CODE, RuleOperator.IN, "SPRING,SUMMER")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, null, "  ");
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.MISSING_CAMPAIGN_CONTEXT);
+    }
+
+    @Test
+    void givenCampaignCodeIn_andCodeInList_whenEvaluate_thenEligible() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000e2");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.CAMPAIGN_CODE, RuleOperator.IN, "SPRING, SUMMER")));
+
+        // Also pins that both the rule list and the supplied code are trimmed before comparison.
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, null, " SUMMER ");
+
+        assertThat(decision.isEligible()).isTrue();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.ELIGIBLE);
+    }
+
+    @Test
+    void givenCampaignCodeNotIn_andCodeInList_whenEvaluate_thenExcluded() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000e3");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.CAMPAIGN_CODE, RuleOperator.NOT_IN, "BLOCKED")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, null, "BLOCKED");
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.CAMPAIGN_CODE_EXCLUDED);
+    }
+
+    @Test
+    void givenFleetSizeRule_andUnsupportedOperator_whenEvaluate_thenEvaluationError() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+        UUID accountId = UUID.fromString("00000000-0000-0000-0000-0000000000f2");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.ACCOUNT_FLEET_SIZE, RuleOperator.IN, "10")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, accountId, null, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.EVALUATION_ERROR);
+    }
+
+    @Test
+    void givenVehicleTagRule_andUnsupportedOperator_whenEvaluate_thenEvaluationError() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000f3");
+        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-0000000000f4");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.VEHICLE_TAG, RuleOperator.IN, "FLEET")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, vehicleId, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.EVALUATION_ERROR);
+    }
+
+    @Test
+    void givenFleetSizeRule_andNonNumericThreshold_whenEvaluate_thenEvaluationError() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000b3");
+        UUID accountId = UUID.fromString("00000000-0000-0000-0000-0000000000b4");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(
+                        rule(ConditionType.ACCOUNT_FLEET_SIZE, RuleOperator.GREATER_THAN_OR_EQUAL_TO, "not-a-number")));
+        when(accountProvider.getAccountContext(any())).thenReturn(Optional.of(new AccountContext(accountId, 9)));
+
+        // A malformed rule must refuse the promotion rather than throw out of the evaluator.
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, accountId, null, null, null);
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.EVALUATION_ERROR);
+    }
+
+    @Test
+    void givenFleetSizeRule_andFleetMeetsThreshold_whenEvaluate_thenEligible() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000b5");
+        UUID accountId = UUID.fromString("00000000-0000-0000-0000-0000000000b6");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(
+                        List.of(rule(ConditionType.ACCOUNT_FLEET_SIZE, RuleOperator.GREATER_THAN_OR_EQUAL_TO, "10")));
+        when(accountProvider.getAccountContext(any())).thenReturn(Optional.of(new AccountContext(accountId, 10)));
+
+        // Boundary: the threshold is inclusive, so exactly-at-threshold must pass.
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, accountId, null, null, null);
+
+        assertThat(decision.isEligible()).isTrue();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.ELIGIBLE);
+    }
+
+    @Test
+    void givenCampaignCodeEquals_andCodeNotInList_whenEvaluate_thenNotMatched() {
+        UUID promotionId = UUID.fromString("00000000-0000-0000-0000-0000000000e4");
+        when(ruleRepo.findByPromotion_PromotionOfferId(any()))
+                .thenReturn(List.of(rule(ConditionType.CAMPAIGN_CODE, RuleOperator.EQUALS, "SPRING")));
+
+        EligibilityDecision decision = service().evaluateEligibility(promotionId, null, null, null, "AUTUMN");
+
+        assertThat(decision.isEligible()).isFalse();
+        assertThat(decision.reasonCode()).isEqualTo(EligibilityReasonCode.CAMPAIGN_CODE_NOT_MATCHED);
+    }
+
+    private EligibilityEvaluationServiceImpl service() {
+        return new EligibilityEvaluationServiceImpl(ruleRepo, promotionRepo, accountProvider, vehicleProvider);
+    }
+
     private PromotionEligibilityRule rule(ConditionType conditionType, RuleOperator operator, String value) {
         PromotionEligibilityRule rule = new PromotionEligibilityRule();
         rule.setConditionType(conditionType);

--- a/pos-tax/pom.xml
+++ b/pos-tax/pom.xml
@@ -17,12 +17,12 @@
     <description>Tax calculation service with external API passthrough and test mode support</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 78.5% line / 66.8% branch by the gate's own
+        <!-- Coverage ratchet: measured 79.9% line / 69.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.75</jacoco.line.min>
-        <jacoco.branch.min>0.63</jacoco.branch.min>
+        <jacoco.line.min>0.76</jacoco.line.min>
+        <jacoco.branch.min>0.66</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
@@ -268,41 +268,52 @@ public class AvalaraTaxProvider implements TaxProviderClient {
         BigDecimal subtotal = round(sumLineSubtotals(request));
         BigDecimal totalTax = round(tx.totalTax() != null ? tx.totalTax() : BigDecimal.ZERO);
 
-        Map<String, BigDecimal> requestSubtotals = new LinkedHashMap<>();
         Map<String, TaxLineItem> requestLines = new LinkedHashMap<>();
+        Map<String, BigDecimal> requestSubtotals = new LinkedHashMap<>();
         for (TaxLineItem item : request.getLineItems()) {
             requestSubtotals.put(item.getLineItemId(), round(item.getSubtotal()));
             requestLines.put(item.getLineItemId(), item);
         }
 
-        // Per-line tax breakdown + jurisdiction aggregation from AvaTax lines[].details[].
-        List<LineItemTax> lineItemTaxes = new ArrayList<>();
-        List<BigDecimal> rawLineTaxes = new ArrayList<>();
         Map<String, JurisdictionAccumulator> jurisdictionByCode = new LinkedHashMap<>();
+        List<BigDecimal> rawLineTaxes = new ArrayList<>();
+        List<LineItemTax> lineItemTaxes =
+                mapLineItemTaxes(tx, requestSubtotals, requestLines, jurisdictionByCode, rawLineTaxes);
 
+        reconcileLineTaxesToTotal(lineItemTaxes, rawLineTaxes, totalTax);
+        List<TaxJurisdiction> jurisdictions = aggregateJurisdictions(request, jurisdictionByCode, totalTax);
+
+        return TaxCalculationResponse.builder()
+                .subtotal(subtotal)
+                .totalTax(totalTax)
+                .total(subtotal.add(totalTax))
+                .effectiveTaxRate(effectiveRate(request, tx, totalTax))
+                .jurisdictions(jurisdictions)
+                .lineItemTaxes(lineItemTaxes)
+                .testMode(false)
+                .calculatedAt(clock.instant())
+                .referenceId(request.getReferenceId())
+                .referenceType(request.getReferenceType())
+                .externalTransactionId(externalId(tx))
+                .calculationType(calculationType)
+                .build();
+    }
+
+    /** Per-line tax breakdown from AvaTax {@code lines[].details[]}, accumulating jurisdictions as it goes. */
+    @NonNull
+    private List<LineItemTax> mapLineItemTaxes(
+            @NonNull TransactionModel tx,
+            @NonNull Map<String, BigDecimal> requestSubtotals,
+            @NonNull Map<String, TaxLineItem> requestLines,
+            @NonNull Map<String, JurisdictionAccumulator> jurisdictionByCode,
+            @NonNull List<BigDecimal> rawLineTaxes) {
+        List<LineItemTax> lineItemTaxes = new ArrayList<>();
         List<TransactionLineModel> avaLines = tx.lines() != null ? tx.lines() : List.of();
         for (TransactionLineModel avaLine : avaLines) {
             BigDecimal lineTax = avaLine.tax() != null ? avaLine.tax() : BigDecimal.ZERO;
             rawLineTaxes.add(lineTax);
 
-            List<JurisdictionTax> lineJurisdictions = new ArrayList<>();
-            List<TransactionLineDetailModel> details = avaLine.details() != null ? avaLine.details() : List.of();
-            for (TransactionLineDetailModel detail : details) {
-                BigDecimal rate = detail.rate() != null ? detail.rate() : BigDecimal.ZERO;
-                BigDecimal amount = detail.tax() != null ? detail.tax() : BigDecimal.ZERO;
-                TaxJurisdictionType type = mapJurisdictionType(detail.jurisdictionType());
-                String code = detail.jurisCode() != null ? detail.jurisCode() : type.code();
-                lineJurisdictions.add(JurisdictionTax.builder()
-                        .jurisdictionType(type)
-                        .code(code)
-                        .rate(rate)
-                        .amount(round(amount))
-                        .exempt(false)
-                        .build());
-                jurisdictionByCode
-                        .computeIfAbsent(type.code() + "|" + code, k -> new JurisdictionAccumulator(type, rate))
-                        .add(amount);
-            }
+            List<JurisdictionTax> lineJurisdictions = mapLineJurisdictions(avaLine, jurisdictionByCode);
 
             String lineId = avaLine.lineNumber();
             BigDecimal lineSubtotal = requestSubtotals.getOrDefault(lineId, round(safeAmount(avaLine.taxableAmount())));
@@ -317,66 +328,96 @@ public class AvalaraTaxProvider implements TaxProviderClient {
                     .jurisdictions(lineJurisdictions)
                     .build());
         }
+        return lineItemTaxes;
+    }
 
-        // Sigma-invariant repair: reconcile line tax amounts to the AvaTax grand total.
-        if (!lineItemTaxes.isEmpty()) {
-            List<BigDecimal> reconciledLineTaxes = reconciler.reconcileAmountsToTarget(rawLineTaxes, totalTax);
-            for (int i = 0; i < lineItemTaxes.size(); i++) {
-                LineItemTax lit = lineItemTaxes.get(i);
-                lit.setTaxAmount(reconciledLineTaxes.get(i));
-                lit.setTotal(lit.getSubtotal().add(reconciledLineTaxes.get(i)));
-            }
+    @NonNull
+    private List<JurisdictionTax> mapLineJurisdictions(
+            @NonNull TransactionLineModel avaLine, @NonNull Map<String, JurisdictionAccumulator> jurisdictionByCode) {
+        List<JurisdictionTax> lineJurisdictions = new ArrayList<>();
+        List<TransactionLineDetailModel> details = avaLine.details() != null ? avaLine.details() : List.of();
+        for (TransactionLineDetailModel detail : details) {
+            BigDecimal rate = detail.rate() != null ? detail.rate() : BigDecimal.ZERO;
+            BigDecimal amount = detail.tax() != null ? detail.tax() : BigDecimal.ZERO;
+            TaxJurisdictionType type = mapJurisdictionType(detail.jurisdictionType());
+            String code = detail.jurisCode() != null ? detail.jurisCode() : type.code();
+            lineJurisdictions.add(JurisdictionTax.builder()
+                    .jurisdictionType(type)
+                    .code(code)
+                    .rate(rate)
+                    .amount(round(amount))
+                    .exempt(false)
+                    .build());
+            jurisdictionByCode
+                    .computeIfAbsent(type.code() + "|" + code, k -> new JurisdictionAccumulator(type, rate))
+                    .add(amount);
         }
+        return lineJurisdictions;
+    }
 
-        // Aggregate top-level jurisdictions and reconcile their amounts to the grand total.
-        List<TaxJurisdiction> jurisdictions = new ArrayList<>();
+    /** Sigma-invariant repair: reconcile line tax amounts to the AvaTax grand total. */
+    private void reconcileLineTaxesToTotal(
+            @NonNull List<LineItemTax> lineItemTaxes,
+            @NonNull List<BigDecimal> rawLineTaxes,
+            @NonNull BigDecimal totalTax) {
+        if (lineItemTaxes.isEmpty()) {
+            return;
+        }
+        List<BigDecimal> reconciledLineTaxes = reconciler.reconcileAmountsToTarget(rawLineTaxes, totalTax);
+        for (int i = 0; i < lineItemTaxes.size(); i++) {
+            LineItemTax lit = lineItemTaxes.get(i);
+            lit.setTaxAmount(reconciledLineTaxes.get(i));
+            lit.setTotal(lit.getSubtotal().add(reconciledLineTaxes.get(i)));
+        }
+    }
+
+    /** Aggregates top-level jurisdictions and reconciles their amounts to the grand total. */
+    @NonNull
+    private List<TaxJurisdiction> aggregateJurisdictions(
+            @NonNull TaxCalculationRequest request,
+            @NonNull Map<String, JurisdictionAccumulator> jurisdictionByCode,
+            @NonNull BigDecimal totalTax) {
         List<BigDecimal> jurisdictionAmounts = new ArrayList<>();
         for (JurisdictionAccumulator acc : jurisdictionByCode.values()) {
             jurisdictionAmounts.add(acc.amount);
         }
-        List<BigDecimal> reconciledJurisdiction = jurisdictionAmounts.isEmpty()
+        List<BigDecimal> reconciled = jurisdictionAmounts.isEmpty()
                 ? jurisdictionAmounts
                 : reconciler.reconcileAmountsToTarget(jurisdictionAmounts, totalTax);
+
+        List<TaxJurisdiction> jurisdictions = new ArrayList<>();
         int j = 0;
-        String country = request.getCountryCode();
         for (JurisdictionAccumulator acc : jurisdictionByCode.values()) {
             jurisdictions.add(TaxJurisdiction.builder()
-                    .countryCode(country)
+                    .countryCode(request.getCountryCode())
                     .regionCode(request.getStateCode())
                     .city(request.getCity())
                     .postalCode(request.getPostalCode())
                     // Top-level taxRate is expressed as percentage points (e.g. 7.25).
                     .taxRate(acc.rate.multiply(HUNDRED))
                     .jurisdictionType(acc.type)
-                    .taxAmount(reconciledJurisdiction.get(j++))
+                    .taxAmount(reconciled.get(j++))
                     .build());
         }
+        return jurisdictions;
+    }
 
-        // Effective rate is tax over the TAXABLE base, not gross subtotal: exempt lines carry
-        // subtotal but contribute no tax, so including them would dilute the rate (#984). Prefer
-        // AvaTax's own taxable figure (it already nets out exempt/entity-use lines); fall back to
-        // the sum of non-exempt request subtotals when the provider omits it.
+    /**
+     * Effective rate is tax over the TAXABLE base, not gross subtotal.
+     *
+     * <p>Exempt lines carry subtotal but contribute no tax, so including them would dilute the rate
+     * (#984). Prefer AvaTax's own taxable figure — it already nets out exempt/entity-use lines — and
+     * fall back to the sum of non-exempt request subtotals when the provider omits it.
+     */
+    @NonNull
+    private BigDecimal effectiveRate(
+            @NonNull TaxCalculationRequest request, @NonNull TransactionModel tx, @NonNull BigDecimal totalTax) {
         BigDecimal taxableBase = tx.totalTaxable() != null && tx.totalTaxable().signum() != 0
                 ? round(tx.totalTaxable())
                 : round(sumNonExemptSubtotals(request));
-        BigDecimal effectiveRate = taxableBase.signum() == 0
+        return taxableBase.signum() == 0
                 ? BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP)
                 : totalTax.multiply(HUNDRED).divide(taxableBase, MONEY_SCALE, RoundingMode.HALF_UP);
-
-        return TaxCalculationResponse.builder()
-                .subtotal(subtotal)
-                .totalTax(totalTax)
-                .total(subtotal.add(totalTax))
-                .effectiveTaxRate(effectiveRate)
-                .jurisdictions(jurisdictions)
-                .lineItemTaxes(lineItemTaxes)
-                .testMode(false)
-                .calculatedAt(clock.instant())
-                .referenceId(request.getReferenceId())
-                .referenceType(request.getReferenceType())
-                .externalTransactionId(externalId(tx))
-                .calculationType(calculationType)
-                .build();
     }
 
     @NonNull

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraTaxProviderTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraTaxProviderTest.java
@@ -499,4 +499,115 @@ class AvalaraTaxProviderTest {
                 }
                 """;
     }
+
+    @Test
+    @DisplayName("#984c: when AvaTax omits totalTaxable, the rate falls back to non-exempt subtotals")
+    void effectiveRateFallsBackToNonExemptSubtotalsWhenProviderOmitsTaxable() {
+        // sumNonExemptSubtotals had 0% branch coverage: the #984 fallback was never exercised, so
+        // nothing held the rule that an exempt line must not dilute the effective rate when the
+        // provider declines to report a taxable figure. Effective rate is customer-visible.
+        Fixture f = fixture();
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andRespond(withSuccess(exemptLineResponseNoTaxableJson(), MediaType.APPLICATION_JSON));
+
+        TaxCalculationResponse response = f.provider().estimate(exemptLineRequest());
+        f.server().verify();
+
+        assertThat(response.getSubtotal()).isEqualByComparingTo("150.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("7.25");
+        // Same answer as when AvaTax reports totalTaxable=100.00: 7.25 / 100.00, not 7.25 / 150.00.
+        assertThat(response.getEffectiveTaxRate()).isEqualByComparingTo("7.25");
+    }
+
+    @Test
+    @DisplayName("#984d: an all-exempt request yields a zero rate rather than dividing by zero")
+    void allExemptRequestYieldsZeroEffectiveRate() {
+        Fixture f = fixture();
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(TaxLineItem.builder()
+                        .lineItemId("1")
+                        .description("Resale Part")
+                        .quantity(BigDecimal.ONE)
+                        .unitPrice(new BigDecimal("50.00"))
+                        .taxExempt(true)
+                        .build()))
+                .destinationAddress(TaxAddress.builder()
+                        .countryCode("US")
+                        .regionCode("CA")
+                        .city("Los Angeles")
+                        .postalCode("90001")
+                        .line1("123 Main St")
+                        .build())
+                .currencyCode("USD")
+                .referenceId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+                .transactionDate("2026-02-21T09:30:00Z")
+                .build();
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andRespond(withSuccess(allExemptResponseJson(), MediaType.APPLICATION_JSON));
+
+        TaxCalculationResponse response = f.provider().estimate(request);
+        f.server().verify();
+
+        // Taxable base is zero on both paths; the guard must return 0.00, not throw.
+        assertThat(response.getEffectiveTaxRate()).isEqualByComparingTo("0.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("0.00");
+    }
+
+    private TaxCalculationRequest exemptLineRequest() {
+        return TaxCalculationRequest.builder()
+                .lineItems(List.of(
+                        TaxLineItem.builder()
+                                .lineItemId("1")
+                                .description("Oil Change Service")
+                                .quantity(BigDecimal.ONE)
+                                .unitPrice(new BigDecimal("100.00"))
+                                .taxCategory("SERVICES")
+                                .build(),
+                        TaxLineItem.builder()
+                                .lineItemId("2")
+                                .description("Resale Part")
+                                .quantity(BigDecimal.ONE)
+                                .unitPrice(new BigDecimal("50.00"))
+                                .taxExempt(true)
+                                .build()))
+                .destinationAddress(TaxAddress.builder()
+                        .countryCode("US")
+                        .regionCode("CA")
+                        .city("Los Angeles")
+                        .postalCode("90001")
+                        .line1("123 Main St")
+                        .build())
+                .currencyCode("USD")
+                .referenceId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+                .transactionDate("2026-02-21T09:30:00Z")
+                .build();
+    }
+
+    /** The exempt-line response with totalTaxable absent, forcing the #984 fallback. */
+    private String exemptLineResponseNoTaxableJson() {
+        return exemptLineResponseJson().replace("  \"totalTaxable\": 100.00,\n", "");
+    }
+
+    private String allExemptResponseJson() {
+        return """
+                {
+                  "id": 987654322,
+                  "code": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": "Temporary",
+                  "totalAmount": 50.00,
+                  "totalTax": 0.00,
+                  "lines": [
+                    {
+                      "lineNumber": "1",
+                      "lineAmount": 50.00,
+                      "tax": 0.00,
+                      "taxableAmount": 0.00,
+                      "details": []
+                    }
+                  ]
+                }
+                """;
+    }
 }

--- a/pos-warranty/pom.xml
+++ b/pos-warranty/pom.xml
@@ -14,12 +14,12 @@
     <description>POS Warranty Claims module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 87.3% line / 78.9% branch by the gate's own
+        <!-- Coverage ratchet: measured 87.2% line / 79.6% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
         <jacoco.line.min>0.84</jacoco.line.min>
-        <jacoco.branch.min>0.75</jacoco.branch.min>
+        <jacoco.branch.min>0.76</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/EligibilityServiceImpl.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/EligibilityServiceImpl.java
@@ -76,77 +76,114 @@ public class EligibilityServiceImpl implements EligibilityService {
                         CLAIM_NOT_FOUND_CODE, "Warranty claim '" + claimId + "' was not found"));
 
         List<Map<String, Object>> reasons = new ArrayList<>();
+        LocalDate saleDate = claim.getOriginSaleDate();
 
-        // --- Origin verification (PRD §6 step 2: "origin verified?")
-        // -----------------------
+        verifyOrigin(claim, reasons);
+        WarrantyPolicy policy = matchPolicy(claim, saleDate, reasons);
+        selectCoverage(claim, policy);
+        Proration proration = prorateLines(claim, policy, saleDate, reasons);
+
+        EligibilityResult result = overallResult(reasons);
+
+        Map<String, Object> suggested = new LinkedHashMap<>();
+        suggested.put("eligible", result == EligibilityResult.ELIGIBLE);
+        suggested.put("policyId", policy != null ? policy.getId().toString() : null);
+        suggested.put("providerId", policy != null ? policy.getProviderId().toString() : null);
+        suggested.put("settlementType", suggestedSettlementType(policy));
+        // Never suggest a definite $0 when a line's credit is unknowable.
+        suggested.put("totalRequested", proration.anyAmountUnknown() ? null : proration.totalRequested());
+        suggested.put("perLine", proration.perLine());
+
+        claim.setEligibilityResult(result);
+        claim.setEligibilityReasons(reasons);
+        claim.setSuggestedOutcome(suggested);
+        claimRepository.save(claim);
+
+        return new EligibilityEvaluation(result, reasons, suggested);
+    }
+
+    /** What the per-line proration pass produced (PRD §6 table). */
+    private record Proration(BigDecimal totalRequested, boolean anyAmountUnknown, List<Map<String, Object>> perLine) {}
+
+    /** Origin verification (PRD §6 step 2: "origin verified?"). */
+    private void verifyOrigin(WarrantyClaim claim, List<Map<String, Object>> reasons) {
         boolean originUnverified = Boolean.TRUE.equals(claim.getOriginUnverified());
         reasons.add(reason(
                 "originVerified",
                 "original sale located and verified",
                 !originUnverified,
                 originUnverified ? null : Boolean.TRUE));
+    }
 
-        // --- Candidate policy matching (PRD §6 step 1)
-        // --------------------------------------
-        LocalDate saleDate = claim.getOriginSaleDate();
+    /**
+     * Candidate policy matching (PRD §6 step 1).
+     *
+     * @return the single governing policy, or {@code null} when none matched, several tied, or the
+     *     match could not be decided — every one of which is a reason appended to {@code reasons}
+     */
+    private @Nullable WarrantyPolicy matchPolicy(
+            WarrantyClaim claim, @Nullable LocalDate saleDate, List<Map<String, Object>> reasons) {
         ProductFacts facts = resolveProductFacts(claim);
-        WarrantyPolicy policy = null;
         if (saleDate == null) {
             reasons.add(reason("originSaleDate", "known original sale date", null, null));
-        } else {
-            CoverageType coverageType =
-                    CoverageType.valueOf(claim.getClaimType().name());
-            List<WarrantyPolicy> effective = policyRepository.findEffectiveOn(saleDate).stream()
-                    .filter(p -> p.getCoverageType() == coverageType)
-                    .toList();
-            List<WarrantyPolicy> candidates = findCandidatePolicies(effective, facts);
-            String required = "a policy in effect on " + saleDate + " matching the claimed products";
-            if (candidates.isEmpty()) {
-                // Missing product facts (catalog unreachable) mean we cannot prove no policy
-                // applies — indeterminate rather than a hard fail.
-                reasons.add(reason(POLICY_MATCH, required, "none found", facts.incomplete() ? null : Boolean.FALSE));
-            } else {
-                int topRank = specificityRank(candidates.get(0).getAppliesToType());
-                List<WarrantyPolicy> winners = candidates.stream()
-                        .filter(p -> specificityRank(p.getAppliesToType()) == topRank)
-                        .toList();
-                if (facts.incomplete() && moreSpecificScopeUnevaluated(effective, facts, topRank)) {
-                    // A MANUFACTURER/CATEGORY policy more specific than the winner could not be
-                    // evaluated because catalog facts are unavailable — the broader winner may be
-                    // the wrong policy, so the match is indeterminate rather than a silent
-                    // specificity downgrade.
-                    reasons.add(reason(
-                            POLICY_MATCH,
-                            required,
-                            "product facts unavailable (pos-catalog unreachable); a more specific"
-                                    + " policy may govern",
-                            null));
-                } else if (winners.size() > 1) {
-                    // Specificity tie: no policy governs until a human resolves the ambiguity —
-                    // never adjudicate terms or freeze amounts from an arbitrary tie-break.
-                    reasons.add(reason(
-                            POLICY_MATCH,
-                            required,
-                            "ambiguous — multiple policies tie at the same specificity: "
-                                    + winners.stream()
-                                            .map(WarrantyPolicy::getName)
-                                            .toList(),
-                            null));
-                } else {
-                    policy = winners.get(0);
-                    reasons.add(reason(
-                            POLICY_MATCH, required, policy.getName() + " (" + policy.getId() + ")", Boolean.TRUE));
-                    checkTerms(claim, policy, saleDate, reasons);
-                }
-            }
+            return null;
         }
 
-        // Select coverage onto the claim only when a single policy wins (PRD §6 /
-        // contract);
-        // otherwise clear any coverage a previous evaluation selected so a re-run after
-        // intake
-        // edits (e.g. claimType change) or a registration lapse never leaves stale
-        // policy/provider/registration pointers behind.
+        CoverageType coverageType = CoverageType.valueOf(claim.getClaimType().name());
+        List<WarrantyPolicy> effective = policyRepository.findEffectiveOn(saleDate).stream()
+                .filter(p -> p.getCoverageType() == coverageType)
+                .toList();
+        List<WarrantyPolicy> candidates = findCandidatePolicies(effective, facts);
+        String required = "a policy in effect on " + saleDate + " matching the claimed products";
+        if (candidates.isEmpty()) {
+            // Missing product facts (catalog unreachable) mean we cannot prove no policy
+            // applies — indeterminate rather than a hard fail.
+            reasons.add(reason(POLICY_MATCH, required, "none found", facts.incomplete() ? null : Boolean.FALSE));
+            return null;
+        }
+
+        int topRank = specificityRank(candidates.get(0).getAppliesToType());
+        List<WarrantyPolicy> winners = candidates.stream()
+                .filter(p -> specificityRank(p.getAppliesToType()) == topRank)
+                .toList();
+        if (facts.incomplete() && moreSpecificScopeUnevaluated(effective, facts, topRank)) {
+            // A MANUFACTURER/CATEGORY policy more specific than the winner could not be
+            // evaluated because catalog facts are unavailable — the broader winner may be
+            // the wrong policy, so the match is indeterminate rather than a silent
+            // specificity downgrade.
+            reasons.add(reason(
+                    POLICY_MATCH,
+                    required,
+                    "product facts unavailable (pos-catalog unreachable); a more specific" + " policy may govern",
+                    null));
+            return null;
+        }
+        if (winners.size() > 1) {
+            // Specificity tie: no policy governs until a human resolves the ambiguity —
+            // never adjudicate terms or freeze amounts from an arbitrary tie-break.
+            reasons.add(reason(
+                    POLICY_MATCH,
+                    required,
+                    "ambiguous — multiple policies tie at the same specificity: "
+                            + winners.stream().map(WarrantyPolicy::getName).toList(),
+                    null));
+            return null;
+        }
+
+        WarrantyPolicy policy = winners.get(0);
+        reasons.add(reason(POLICY_MATCH, required, policy.getName() + " (" + policy.getId() + ")", Boolean.TRUE));
+        checkTerms(claim, policy, saleDate, reasons);
+        return policy;
+    }
+
+    /**
+     * Selects coverage onto the claim only when a single policy wins (PRD §6 / contract).
+     *
+     * <p>Otherwise it clears any coverage a previous evaluation selected, so a re-run after intake
+     * edits (e.g. a claimType change) or a registration lapse never leaves stale
+     * policy/provider/registration pointers behind.
+     */
+    private void selectCoverage(WarrantyClaim claim, @Nullable WarrantyPolicy policy) {
         if (policy != null) {
             claim.setPolicyId(policy.getId());
             claim.setProviderId(policy.getProviderId());
@@ -155,9 +192,14 @@ public class EligibilityServiceImpl implements EligibilityService {
             claim.setProviderId(null);
             claim.setRegistrationId(null);
         }
+    }
 
-        // --- Per-line proration (PRD §6 table)
-        // -----------------------------------------------
+    /** Per-line proration (PRD §6 table). */
+    private Proration prorateLines(
+            WarrantyClaim claim,
+            @Nullable WarrantyPolicy policy,
+            @Nullable LocalDate saleDate,
+            List<Map<String, Object>> reasons) {
         Long monthsElapsed = saleDate != null ? ChronoUnit.MONTHS.between(saleDate, referenceDate(claim)) : null;
         // Sale-time odometer is not captured anywhere upstream today, so the delta is
         // unknown.
@@ -204,26 +246,7 @@ public class EligibilityServiceImpl implements EligibilityService {
             lineEntry.put("amountRequested", amount);
             perLine.add(lineEntry);
         }
-
-        // --- Overall result
-        // --------------------------------------------------------------------
-        EligibilityResult result = overallResult(reasons);
-
-        Map<String, Object> suggested = new LinkedHashMap<>();
-        suggested.put("eligible", result == EligibilityResult.ELIGIBLE);
-        suggested.put("policyId", policy != null ? policy.getId().toString() : null);
-        suggested.put("providerId", policy != null ? policy.getProviderId().toString() : null);
-        suggested.put("settlementType", suggestedSettlementType(policy));
-        // Never suggest a definite $0 when a line's credit is unknowable.
-        suggested.put("totalRequested", anyAmountUnknown ? null : totalRequested);
-        suggested.put("perLine", perLine);
-
-        claim.setEligibilityResult(result);
-        claim.setEligibilityReasons(reasons);
-        claim.setSuggestedOutcome(suggested);
-        claimRepository.save(claim);
-
-        return new EligibilityEvaluation(result, reasons, suggested);
+        return new Proration(totalRequested, anyAmountUnknown, perLine);
     }
 
     // -----------------------------------------------------------------------------------------

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/service/EligibilityServiceImplTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/service/EligibilityServiceImplTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -588,5 +589,98 @@ class EligibilityServiceImplTest {
         assertThatThrownBy(() -> service.evaluate(CLAIM_ID))
                 .isInstanceOf(WarrantyNotFoundException.class)
                 .hasMessageContaining(CLAIM_ID.toString());
+    }
+
+    // ── Registration-matching coverage (Phase 3.6) ─────────────────────────────────
+    //
+    // findActiveRegistration filters on three rules, and JaCoCo had its vehicle-scope
+    // predicate at 16.7% branch: essentially untested. That filter decides whether a
+    // registration taken out for one vehicle can cover a claim on another. Getting it wrong
+    // grants warranty coverage to a vehicle nobody registered, which is the expensive
+    // direction. The expiry boundary was equally unpinned.
+
+    @Test
+    @DisplayName("A registration for a different vehicle does not cover this claim")
+    void registrationForAnotherVehicleDoesNotMatch() {
+        WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
+        claim.setVehicleId(UUID.fromString("018f0000-0000-7000-8000-000000000091"));
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setCoverageType(CoverageType.ROAD_HAZARD);
+        WarrantyRegistration otherVehicle = registration(policy.getId(), null);
+        otherVehicle.setVehicleId(UUID.fromString("018f0000-0000-7000-8000-000000000099"));
+        stubRegistrationScenario(claim, policy, otherVehicle);
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(claim.getRegistrationId()).isNull();
+    }
+
+    @Test
+    @DisplayName("A registration with no vehicle scope covers any vehicle on the policy")
+    void policyLevelRegistrationCoversAnyVehicle() {
+        WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
+        claim.setVehicleId(UUID.fromString("018f0000-0000-7000-8000-000000000098"));
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setCoverageType(CoverageType.ROAD_HAZARD);
+        // vehicleId left null: a policy-level registration is deliberately not vehicle-bound.
+        WarrantyRegistration policyLevel = registration(policy.getId(), null);
+        stubRegistrationScenario(claim, policy, policyLevel);
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.ELIGIBLE);
+        assertThat(claim.getRegistrationId()).isEqualTo(policyLevel.getId());
+    }
+
+    @Test
+    @DisplayName("A registration that expired before the failure date does not cover the claim")
+    void expiredRegistrationDoesNotMatch() {
+        WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setCoverageType(CoverageType.ROAD_HAZARD);
+        WarrantyRegistration expired = registration(policy.getId(), FAILURE_DATE.minusDays(1));
+        stubRegistrationScenario(claim, policy, expired);
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(claim.getRegistrationId()).isNull();
+    }
+
+    @Test
+    @DisplayName("A registration expiring on the failure date still covers it")
+    void registrationExpiringOnTheFailureDateStillMatches() {
+        WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setCoverageType(CoverageType.ROAD_HAZARD);
+        // Boundary: the filter is `!expiresAt.isBefore(referenceDate)`, so cover ends at the
+        // close of the expiry date rather than the start of it.
+        WarrantyRegistration expiringToday = registration(policy.getId(), FAILURE_DATE);
+        stubRegistrationScenario(claim, policy, expiringToday);
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.ELIGIBLE);
+        assertThat(claim.getRegistrationId()).isEqualTo(expiringToday.getId());
+    }
+
+    private WarrantyRegistration registration(UUID policyId, LocalDate expiresAt) {
+        return WarrantyRegistration.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000021"))
+                .policyId(policyId)
+                .customerId(CUSTOMER_ID)
+                .purchaseDate(SALE_DATE)
+                .expiresAt(expiresAt)
+                .status(RegistrationStatus.ACTIVE)
+                .build();
+    }
+
+    private void stubRegistrationScenario(WarrantyClaim claim, WarrantyPolicy policy, WarrantyRegistration reg) {
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
+        when(registrationRepository.findByCustomerIdAndStatus(CUSTOMER_ID, RegistrationStatus.ACTIVE))
+                .thenReturn(List.of(reg));
     }
 }


### PR DESCRIPTION
Phase 3.6 of `docs/SONARQUBE_REMEDIATION_PLAN.md` — the `java:S3776` cognitive-complexity findings. **This PR covers the five worst of the 62; the remaining 57 are follow-up work.** Follows #1487, #1488, #1490, #1491 and #1495.

## Capability & Traceability
- Capability: n/a — code-health work, not a capability slice
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:price`, `domain:inventory`, `domain:accounting`, `domain:warranty`, `domain:tax`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no contract semantics change. No controller, DTO, event payload, `openapi.yaml`, or validation/error model changes. `InventoryFactPublisher` still emits the same fourteen event types with the same schema versions and aggregate ids — the tests added here are what pin that. Reference retained per the template so the Contract Sync Enforcement check can find `BACKEND_CONTRACT_GUIDE.md` in this body.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

Unlike every earlier phase, this one changes real control flow, so the order of work matters and each commit records it: **measure branch coverage → write characterisation tests against the unrefactored method → refactor → confirm the same tests pass → close the gaps the split makes visible → ratchet the floor.**

| # | Target | Cx | Class branch coverage | Floor |
| - | ------ | -: | --------------------- | ----- |
| 1 | `pos-price` `EligibilityEvaluationServiceImpl.evaluateSingleRule` | 57 | module 80.4% → 85.0% | branch `0.77→0.81` |
| 2 | `pos-inventory` `InventoryFactPublisher.publishPending` | 52 | 39.5% → 58.1% | line `0.76→0.77`, branch `0.61→0.62` |
| 3 | `pos-accounting` `PredicateParser.tokenize` | 37 | 98.1% → 98.7% | already matched |
| 4 | `pos-warranty` `EligibilityServiceImpl.evaluate` | 34 | 78.9% → 83.6% | branch `0.75→0.76` |
| 5 | `pos-tax` `AvalaraTaxProvider.mapResponse` | 34 | 62.6% → 69.7% | line `0.75→0.76`, branch `0.63→0.66` |

### The coverage work is not incidental — it found real gaps

The plan gated 3.6 on test coverage. That gate earned its keep, and the pattern that emerged is worth stating: **the complexity finding names a method, but the untested branches are almost always in the helper it delegates to** — which is where the business rules live.

- **`sumNonExemptSubtotals` was at 0% branch.** It is the `#984` fallback for the effective-rate denominator: an exempt line carries subtotal but no tax, so counting it dilutes the rate. AvaTax normally reports `totalTaxable` and that path is well tested — nothing exercised the case where the provider omits it. Effective tax rate is customer-visible.
- **`findActiveRegistration`'s vehicle-scope filter was at 16.7% branch** — one covered path in six. It decides whether a registration taken out for one vehicle can cover a claim on another. Wrong answer grants warranty coverage to a vehicle nobody registered.
- **`InventoryFactPublisher` emits fourteen fact types to the outbox, and exactly one had a publish test.** Every one of those events is consumed by other modules, so each block's mapping — event type, schema version, aggregate id — is a contract, and thirteen were unpinned.
- **The `NOT_IN` (exclusion) operator was barely covered on any condition type** in the promotion-eligibility evaluator. Those are the rules that *deny* a promotion; a defect grants a discount that should have been refused.

Twenty-seven tests were added across the five targets. Writing them surfaced things worth knowing independently — the backorder and reservation events require exactly one of `workorderLineId`/`salesOrderLineId`, a transfer-order update rejects an empty line list, and warranty cover ends at the *close* of the expiry date (`!expiresAt.isBefore(referenceDate)`), not the start.

### Two findings that changed what the right fix was

**`PredicateParser` needed no characterisation work at all** — already 98.1% branch behind 21 tests and a fuzz test. Recorded in that commit because the discipline is a gate, not a ritual. The file also already named the shape to follow: `lexNumber(input, start, tokens)` predated this change, and the other branches simply had not been given the same treatment.

**A branch that reads as uncovered is not always a gap.** `compareString`'s ordering arm looks like a missing lexicographic-comparison test. It is not: the grammar rejects `>=` against a quoted string at parse time, so that arm is unreachable through the public API. The test now asserts the parse error a rule author actually meets, and records why the branch stays uncovered so the next person does not re-derive it.

### On the exhaustive switch

`evaluateSingleRule`'s `if/else` chain over `ConditionType` became an exhaustive `switch`. For every condition type that exists today the outcome is identical — the twelve characterisation tests pass unchanged, which is the evidence. Adding a new condition type now fails to compile rather than silently falling through to ELIGIBLE, which is the safe direction for a rule engine whose job is to withhold discounts.

## Tests

Every characterisation test was run against the **unrefactored** method first, then again after the split. That is the evidence that behaviour was preserved; the two boundary tests from earlier phases were additionally checked to fail against the bug they guard.

- [x] Unit tests added/updated — 27 across five modules
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a, no contract changed

**How to run:**

```bash
./mvnw -pl pos-price,pos-inventory,pos-accounting,pos-warranty,pos-tax -DskipTests=false verify
```

`verify` rather than `test`: this PR raises seven coverage floors, and the ratchet only runs at `verify`. All five modules pass with the new floors enforced — `pos-price` 172, `pos-inventory` 958, `pos-accounting` 1257, `pos-warranty` 425, `pos-tax` 129 tests, with Spotless, Checkstyle and SpotBugs enabled.

## Risk & Rollback
- Risk level: **Medium.** This is the first phase to change control flow. No behaviour is intended to change, but "intended" is doing real work in that sentence, which is why every target carries characterisation tests written before the refactor rather than after. The exhaustive-switch conversion in `pos-price` is the one deliberate semantic change, and it is compile-time only.
- Rollback plan: revert the commits. No schema change, no migration, no new dependency. The raised floors revert with the poms; nothing else depends on them.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no; `claude/*` branch, consistent with recently merged PRs
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap id for code-health work
- [ ] Links to parent + child issues are present — no tracking issue exists for this work
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending first run

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKBxAj3zreJqYprAGvtXnS)_