### PR TITLE
fix(inventory): distinguishable refusals for receiving and executable putaway tasks (#1492, #1493, #1496)

### DIFF
--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -2527,7 +2527,7 @@ paths:
 
         Emits an INVENTORY_GOODS_RECEIPT_CREATE event, decrements the purchase order''s open balance, moves the PO to PARTIALLY_RECEIVED or FULLY_RECEIVED, and updates the linked ASN''s received quantities and status.
 
-        Returns 403 when the receipt exceeds the open balance without the override authority, 404 when the ASN or a referenced PO line cannot be resolved, 400 when the purchase order is unknown or not receivable, and 422 when a UoM has no conversion path, a LOT-tracked line omits lotNumber, or a serialized line''s serial count mismatches the received quantity.
+        Returns 403 when the caller lacks inventory:goods_receipt:create, 404 when the ASN or a referenced PO line cannot be resolved, 400 when the purchase order is unknown or not receivable, and 422 when a UoM has no conversion path, a LOT-tracked line omits lotNumber, a serialized line''s serial count mismatches the received quantity, or the receipt exceeds the open balance without the override authority (OVER_RECEIPT_NOT_PERMITTED).
 
         '
       operationId: createGoodsReceipt
@@ -2587,7 +2587,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
-          description: UoM conversion undefined, lot number required, or serial count mismatch
+          description: UoM conversion undefined, lot number required, serial count mismatch, or over-receipt without the override authority (OVER_RECEIPT_NOT_PERMITTED)
       security:
       - bearerAuth:
         - inventory:goods_receipt:create
@@ -4521,17 +4521,17 @@ paths:
       - inventory:putaway:view
   /v1/inventory/putaway/tasks/generate:
     post:
-      description: 'Generates one UNASSIGNED putaway task per received line of a goods receipt, sourced from the staging location, with the suggested destination resolved by the highest-priority enabled putaway rule or the default location when no rule exists.
+      description: 'Generates one UNASSIGNED putaway task per received line of a goods receipt, sourced from the receipt''s staging location, with the suggested destination resolved by the highest-priority enabled putaway rule or the default location when no rule exists.
 
         Use this tool once staged goods need storage assignments; do not use executePutaway, which performs the physical move for one task, and do not use claimPutawayTask, which assigns an existing task to a worker.
 
-        Preconditions: the goods receipt named by sourceReceiptId must exist; putaway rules are optional.
+        Preconditions: the goods receipt named by sourceReceiptId must exist and its stock must actually be at the staging location - a receipt that placed stock directly on hand elsewhere (the ASN direct-to-location path) has nothing staged to put away; putaway rules are optional, but the resolved destination must be valid for the SKU under replenishment policy.
 
         Required inputs: sourceReceiptId (UUID string) plus either lineItems, each naming productId (UUID string) and a quantity of at least 1, or the legacy productId/quantity pair, but never both forms together.
 
         Emits an INVENTORY_PUTAWAY_TASK_GENERATE event; the tasks are created UNASSIGNED and no stock moves until executePutaway runs.
 
-        Returns 404 when the goods receipt does not exist, and 400 when both line forms are supplied, neither is supplied, an id is not a valid UUID, or a quantity is below 1.
+        Returns 404 when the goods receipt does not exist, 422 with RECEIPT_NOT_STAGED when the receipt''s stock is not at the staging location or LOCATION_NOT_VALID_FOR_SKU when the resolved destination is not valid for the SKU under replenishment policy (whole request refused, no tasks persisted), and 400 when both line forms are supplied, neither is supplied, an id is not a valid UUID, or a quantity is below 1.
 
         '
       operationId: generatePutawayTasks
@@ -4575,6 +4575,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
           description: Goods receipt not found
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: 'Generation refused: RECEIPT_NOT_STAGED (receipt placed stock directly on hand; nothing staged to put away) or LOCATION_NOT_VALID_FOR_SKU (resolved destination not valid for the SKU under replenishment policy)'
       security:
       - bearerAuth:
         - inventory:putaway:generate
@@ -4718,7 +4724,7 @@ paths:
 
         Emits an INVENTORY_RECEIVING_SESSION_CREATE event; no stock is posted, the session only stages expected quantities until items are received.
 
-        Returns 404 when no such purchase order has been projected, 400 when it is already fully received, is not in a receivable status, or entryMethod is not a known value, and 422 when the source document type is not a purchase order.
+        Returns 409 (SOURCE_DOCUMENT_LINES_UNAVAILABLE) when sourceDocumentId is a well-formed purchase order id absent from this service''s projection - the projection may simply not have caught up yet, or the id may be unknown, and this service cannot tell which; retry after a few seconds, per the response''s nextAction - 404 when sourceDocumentId cannot even be parsed as a purchase order identifier, 400 when the purchase order is already fully received, is not in a receivable status, or entryMethod is not a known value, and 422 when the source document type is not a purchase order.
 
         '
       operationId: createReceivingSession
@@ -4759,7 +4765,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
-          description: No such purchase order has been projected into pos-inventory
+          description: sourceDocumentId does not parse as a purchase order identifier
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: SOURCE_DOCUMENT_LINES_UNAVAILABLE - the purchase order's line projection has not caught up (or the id is unknown); retryable, see nextAction
         '422':
           content:
             application/json:

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -45,6 +45,7 @@ import com.positivity.inventory.internal.exception.SerialNotAvailableException;
 import com.positivity.inventory.internal.exception.ShortageResolutionException;
 import com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
+import com.positivity.inventory.internal.exception.SourceDocumentLinesUnavailableException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.exception.TransferLocationNotEligibleException;
@@ -127,7 +128,7 @@ public class InventoryGlobalExceptionHandler {
 
     @ExceptionHandler(OverReceiptNotPermittedException.class)
     public ResponseEntity<ApiError> handleOverReceiptNotPermitted(OverReceiptNotPermittedException ex) {
-        return build(HttpStatus.FORBIDDEN, FORBIDDEN, ex.getMessage());
+        return build(HttpStatus.valueOf(422), OverReceiptNotPermittedException.ERROR_CODE, ex.getMessage());
     }
 
     @ExceptionHandler(TaskNotFoundException.class)
@@ -287,6 +288,29 @@ public class InventoryGlobalExceptionHandler {
     @ExceptionHandler({SourceDocumentNotFoundException.class, ReceivingSessionNotFoundException.class})
     public ResponseEntity<ApiError> handleReceivingNotFound(RuntimeException ex) {
         return build(HttpStatus.NOT_FOUND, NOT_FOUND, ex.getMessage());
+    }
+
+    /**
+     * A receiving session named a purchase order id absent from the projection (#1492). The header
+     * and its lines are projected atomically and ADR-0044 forbids a synchronous check against
+     * pos-order, so this module cannot tell replication lag from an unknown id — 409, with a
+     * nextAction that says both.
+     */
+    @ExceptionHandler(SourceDocumentLinesUnavailableException.class)
+    public ResponseEntity<ApiError> handleSourceDocumentLinesUnavailable(SourceDocumentLinesUnavailableException ex) {
+        String correlationId = resolveCorrelationId(null);
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .header(X_CORRELATION_ID, correlationId)
+                .body(ApiError.guided(
+                        SourceDocumentLinesUnavailableException.ERROR_CODE,
+                        ex.getMessage(),
+                        HttpStatus.CONFLICT.value(),
+                        Instant.now(clock).toString(),
+                        correlationId,
+                        null,
+                        "The purchase-order line projection has not caught up. Retry in a few seconds; "
+                                + "if this persists, the purchase order id is unknown.",
+                        null));
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/OverReceiptNotPermittedException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/OverReceiptNotPermittedException.java
@@ -1,6 +1,15 @@
 package com.positivity.inventory.internal.exception;
 
+/**
+ * Thrown when a goods receipt would push the received total past the purchase order's open
+ * balance and the caller does not hold {@code inventory:goods_receipt:override}.
+ *
+ * <p>Maps to a deterministic 422 with code {@code OVER_RECEIPT_NOT_PERMITTED} — the request is
+ * well-formed, but posting it would over-receive the order without the authority to do so.
+ */
 public class OverReceiptNotPermittedException extends RuntimeException {
+
+    public static final String ERROR_CODE = "OVER_RECEIPT_NOT_PERMITTED";
 
     public OverReceiptNotPermittedException(String message) {
         super(message);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/ReceiptNotStagedException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/ReceiptNotStagedException.java
@@ -1,0 +1,43 @@
+package com.positivity.inventory.internal.exception;
+
+import java.util.UUID;
+
+/**
+ * Thrown when putaway is requested for a receipt whose stock never passed through staging.
+ *
+ * <p>Putaway moves stock out of the staging location into storage; a receipt that placed its
+ * stock directly at a location other than staging has nothing staged to put away. This is a
+ * modeling refusal, not a data consistency error: the caller should look at the receipt's actual
+ * location rather than retry or reconcile.
+ */
+public class ReceiptNotStagedException extends PutawayValidationException {
+    public static final String ERROR_CODE = "RECEIPT_NOT_STAGED";
+
+    private final UUID receiptId;
+    private final UUID actualLocationId;
+    private final UUID stagingLocationId;
+
+    public ReceiptNotStagedException(UUID receiptId, UUID actualLocationId, UUID stagingLocationId) {
+        super(
+                ERROR_CODE,
+                String.format(
+                        "Goods receipt %s cannot be put away: its stock is at location %s, not the staging "
+                                + "location %s. Putaway only applies to stock that went through staging.",
+                        receiptId, actualLocationId, stagingLocationId));
+        this.receiptId = receiptId;
+        this.actualLocationId = actualLocationId;
+        this.stagingLocationId = stagingLocationId;
+    }
+
+    public UUID getReceiptId() {
+        return receiptId;
+    }
+
+    public UUID getActualLocationId() {
+        return actualLocationId;
+    }
+
+    public UUID getStagingLocationId() {
+        return stagingLocationId;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/SourceDocumentLinesUnavailableException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/SourceDocumentLinesUnavailableException.java
@@ -1,0 +1,21 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Thrown when a receiving session names a purchase order that the {@code ext_purchase_order}
+ * projection does not (yet) hold (issue #1492).
+ *
+ * <p>{@code PurchaseOrderUpdatedV1} projects a header and its lines atomically, and ADR-0044 rules
+ * out a synchronous call to pos-order to tell replication lag apart from an unknown purchase order
+ * id — this module can only see the missing row, not the reason for it. Maps to a deterministic
+ * 409 with code {@code SOURCE_DOCUMENT_LINES_UNAVAILABLE} and a guided {@code nextAction}: retry
+ * shortly, since the projection may still be catching up, and treat the id as unknown if it does
+ * not.
+ */
+public class SourceDocumentLinesUnavailableException extends RuntimeException {
+
+    public static final String ERROR_CODE = "SOURCE_DOCUMENT_LINES_UNAVAILABLE";
+
+    public SourceDocumentLinesUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
@@ -254,7 +254,8 @@ public class AsnServiceImpl implements AsnService {
         long currentOpenBalance = safeLong(purchaseOrder.getOpenBalanceMinor());
         if (receiptTotalMinor > currentOpenBalance
                 && !SecurityContextHelper.hasAuthority("inventory:goods_receipt:override")) {
-            throw new OverReceiptNotPermittedException("OVER_RECEIPT_NOT_PERMITTED");
+            throw new OverReceiptNotPermittedException("Receiving " + receiptTotalMinor + " exceeds the "
+                    + currentOpenBalance + " outstanding on purchase order " + purchaseOrder.getPurchaseOrderId());
         }
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayGenerationServiceImpl.java
@@ -7,12 +7,14 @@ import com.positivity.inventory.internal.entity.GoodsReceiptEntity;
 import com.positivity.inventory.internal.entity.PutawayRule;
 import com.positivity.inventory.internal.entity.PutawayTask;
 import com.positivity.inventory.internal.enums.PutawayTaskStatus;
+import com.positivity.inventory.internal.exception.ReceiptNotStagedException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.repository.GoodsReceiptRepository;
 import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.internal.repository.PutawayTaskRepository;
 import com.positivity.inventory.service.PutawayGenerationService;
+import com.positivity.inventory.service.PutawayValidationService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,16 +29,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PutawayGenerationServiceImpl implements PutawayGenerationService {
 
-    // NOTE: These default/staging location IDs are hardcoded for simplicity, but in
-    // a real implementation they would likely be configurable or determined
-    // dynamically based on the receipt or warehouse context.
     private static final UUID DEFAULT_LOCATION = UUID.fromString("00000000-0000-0000-0000-000000000001");
-    private static final UUID STAGING_LOCATION = UUID.fromString("00000000-0000-0000-0000-000000000002");
 
     private final PutawayRuleRepository putawayRuleRepository;
     private final PutawayTaskRepository putawayTaskRepository;
     private final GoodsReceiptRepository goodsReceiptRepository;
     private final PutawayDestinationResolver putawayDestinationResolver;
+    private final StagingLocationResolver stagingLocationResolver;
+    private final PutawayValidationService putawayValidationService;
 
     @Override
     @Transactional
@@ -45,6 +45,11 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
         GoodsReceiptEntity sourceReceipt = goodsReceiptRepository
                 .findById(sourceReceiptId)
                 .orElseThrow(() -> new ResourceNotFoundException("GoodsReceipt", sourceReceiptId.toString()));
+
+        UUID stagingLocationId = stagingLocationResolver.resolveStagingLocationId();
+        if (!stagingLocationId.equals(sourceReceipt.getLocationId())) {
+            throw new ReceiptNotStagedException(sourceReceiptId, sourceReceipt.getLocationId(), stagingLocationId);
+        }
 
         List<PutawayRule> enabledRules = putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc();
         Optional<PutawayRule> winningRule =
@@ -111,12 +116,14 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
         PutawayDestinationResolver.ResolvedDestination destination = winningRule
                 .map(rule -> putawayDestinationResolver.resolve(rule, lineItem.productId(), lineItem.quantity()))
                 .orElseGet(() -> new PutawayDestinationResolver.ResolvedDestination(DEFAULT_LOCATION, null, null));
+        putawayValidationService.validateLocationCompatibility(
+                destination.destinationLocationId(), lineItem.productId().toString());
 
         return PutawayTask.builder()
                 .sourceReceipt(sourceReceipt)
                 .productId(lineItem.productId())
                 .quantity(lineItem.quantity())
-                .sourceLocationId(STAGING_LOCATION)
+                .sourceLocationId(sourceReceipt.getLocationId())
                 .suggestedDestinationLocationId(destination.destinationLocationId())
                 .originalSuggestedLocationId(destination.originalSuggestedLocationId())
                 .finalSuggestedLocationId(destination.isFallback() ? destination.destinationLocationId() : null)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
@@ -26,13 +26,11 @@ import com.positivity.inventory.internal.repository.InventoryVarianceRepository;
 import com.positivity.inventory.internal.repository.ReceivingSessionRepository;
 import com.positivity.inventory.service.ReceivingService;
 import com.positivity.security.common.SecurityContextHelper;
-import jakarta.servlet.http.HttpServletRequest;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -41,9 +39,6 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.servlet.HandlerMapping;
 
 @Service
 @RequiredArgsConstructor
@@ -52,7 +47,6 @@ import org.springframework.web.servlet.HandlerMapping;
 public class ReceivingServiceImpl implements ReceivingService {
 
     private static final String PART_MATCH_OVERRIDE_PERMISSION = "inventory:override:part-match";
-    private static final UUID DEFAULT_STAGING_LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
     private static final UUID DEFAULT_CROSS_DOCK_LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
 
     private final ReceivingSessionRepository receivingSessionRepository;
@@ -61,17 +55,11 @@ public class ReceivingServiceImpl implements ReceivingService {
     private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final SourceDocumentResolver sourceDocumentResolver;
-    private final SiteDefaultsService siteDefaultsService;
+    private final StagingLocationResolver stagingLocationResolver;
     private final WorkorderValidationService workorderValidationService;
     private final DocumentQuantityConverter documentQuantityConverter;
     private final InventoryLotCaptureService lotCaptureService;
     private final QuantityScaleGuard quantityScaleGuard;
-
-    @Value("${pos.inventory.receiving.site-id:}")
-    private String configuredSiteId;
-
-    @Value("${pos.inventory.receiving.staging-location-id:}")
-    private String configuredStagingLocationId;
 
     @Value("${pos.inventory.receiving.cross-dock-location-id:}")
     private String configuredCrossDockLocationId;
@@ -409,7 +397,7 @@ public class ReceivingServiceImpl implements ReceivingService {
             java.util.List<String> serialNumbers,
             String actorUserId) {
         BigDecimal quantityDelta = toLedgerQuantity(productId, quantity, "receivedQuantity");
-        UUID stagingLocationId = resolveStagingLocationId();
+        UUID stagingLocationId = stagingLocationResolver.resolveStagingLocationId();
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(productId)
                 .locationId(stagingLocationId)
@@ -488,42 +476,6 @@ public class ReceivingServiceImpl implements ReceivingService {
         return Quantities.nz(currentOnHand).add(quantityDelta);
     }
 
-    private UUID resolveStagingLocationId() {
-        UUID fallbackStagingLocationId = resolveLocationId(
-                configuredStagingLocationId,
-                DEFAULT_STAGING_LOCATION_ID,
-                "pos.inventory.receiving.staging-location-id");
-
-        UUID siteId = resolveRequestScopedSiteId().orElseGet(this::resolveConfiguredSiteId);
-        if (siteId == null) {
-            return fallbackStagingLocationId;
-        }
-
-        return siteDefaultsService.getDefaultStagingLocationId(siteId).orElse(fallbackStagingLocationId);
-    }
-
-    private Optional<UUID> resolveRequestScopedSiteId() {
-        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes requestAttributes)) {
-            return Optional.empty();
-        }
-
-        HttpServletRequest request = requestAttributes.getRequest();
-        Optional<UUID> fromHeader = parseSiteId(request.getHeader("X-Site-Id"));
-        if (fromHeader.isPresent()) {
-            return fromHeader;
-        }
-
-        Object uriVars = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        if (uriVars instanceof Map<?, ?> values) {
-            Object value = values.get("siteId");
-            if (value instanceof String siteIdValue) {
-                return parseSiteId(siteIdValue);
-            }
-        }
-
-        return Optional.empty();
-    }
-
     private UUID resolveCrossDockLocationId() {
         return resolveLocationId(
                 configuredCrossDockLocationId,
@@ -539,30 +491,6 @@ public class ReceivingServiceImpl implements ReceivingService {
             return UUID.fromString(configuredValue.trim());
         } catch (IllegalArgumentException ex) {
             throw new IllegalStateException(propertyName + " must be a valid UUID: " + configuredValue, ex);
-        }
-    }
-
-    private UUID resolveConfiguredSiteId() {
-        if (configuredSiteId == null || configuredSiteId.isBlank()) {
-            return null;
-        }
-        try {
-            return UUID.fromString(configuredSiteId.trim());
-        } catch (IllegalArgumentException ex) {
-            throw new IllegalStateException(
-                    "pos.inventory.receiving.site-id must be a valid UUID: " + configuredSiteId, ex);
-        }
-    }
-
-    private Optional<UUID> parseSiteId(String rawSiteId) {
-        if (rawSiteId == null || rawSiteId.isBlank()) {
-            return Optional.empty();
-        }
-        try {
-            return Optional.of(UUID.fromString(rawSiteId.trim()));
-        } catch (IllegalArgumentException ex) {
-            log.debug("Ignoring invalid request-scoped siteId value: {}", rawSiteId);
-            return Optional.empty();
         }
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SourceDocumentResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SourceDocumentResolver.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
 import com.positivity.inventory.internal.enums.SourceDocumentType;
 import com.positivity.inventory.internal.exception.InvalidPoReferenceException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
+import com.positivity.inventory.internal.exception.SourceDocumentLinesUnavailableException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.internal.exception.UnsupportedSourceDocumentTypeException;
 import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
@@ -50,6 +51,15 @@ import org.springframework.transaction.annotation.Transactional;
  * dropped. An order whose lines are all closed reads as already received rather than as an empty
  * session. Only {@link PurchaseOrderUpdatedV1#OPEN_SUPPLY_STATUSES} can be received against: a
  * DRAFT order has not been committed to and a CANCELLED one never will be.
+ *
+ * <h2>Not found vs. not yet replicated (#1492)</h2>
+ *
+ * The header and its lines are projected atomically, so a missing {@code ext_purchase_order} row
+ * could mean either that replication has not caught up yet or that the id names no order at all —
+ * and, per ADR-0044, this module cannot call pos-order to tell the two apart. A source document id
+ * this module could never parse as a purchase order UUID is reported as not found outright; a
+ * well-formed UUID absent from the projection is reported as unavailable, not missing, leaving the
+ * caller to retry.
  */
 @Slf4j
 @Service
@@ -67,7 +77,11 @@ public class SourceDocumentResolver {
      * Resolves the still-expected lines of {@code sourceDocumentId}.
      *
      * @throws UnsupportedSourceDocumentTypeException when the type is not {@link SourceDocumentType#PO}
-     * @throws SourceDocumentNotFoundException when no such order has been projected
+     * @throws SourceDocumentNotFoundException when {@code sourceDocumentId} cannot even parse as a
+     *     purchase order identifier
+     * @throws SourceDocumentLinesUnavailableException when {@code sourceDocumentId} is a well-formed
+     *     purchase order id absent from the projection — not yet replicated, or unknown; this module
+     *     cannot tell which
      * @throws SourceDocumentAlreadyReceivedException when the order has nothing left to receive
      * @throws InvalidPoReferenceException when the order is not in a receivable status
      */
@@ -80,8 +94,8 @@ public class SourceDocumentResolver {
         UUID poId = parsePurchaseOrderId(sourceDocumentId);
         ExtPurchaseOrderReplica order = purchaseOrderRepository
                 .findById(poId)
-                .orElseThrow(() -> new SourceDocumentNotFoundException(
-                        "No purchase order " + sourceDocumentId + " has been projected into pos-inventory"));
+                .orElseThrow(() -> new SourceDocumentLinesUnavailableException(
+                        "Purchase order " + sourceDocumentId + " has not replicated its lines into pos-inventory yet"));
 
         String status = order.getStatus();
         if (isReceivedStatus(status)) {
@@ -126,7 +140,8 @@ public class SourceDocumentResolver {
 
     /**
      * A source document id that is not a purchase-order UUID names no order this module could ever
-     * hold, so it is reported the same way an unknown one is.
+     * hold, projected or not — a genuine not-found, unlike a well-formed id absent from the
+     * projection (#1492).
      */
     private static UUID parsePurchaseOrderId(String sourceDocumentId) {
         try {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StagingLocationResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StagingLocationResolver.java
@@ -1,0 +1,107 @@
+package com.positivity.inventory.internal.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Resolves the staging location goods are received into, shared by every caller that needs to
+ * know where staged stock lives: the fallback chain is a configured property, then a per-site
+ * default served from the {@code location_ref} replica, then a hardcoded default.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StagingLocationResolver {
+
+    private static final UUID DEFAULT_STAGING_LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+    private final SiteDefaultsService siteDefaultsService;
+
+    @Value("${pos.inventory.receiving.site-id:}")
+    private String configuredSiteId;
+
+    @Value("${pos.inventory.receiving.staging-location-id:}")
+    private String configuredStagingLocationId;
+
+    @NonNull
+    public UUID resolveStagingLocationId() {
+        UUID fallbackStagingLocationId = resolveLocationId(
+                configuredStagingLocationId,
+                DEFAULT_STAGING_LOCATION_ID,
+                "pos.inventory.receiving.staging-location-id");
+
+        UUID siteId = resolveRequestScopedSiteId().orElseGet(this::resolveConfiguredSiteId);
+        if (siteId == null) {
+            return fallbackStagingLocationId;
+        }
+
+        return siteDefaultsService.getDefaultStagingLocationId(siteId).orElse(fallbackStagingLocationId);
+    }
+
+    private Optional<UUID> resolveRequestScopedSiteId() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes requestAttributes)) {
+            return Optional.empty();
+        }
+
+        HttpServletRequest request = requestAttributes.getRequest();
+        Optional<UUID> fromHeader = parseSiteId(request.getHeader("X-Site-Id"));
+        if (fromHeader.isPresent()) {
+            return fromHeader;
+        }
+
+        Object uriVars = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (uriVars instanceof Map<?, ?> values) {
+            Object value = values.get("siteId");
+            if (value instanceof String siteIdValue) {
+                return parseSiteId(siteIdValue);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private UUID resolveConfiguredSiteId() {
+        if (configuredSiteId == null || configuredSiteId.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(configuredSiteId.trim());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException(
+                    "pos.inventory.receiving.site-id must be a valid UUID: " + configuredSiteId, ex);
+        }
+    }
+
+    private Optional<UUID> parseSiteId(String rawSiteId) {
+        if (rawSiteId == null || rawSiteId.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(UUID.fromString(rawSiteId.trim()));
+        } catch (IllegalArgumentException ex) {
+            log.debug("Ignoring invalid request-scoped siteId value: {}", rawSiteId);
+            return Optional.empty();
+        }
+    }
+
+    private UUID resolveLocationId(String configuredValue, UUID defaultValue, String propertyName) {
+        if (configuredValue == null || configuredValue.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return UUID.fromString(configuredValue.trim());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException(propertyName + " must be a valid UUID: " + configuredValue, ex);
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReceivingService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReceivingService.java
@@ -27,14 +27,12 @@ public interface ReceivingService {
      * @param request     the source document identifier and entry method
      * @param actorUserId the authenticated user initiating the session
      * @return the created receiving session with pre-populated lines
-     * @throws com.positivity.inventory.internal.exception.SourceDocumentNotFoundException        if
-     *                                                                                            PO/ASN
-     *                                                                                            not
-     *                                                                                            found
+     * @throws com.positivity.inventory.internal.exception.SourceDocumentNotFoundException if the
+     *     source document id cannot even parse as a purchase order identifier
+     * @throws com.positivity.inventory.internal.exception.SourceDocumentLinesUnavailableException
+     *     if the purchase order id is well-formed but absent from the projection
      * @throws com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException if
-     *                                                                                            PO/ASN
-     *                                                                                            already
-     *                                                                                            closed
+     *     PO/ASN already closed
      */
     @NonNull
     ReceivingSessionResponse createReceivingSession(

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/AsnContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/AsnContractBehaviorIT.java
@@ -208,32 +208,33 @@ class AsnContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.locationId").value(locationId.toString()));
     }
 
-    // ─── AC #5: Over-receipt without permission → 403 ─────────────────────────
+    // ─── AC #5: Over-receipt without permission → 422 ─────────────────────────
 
     /**
      * AC #5: Verifies that a goods receipt whose quantity exceeds the remaining PO
-     * quantity is rejected with 403 FORBIDDEN (error code
-     * OVER_RECEIPT_NOT_PERMITTED)
+     * quantity is rejected with 422 (error code OVER_RECEIPT_NOT_PERMITTED)
      * when the actor does not hold the override permission.
      *
-     * Issue: #571
+     * Issue: #571, #1493
      */
     @Test
-    @DisplayName("POST /goods-receipts over-receive without override permission → 403 Forbidden")
-    void overReceipt_withoutPermission_returns403() throws Exception {
-        // Issue #571 AC #5: over-receipt without permission must be 403
+    @DisplayName("POST /goods-receipts over-receive without override permission → 422 Unprocessable Entity")
+    void overReceipt_withoutPermission_returns422() throws Exception {
+        // Issue #1493: over-receipt without permission is a 422 domain rule violation, not a 403
         UUID poId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
         when(asnService.createGoodsReceipt(any(CreateGoodsReceiptRequest.class), anyString()))
-                .thenThrow(new OverReceiptNotPermittedException("OVER_RECEIPT_NOT_PERMITTED"));
+                .thenThrow(new OverReceiptNotPermittedException(
+                        "Receiving 50000 exceeds the 10000 outstanding on purchase order " + poId));
 
         String body = objectMapper.writeValueAsString(buildCreateGoodsReceiptRequest(poId, locationId));
 
         mockMvc.perform(withGoodsReceiptCreateAuth(post("/v1/inventory/goods-receipts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("OVER_RECEIPT_NOT_PERMITTED"));
     }
 
     // ─── AC #6: GRNI balance available for AP matching ───────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/PutawayGenerationContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/PutawayGenerationContractBehaviorIT.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.positivity.inventory.internal.dto.putaway.GeneratePutawayTasksRequest;
 import com.positivity.inventory.internal.dto.putaway.PutawayTaskResponse;
+import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
+import com.positivity.inventory.internal.exception.ReceiptNotStagedException;
 import com.positivity.inventory.service.PutawayGenerationService;
 import java.time.Clock;
 import java.time.Instant;
@@ -245,6 +247,75 @@ class PutawayGenerationContractBehaviorIT extends BaseContractIntegrationTest {
                         .content(requestBody))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$[0].status").value("REQUIRES_LOCATION_SELECTION"));
+    }
+
+    // ─── AC8: Receipt not staged blocks generation → 422 ──────────────────────
+
+    /**
+     * Verifies that when the source receipt's stock landed directly on hand rather than at the
+     * staging location, the service throws {@link ReceiptNotStagedException} and the controller
+     * returns 422 with error code {@code RECEIPT_NOT_STAGED}.
+     *
+     * Issue: #1496
+     */
+    @Test
+    @DisplayName("AC8: receipt not staged returns 422 with RECEIPT_NOT_STAGED error code")
+    void generatePutawayTasks_receiptNotStaged_returns422WithReceiptNotStagedErrorCode() throws Exception {
+        UUID receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID directOnHandLocation = UUID.fromString("00000000-0000-0000-0000-0000000000f0");
+        UUID stagingLocation = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+        when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
+                .thenThrow(new ReceiptNotStagedException(receiptId, directOnHandLocation, stagingLocation));
+
+        String requestBody = objectMapper.writeValueAsString(objectMapper
+                .createObjectNode()
+                .put("sourceReceiptId", receiptId.toString())
+                .put(
+                        "productId",
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .put("quantity", 5));
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("RECEIPT_NOT_STAGED"));
+    }
+
+    // ─── AC9: Resolved destination invalid for SKU blocks generation → 422 ────
+
+    /**
+     * Verifies that when the resolved destination fails the same compatibility check execution
+     * uses, the service throws {@link LocationNotValidForSkuException} and the controller returns
+     * 422 with error code {@code LOCATION_NOT_VALID_FOR_SKU}.
+     *
+     * Issue: #1496
+     */
+    @Test
+    @DisplayName("AC9: destination invalid for SKU returns 422 with LOCATION_NOT_VALID_FOR_SKU error code")
+    void generatePutawayTasks_destinationInvalidForSku_returns422WithLocationNotValidErrorCode() throws Exception {
+        String receiptId =
+                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+        UUID destinationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+        when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
+                .thenThrow(new LocationNotValidForSkuException(
+                        destinationId, "PROD-001", "SKU is not configured in replenishment policies"));
+
+        String requestBody = objectMapper.writeValueAsString(objectMapper
+                .createObjectNode()
+                .put("sourceReceiptId", receiptId)
+                .put(
+                        "productId",
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .put("quantity", 5));
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("LOCATION_NOT_VALID_FOR_SKU"));
     }
 
     // ─── AC5: Get available tasks ─────────────────────────────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReceivingSessionContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReceivingSessionContractBehaviorIT.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.positivity.inventory.internal.dto.receiving.ReceivingLineResponse;
 import com.positivity.inventory.internal.dto.receiving.ReceivingSessionResponse;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
+import com.positivity.inventory.internal.exception.SourceDocumentLinesUnavailableException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.service.ReceivingService;
 import java.math.BigDecimal;
@@ -37,7 +38,7 @@ import tools.jackson.databind.node.ObjectNode;
  * <li>ADR-0011: gateway security — authenticated gateway headers and
  * required receiving authorities</li>
  * <li>ADR-0017: HTTP response codes — 201 for creation, 400 for invalid input,
- * 404 for not-found</li>
+ * 404 for not-found, 409 when the purchase-order projection has not caught up (#1492)</li>
  * <li>ADR-0018: actor identity resolved from gateway auth context
  * ({@code X-User-Id} preferred, {@code X-User} fallback)</li>
  * </ul>
@@ -159,20 +160,49 @@ class ReceivingSessionContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.status").value("OPEN"));
     }
 
-    // ─── AC3: POST with non-existing PO → 404 ────────────────────────────────
+    // ─── AC3: POST with a PO absent from the projection → 409 ────────────────
 
     /**
-     * Verifies that requesting a receiving session for a PO that does not exist
-     * returns 404 with an error message, per story #35 AC3 and ADR-0017.
+     * Verifies that requesting a receiving session for a purchase order id absent from the
+     * projection returns 409 SOURCE_DOCUMENT_LINES_UNAVAILABLE with a non-empty
+     * {@code nextAction}, per issue #1492: this module cannot tell replication lag from an
+     * unknown purchase order id, so it asks the caller to retry.
      *
-     * Issue: #35
+     * Issue: #1492
      */
     @Test
-    @DisplayName("AC3: POST /receiving/sessions with non-existent PO returns 404 with error message")
-    void createReceivingSession_withNonExistentPO_returns404() throws Exception {
-        // Issue #35: unknown source document must yield 404 per ADR-0017
+    @DisplayName("AC3: POST /receiving/sessions with a PO absent from the projection returns 409 with nextAction")
+    void createReceivingSession_withUnprojectedPO_returns409() throws Exception {
+        UUID poId = UUID.fromString("00000000-0000-0000-0000-000000000999");
         when(receivingService.createReceivingSession(any(), any()))
-                .thenThrow(new SourceDocumentNotFoundException("Source document PO-999 not found"));
+                .thenThrow(new SourceDocumentLinesUnavailableException(
+                        "Purchase order " + poId + " has not replicated its lines into pos-inventory yet"));
+
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("sourceDocumentId", poId.toString());
+        body.put("entryMethod", "MANUAL");
+
+        mockMvc.perform(withReceivingAuth(post("/v1/inventory/receiving/sessions"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SOURCE_DOCUMENT_LINES_UNAVAILABLE"))
+                .andExpect(jsonPath("$.nextAction").isNotEmpty());
+    }
+
+    /**
+     * A source document id that cannot even parse as a purchase order identifier names no order
+     * this module could ever hold, so it remains a genuine 404 (issue #1492 scopes the 409 to
+     * well-formed ids absent from the projection).
+     *
+     * Issue: #1492
+     */
+    @Test
+    @DisplayName("AC3: POST /receiving/sessions with a non-PO source document id returns 404")
+    void createReceivingSession_withNonPoSourceDocumentId_returns404() throws Exception {
+        when(receivingService.createReceivingSession(any(), any()))
+                .thenThrow(new SourceDocumentNotFoundException(
+                        "Source document id PO-999 is not a purchase order identifier"));
 
         ObjectNode body = objectMapper.createObjectNode();
         body.put("sourceDocumentId", "PO-999");

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayGenerationServiceImplTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.dto.putaway.GeneratePutawayTasksRequest;
@@ -15,6 +18,8 @@ import com.positivity.inventory.internal.entity.GoodsReceiptEntity;
 import com.positivity.inventory.internal.entity.PutawayRule;
 import com.positivity.inventory.internal.entity.PutawayTask;
 import com.positivity.inventory.internal.enums.PutawayTaskStatus;
+import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
+import com.positivity.inventory.internal.exception.ReceiptNotStagedException;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.GoodsReceiptRepository;
@@ -23,6 +28,7 @@ import com.positivity.inventory.internal.repository.PutawayTaskRepository;
 import com.positivity.inventory.internal.service.ProximitySourcingStrategy;
 import com.positivity.inventory.internal.service.PutawayDestinationResolver;
 import com.positivity.inventory.internal.service.PutawayGenerationServiceImpl;
+import com.positivity.inventory.internal.service.StagingLocationResolver;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PutawayGenerationServiceImplTest {
     private static final UUID DEST_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UUID DEFAULT_LOCATION = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID STAGING_LOCATION = UUID.fromString("00000000-0000-0000-0000-000000000002");
 
     @Mock
     private PutawayRuleRepository putawayRuleRepository;
@@ -56,6 +63,9 @@ class PutawayGenerationServiceImplTest {
     @Mock
     private PutawayValidationService putawayValidationService;
 
+    @Mock
+    private StagingLocationResolver stagingLocationResolver;
+
     private PutawayGenerationServiceImpl service;
 
     @BeforeEach
@@ -66,10 +76,16 @@ class PutawayGenerationServiceImplTest {
                 proximitySourcingStrategy,
                 putawayValidationService);
         service = new PutawayGenerationServiceImpl(
-                putawayRuleRepository, putawayTaskRepository, goodsReceiptRepository, destinationResolver);
+                putawayRuleRepository,
+                putawayTaskRepository,
+                goodsReceiptRepository,
+                destinationResolver,
+                stagingLocationResolver,
+                putawayValidationService);
         lenient()
                 .when(goodsReceiptRepository.findById(any(UUID.class)))
                 .thenAnswer(inv -> Optional.of(receipt(inv.getArgument(0))));
+        lenient().when(stagingLocationResolver.resolveStagingLocationId()).thenReturn(STAGING_LOCATION);
     }
 
     @Test
@@ -92,6 +108,7 @@ class PutawayGenerationServiceImplTest {
         PutawayTaskResponse response = responses.get(0);
         assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.UNASSIGNED.toString());
         assertThat(response.getSuggestedDestinationLocationId()).isEqualTo(DEST_A);
+        assertThat(response.getSourceLocationId()).isEqualTo(STAGING_LOCATION);
     }
 
     @Test
@@ -330,9 +347,54 @@ class PutawayGenerationServiceImplTest {
                 .hasMessage("Either lineItems or productId/quantity is required");
     }
 
+    @Test
+    void generateTasksForReceipt_receiptNotAtStagingLocation_throwsReceiptNotStagedException() {
+        UUID receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID directOnHandLocation = UUID.fromString("00000000-0000-0000-0000-0000000000f0");
+        GoodsReceiptEntity receipt = new GoodsReceiptEntity();
+        receipt.setReceiptId(receiptId);
+        receipt.setLocationId(directOnHandLocation);
+        when(goodsReceiptRepository.findById(receiptId)).thenReturn(Optional.of(receipt));
+
+        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                .sourceReceiptId(receiptId.toString())
+                .productId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .quantity(5)
+                .build();
+
+        assertThatThrownBy(() -> service.generateTasksForReceipt(request))
+                .isInstanceOf(ReceiptNotStagedException.class)
+                .hasMessageContaining(directOnHandLocation.toString())
+                .hasMessageContaining(STAGING_LOCATION.toString());
+    }
+
+    @Test
+    void generateTasksForReceipt_destinationInvalidForSku_throwsLocationNotValidForSkuException() {
+        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                .sourceReceiptId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .productId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .quantity(5)
+                .build();
+        PutawayRule rule = new PutawayRule();
+        rule.setDestinationLocationId(DEST_A);
+        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(List.of(rule));
+        doThrow(new LocationNotValidForSkuException(DEST_A, "sku", "SKU is not configured in replenishment policies"))
+                .when(putawayValidationService)
+                .validateLocationCompatibility(any(UUID.class), any(String.class));
+
+        assertThatThrownBy(() -> service.generateTasksForReceipt(request))
+                .isInstanceOf(LocationNotValidForSkuException.class);
+
+        verify(putawayTaskRepository, never()).saveAll(anyList());
+    }
+
     private GoodsReceiptEntity receipt(UUID receiptId) {
         GoodsReceiptEntity receipt = new GoodsReceiptEntity();
         receipt.setReceiptId(receiptId);
+        receipt.setLocationId(STAGING_LOCATION);
         return receipt;
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -28,7 +29,7 @@ import com.positivity.inventory.internal.exception.FractionalQuantityNotAllowedE
 import com.positivity.inventory.internal.exception.PartMatchPermissionException;
 import com.positivity.inventory.internal.exception.ReceivingSessionNotFoundException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
-import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
+import com.positivity.inventory.internal.exception.SourceDocumentLinesUnavailableException;
 import com.positivity.inventory.internal.exception.WorkorderClosedException;
 import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
 import com.positivity.inventory.internal.repository.ExtProductUomReplicaRepository;
@@ -37,8 +38,8 @@ import com.positivity.inventory.internal.repository.InventoryVarianceRepository;
 import com.positivity.inventory.internal.repository.ReceivingSessionRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReceivingServiceImpl;
-import com.positivity.inventory.internal.service.SiteDefaultsService;
 import com.positivity.inventory.internal.service.SourceDocumentResolver;
+import com.positivity.inventory.internal.service.StagingLocationResolver;
 import com.positivity.inventory.internal.service.UomConversionService;
 import com.positivity.inventory.internal.service.UomConversionServiceImpl;
 import com.positivity.inventory.internal.service.WorkorderValidationService;
@@ -53,6 +54,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -63,7 +65,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ReceivingServiceImplTest {
@@ -92,7 +93,7 @@ class ReceivingServiceImplTest {
     private SourceDocumentResolver sourceDocumentResolver;
 
     @Mock
-    private SiteDefaultsService siteDefaultsService;
+    private StagingLocationResolver stagingLocationResolver;
 
     @Mock
     private WorkorderValidationService workorderValidationService;
@@ -125,6 +126,11 @@ class ReceivingServiceImplTest {
 
     @InjectMocks
     private ReceivingServiceImpl receivingService;
+
+    @BeforeEach
+    void stubDefaultStagingLocation() {
+        lenient().when(stagingLocationResolver.resolveStagingLocationId()).thenReturn(STAGING_LOCATION_ID);
+    }
 
     @AfterEach
     void clearSecurityContext() {
@@ -172,14 +178,15 @@ class ReceivingServiceImplTest {
     }
 
     @Test
-    void createReceivingSession_sourceDocumentNotFound() {
+    void createReceivingSession_sourceDocumentLinesUnavailable() {
         when(sourceDocumentResolver.resolve(any(), any()))
-                .thenThrow(new SourceDocumentNotFoundException("No purchase order PO-999 in pos-order"));
+                .thenThrow(new SourceDocumentLinesUnavailableException(
+                        "Purchase order PO-999 has not replicated its lines into pos-inventory yet"));
 
         CreateReceivingSessionRequest request = new CreateReceivingSessionRequest("PO-999", "MANUAL");
 
         assertThrows(
-                SourceDocumentNotFoundException.class,
+                SourceDocumentLinesUnavailableException.class,
                 () -> receivingService.createReceivingSession(request, "test-user"));
     }
 
@@ -488,14 +495,15 @@ class ReceivingServiceImplTest {
     }
 
     @Test
-    void createReceivingSession_sourceDocumentWithNoLines_throwsNotFound() {
+    void createReceivingSession_sourceDocumentNotProjected_throwsLinesUnavailable() {
         when(sourceDocumentResolver.resolve(any(), any()))
-                .thenThrow(new SourceDocumentNotFoundException("No purchase order PO-123 has been projected"));
+                .thenThrow(new SourceDocumentLinesUnavailableException(
+                        "Purchase order PO-123 has not replicated its lines into pos-inventory yet"));
 
         CreateReceivingSessionRequest request = new CreateReceivingSessionRequest("PO-123", "MANUAL");
 
         assertThrows(
-                SourceDocumentNotFoundException.class,
+                SourceDocumentLinesUnavailableException.class,
                 () -> receivingService.createReceivingSession(request, "test-user"));
     }
 
@@ -623,10 +631,9 @@ class ReceivingServiceImplTest {
     void receiveItemsIntoStaging_ledgerEntryUsesSiteDefaultStagingLocationWhenConfigured() {
         UUID sessionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID lineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID siteId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID siteDefaultStagingLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        ReflectionTestUtils.setField(receivingService, "configuredSiteId", siteId.toString());
+        when(stagingLocationResolver.resolveStagingLocationId()).thenReturn(siteDefaultStagingLocationId);
 
         ReceivingLine line = ReceivingLine.builder()
                 .lineId(lineId)
@@ -644,8 +651,6 @@ class ReceivingServiceImplTest {
         line.setSession(session);
         when(receivingSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
         when(receivingSessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        when(siteDefaultsService.getDefaultStagingLocationId(siteId))
-                .thenReturn(Optional.of(siteDefaultStagingLocationId));
         when(ledgerPostingService.post(any())).thenAnswer(inv -> inv.getArgument(0));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", siteDefaultStagingLocationId))
                 .thenReturn(new BigDecimal("7"));

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/SourceDocumentResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/SourceDocumentResolverTest.java
@@ -111,7 +111,7 @@ class SourceDocumentResolverTest {
     }
 
     @Test
-    @DisplayName("an order the projection does not hold reports lines unavailable, not not-found (#1492)")
+    @DisplayName("an order the projection does not hold reports lines unavailable rather than NOT_FOUND (#1492)")
     void unprojectedOrderReportsLinesUnavailable() {
         when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.empty());
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/SourceDocumentResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/SourceDocumentResolverTest.java
@@ -9,6 +9,7 @@ import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
 import com.positivity.inventory.internal.enums.SourceDocumentType;
 import com.positivity.inventory.internal.exception.InvalidPoReferenceException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
+import com.positivity.inventory.internal.exception.SourceDocumentLinesUnavailableException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.internal.exception.UnsupportedSourceDocumentTypeException;
 import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
@@ -110,12 +111,12 @@ class SourceDocumentResolverTest {
     }
 
     @Test
-    @DisplayName("an order the projection does not hold is not found")
-    void unprojectedOrderIsNotFound() {
+    @DisplayName("an order the projection does not hold reports lines unavailable, not not-found (#1492)")
+    void unprojectedOrderReportsLinesUnavailable() {
         when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.empty());
 
         assertThatThrownBy(this::resolve)
-                .isInstanceOf(SourceDocumentNotFoundException.class)
+                .isInstanceOf(SourceDocumentLinesUnavailableException.class)
                 .hasMessageContaining(PO_ID.toString());
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/StagingLocationResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/StagingLocationResolverTest.java
@@ -1,0 +1,123 @@
+package com.positivity.inventory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.service.SiteDefaultsService;
+import com.positivity.inventory.internal.service.StagingLocationResolver;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+@ExtendWith(MockitoExtension.class)
+class StagingLocationResolverTest {
+
+    private static final UUID DEFAULT_STAGING_LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+    @Mock
+    private SiteDefaultsService siteDefaultsService;
+
+    private StagingLocationResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new StagingLocationResolver(siteDefaultsService);
+    }
+
+    @AfterEach
+    void clearRequestContext() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void resolveStagingLocationId_noConfigNoSite_returnsHardcodedDefault() {
+        assertThat(resolver.resolveStagingLocationId()).isEqualTo(DEFAULT_STAGING_LOCATION_ID);
+    }
+
+    @Test
+    void resolveStagingLocationId_configuredStagingLocation_returnsConfiguredValue() {
+        UUID configured = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+        ReflectionTestUtils.setField(resolver, "configuredStagingLocationId", configured.toString());
+
+        assertThat(resolver.resolveStagingLocationId()).isEqualTo(configured);
+    }
+
+    @Test
+    void resolveStagingLocationId_invalidConfiguredStagingLocation_throwsIllegalState() {
+        ReflectionTestUtils.setField(resolver, "configuredStagingLocationId", "not-a-uuid");
+
+        assertThatThrownBy(() -> resolver.resolveStagingLocationId())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pos.inventory.receiving.staging-location-id");
+    }
+
+    @Test
+    void resolveStagingLocationId_configuredSiteWithDefault_usesSiteDefault() {
+        UUID siteId = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        UUID siteDefault = UUID.fromString("00000000-0000-0000-0000-0000000000cc");
+        ReflectionTestUtils.setField(resolver, "configuredSiteId", siteId.toString());
+        when(siteDefaultsService.getDefaultStagingLocationId(siteId)).thenReturn(Optional.of(siteDefault));
+
+        assertThat(resolver.resolveStagingLocationId()).isEqualTo(siteDefault);
+    }
+
+    @Test
+    void resolveStagingLocationId_configuredSiteWithoutDefault_fallsBackToConfiguredStaging() {
+        UUID siteId = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        UUID configuredStaging = UUID.fromString("00000000-0000-0000-0000-0000000000dd");
+        ReflectionTestUtils.setField(resolver, "configuredSiteId", siteId.toString());
+        ReflectionTestUtils.setField(resolver, "configuredStagingLocationId", configuredStaging.toString());
+        when(siteDefaultsService.getDefaultStagingLocationId(siteId)).thenReturn(Optional.empty());
+
+        assertThat(resolver.resolveStagingLocationId()).isEqualTo(configuredStaging);
+    }
+
+    @Test
+    void resolveStagingLocationId_requestScopedHeaderOverridesConfiguredSite() {
+        UUID configuredSiteId = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        UUID headerSiteId = UUID.fromString("00000000-0000-0000-0000-0000000000ee");
+        UUID headerSiteDefault = UUID.fromString("00000000-0000-0000-0000-0000000000ff");
+        ReflectionTestUtils.setField(resolver, "configuredSiteId", configuredSiteId.toString());
+        when(siteDefaultsService.getDefaultStagingLocationId(headerSiteId)).thenReturn(Optional.of(headerSiteDefault));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Site-Id", headerSiteId.toString());
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        assertThat(resolver.resolveStagingLocationId()).isEqualTo(headerSiteDefault);
+    }
+
+    @Test
+    void resolveStagingLocationId_requestScopedPathVariable_usesSiteDefault() {
+        UUID pathSiteId = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+        UUID pathSiteDefault = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+        when(siteDefaultsService.getDefaultStagingLocationId(pathSiteId)).thenReturn(Optional.of(pathSiteDefault));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("siteId", pathSiteId.toString()));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        assertThat(resolver.resolveStagingLocationId()).isEqualTo(pathSiteDefault);
+    }
+
+    @Test
+    void resolveStagingLocationId_invalidConfiguredSiteId_throwsIllegalState() {
+        ReflectionTestUtils.setField(resolver, "configuredSiteId", "not-a-uuid");
+
+        assertThatThrownBy(() -> resolver.resolveStagingLocationId())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pos.inventory.receiving.site-id");
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (bug fixes from SDK integration suite findings)
- Parent STORY (durion): n/a
- Child issues: louisburroughs/durion-positivity-backend#1492, louisburroughs/durion-positivity-backend#1493, louisburroughs/durion-positivity-backend#1496
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — error-status semantics for goods receipts, receiving sessions, and putaway generation changed as described under Scope (no durion contract PR yet)
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller (`pos-inventory/openapi.yaml` descriptions/responses updated for the three endpoints; no controller signatures changed)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- What changed:
  - **#1492** — `POST /v1/inventory/receiving/sessions` for a purchase order id absent from the `ext_purchase_order` projection now answers **409 `SOURCE_DOCUMENT_LINES_UNAVAILABLE`** with a `nextAction` ("retry in a few seconds; if this persists, the purchase order id is unknown") instead of a 404 indistinguishable from "no such document". New `SourceDocumentLinesUnavailableException`; `SourceDocumentResolver` keeps a plain 404 only for ids that cannot parse as a PO UUID. Because the projection writes header + lines atomically and ADR-0044 forbids a synchronous check against pos-order, the service cannot tell replication lag from an unknown id — the response says both.
  - **#1493** — over-receipt is refused with **422 `OVER_RECEIPT_NOT_PERMITTED`** instead of a bare 403 that role-mode callers could not tell from a missing `inventory:goods_receipt:create`. The message now names the received total, the open balance, and the purchase order.
  - **#1496** — `generatePutawayTasks` no longer emits tasks that cannot be executed: it refuses (**422 `RECEIPT_NOT_STAGED`**) a receipt whose stock landed directly on hand rather than in staging (the ASN direct-to-location path); tasks it does generate are sourced from the receipt's actual location instead of a hardcoded staging constant; and the resolved destination is validated at generation time with the same location-compatibility check execution uses, refusing with the named reason (**422 `LOCATION_NOT_VALID_FOR_SKU`**, no tasks persisted) rather than proposing a destination execution will reject. Staging-location resolution is extracted from `ReceivingServiceImpl` into a shared `StagingLocationResolver` (behavior identical: configured property → per-site default → hardcoded default).
  - **#1494** was scheduled for this PR but is already resolved on main by #1497 (ADR-0057): the availability endpoints enforce `inventory:availability:read`, which TECHNICIAN holds — that issue can be closed with no further change.
- Why: all three are SDK-integration-suite findings against alpha where a transient or business-rule refusal was indistinguishable from a permanent not-found / permission failure, or where the backend manufactured work items it would itself reject.

## Tests
- [x] Unit tests added/updated (`ReceivingServiceImplTest`, `SourceDocumentResolverTest`, `AsnServiceImplTest`, `PutawayGenerationServiceImplTest`, new `StagingLocationResolverTest`)
- [x] Integration tests added/updated (`ReceivingSessionContractBehaviorIT` 409/404 split, `AsnContractBehaviorIT` 422, `PutawayGenerationContractBehaviorIT` new 422 refusal cases)
- [x] Provider behavioral contract tests added/updated (the contract-behavior ITs above)
- How to run: `./mvnw -pl pos-inventory test` (full module: 977 tests, 0 failures, ArchUnit included)

## Risk & Rollback
- Risk level: Low — status-code/error-envelope changes plus a generation-time guard; no schema or event changes. Clients asserting the old 404/403 statuses on these three paths must follow the new codes (the SDK integration suite already records statuses dynamically).
- Rollback plan: revert the single commit; no migrations involved.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (n/a — issue-execution branch)
- [ ] PR title starts with `[CAP:<cap-id>]` (n/a)
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — reference above; semantics documented in `pos-inventory/openapi.yaml`
- [ ] Required CI checks passing (pending)

BACKEND_CONTRACT_GUIDE.md

Closes #1492
Closes #1493
Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXHakvgJu8fJH5NtAFLSec

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXHakvgJu8fJH5NtAFLSec)_