### PR TITLE
build(coverage): ratchet JaCoCo floors and close pos-supplier coverage regression

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -675,14 +675,14 @@ Repo-wide, summing all per-module reports: **80.4% line** (15,791 missed of
 |---|---:|---:|---:|---:|---:|
 | `pos-accounting` | 10668 | 80.3 | 67.3 | 0.77 | 0.64 |
 | `pos-inventory` | 10153 | 79.2 | 64.1 | 0.76 | 0.61 |
-| `pos-workorder` | 7584 | 77.7 | 63.1 | 0.74 | 0.60 |
+| `pos-workorder` | 8373 | 78.8 | 65.0 | 0.75 | 0.62 |
 | `pos-mcp-server` | 6166 | 80.2 | 68.5 | 0.77 | 0.65 |
-| `pos-customer` | 5439 | 82.4 | 69.6 | 0.79 | 0.66 |
-| `pos-supplier` | 5155 | 87.3 | 73.5 | 0.84 | 0.70 |
+| `pos-customer` | 5439 | 83.9 | 74.0 | 0.80 | 0.71 |
+| `pos-supplier` | 6644 | 87.1 | 74.8 | 0.84 | 0.71 |
 | `pos-order` | 4201 | 84.4 | 71.3 | 0.81 | 0.68 |
 | `pos-security-service` | 3559 | 77.1 | 66.6 | 0.74 | 0.63 |
 | `pos-invoice` | 3380 | 77.3 | 63.7 | 0.74 | 0.60 |
-| `pos-catalog` | 3009 | 77.6 | 61.6 | 0.74 | 0.58 |
+| `pos-catalog` | 3302 | 78.4 | 63.1 | 0.75 | 0.60 |
 | `pos-people` | 2901 | 78.7 | 73.1 | 0.75 | 0.70 |
 | `pos-warranty` | 2638 | 87.3 | 78.9 | 0.84 | 0.75 |
 | `pos-location` | 2208 | 78.1 | 66.1 | 0.75 | 0.63 |
@@ -691,21 +691,22 @@ Repo-wide, summing all per-module reports: **80.4% line** (15,791 missed of
 | `pos-people-contact` | 1481 | 72.8 | 62.2 | 0.69 | 0.59 |
 | `pos-marketing` | 1402 | 90.7 | 85.2 | 0.87 | 0.82 |
 | `pos-price` | 1053 | 94.4 | 80.4 | 0.91 | 0.77 |
-| `pos-vehicle-inventory` | 993 | 79.6 | 74.7 | 0.76 | 0.71 |
+| `pos-vehicle-inventory` | 1017 | 79.2 | 75.0 | 0.76 | 0.72 |
 | `pos-tax` | 984 | 78.5 | 66.8 | 0.75 | 0.63 |
 | `pos-domain-events` | 648 | 84.9 | 78.9 | 0.81 | 0.75 |
 | `pos-vehicle-fitment` | 542 | 78.4 | 63.6 | 0.75 | 0.60 |
 | `pos-event-receiver` | 441 | 77.6 | 87.2 | 0.74 | 0.84 |
-| `pos-api-gateway` | 436 | 85.6 | 72.2 | 0.82 | 0.69 |
+| `pos-api-gateway` | 451 | 86.0 | 72.7 | 0.83 | 0.69 |
 | `pos-security-common` | 407 | 79.4 | 80.7 | 0.76 | 0.77 |
-| `pos-documents` | 384 | 72.9 | 75.0 | 0.69 | 0.72 |
+| `pos-documents` | 382 | 73.3 | 75.0 | 0.70 | 0.72 |
 | `pos-openapi-validation` | 258 | 94.2 | 81.2 | 0.91 | 0.78 |
 | `pos-vehicle-reference-nhtsa` | 189 | 53.4 | 58.3 | 0.50 | 0.55 |
-| `pos-events` | 174 | 59.8 | 57.1 | 0.56 | 0.54 |
+| `pos-events` | 284 | 75.4 | 74.4 | 0.72 | 0.71 |
+| `pos-image` | 213 | 76.1 | 91.7 | 0.73 | 0.88 |
+| `pos-web-common` | 188 | 84.6 | 63.4 | 0.81 | 0.60 |
 | `pos-document-helper` | 162 | 95.7 | 90.0 | 0.92 | 0.87 |
 | `pos-tax-common` | 104 | 89.4 | 74.1 | 0.86 | 0.71 |
 | `pos-vehicle-reference-carapi` | 69 | 78.3 | 88.9 | 0.75 | 0.85 |
-| `pos-image` | 61 | 31.1 | 100.0 | 0.28 | 0.97 |
 | `pos-shared-dtos` | 34 | 0.0 | 0.0 | — *(unguarded)* | — |
 | `pos-inquiry` | 16 | 0.0 | — | — *(unguarded)* | — |
 | `pos-service-discovery` | 4 | 0.0 | — | — *(unguarded)* | — |
@@ -794,10 +795,15 @@ are derived (§6.1).
   unstable, and it will fail on a night when nothing changed. Treat a
   thin-margin module as a bug in the floor or a gap in the tests, not as a
   module doing well.
-- The four all-zero modules (`pos-image`, `pos-inquiry`,
-  `pos-vehicle-reference-carapi`, `pos-vehicle-reference-nhtsa`) carry **no**
-  floor. A `0.00` floor is not a gate, and pretending otherwise would misrepresent
-  them as guarded. They need first tests, not thresholds — see §7.
+- The four all-zero modules (`pos-bulk-ingest-lib`, `pos-inquiry`,
+  `pos-service-discovery`, `pos-shared-dtos`) carry **no** floor — each is under
+  the `--min-lines` threshold (§6.5) with no coverage of its own to gate. A
+  `0.00` floor is not a gate, and pretending otherwise would misrepresent them
+  as guarded. They need first tests, not thresholds — see §7.
+  (`pos-image` and `pos-vehicle-reference-carapi` are no longer in this
+  category: both now measure real, non-zero coverage and carry real floors —
+  see the §6.1 table. An earlier version of this list still named them from
+  when they were genuinely all-zero.)
 - Deliberately **not** a single repo-wide bar. At 81.1% a uniform 85% would fail
   a third of the reactor on day one, and a uniform 70% would let the best modules
   rot 15 points before anyone noticed.

--- a/pos-api-gateway/pom.xml
+++ b/pos-api-gateway/pom.xml
@@ -11,11 +11,11 @@
     <description>Spring Cloud API Gateway for POS modules</description>
     <packaging>jar</packaging>
     <properties>
-        <!-- Coverage ratchet: measured 85.6% line / 72.2% branch by the gate's own
+        <!-- Coverage ratchet: measured 86.0% line / 72.7% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.82</jacoco.line.min>
+        <jacoco.line.min>0.83</jacoco.line.min>
         <jacoco.branch.min>0.69</jacoco.branch.min>
 
         <java.version>25</java.version>

--- a/pos-catalog/pom.xml
+++ b/pos-catalog/pom.xml
@@ -14,12 +14,12 @@
     <description>POS Catalog module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 77.6% line / 61.6% branch by the gate's own
+        <!-- Coverage ratchet: measured 78.4% line / 63.1% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.74</jacoco.line.min>
-        <jacoco.branch.min>0.58</jacoco.branch.min>
+        <jacoco.line.min>0.75</jacoco.line.min>
+        <jacoco.branch.min>0.60</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-customer/pom.xml
+++ b/pos-customer/pom.xml
@@ -13,12 +13,12 @@
     <description>POS Customer Module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 83.8% line / 73.8% branch by the gate's own
+        <!-- Coverage ratchet: measured 83.9% line / 74.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
         <jacoco.line.min>0.80</jacoco.line.min>
-        <jacoco.branch.min>0.70</jacoco.branch.min>
+        <jacoco.branch.min>0.71</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-document-helper/pom.xml
+++ b/pos-document-helper/pom.xml
@@ -18,10 +18,12 @@
     <properties>
         <!-- Coverage ratchet: measured 95.7% line / 90.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
-             Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
-             IT-inclusive measurement describes coverage the gate cannot see.
-             The branch floor tolerates one whole branch instead: the module has only 10
-             branches, so one is worth 10 points and a 3-point cushion would fail on noise. -->
+             Floors sit 3 points under, the same standard cushion every module gets.
+             Re-derive them ONLY from a -DskipITs run — an IT-inclusive measurement
+             describes coverage the gate cannot see.
+             Note: this module has only 10 branches (jacoco.csv), so each one is worth
+             about 10 points of the branch percentage — a single branch regression can
+             move the measured figure by more than the 3-point cushion. -->
         <jacoco.line.min>0.92</jacoco.line.min>
         <jacoco.branch.min>0.87</jacoco.branch.min>
     </properties>

--- a/pos-document-helper/pom.xml
+++ b/pos-document-helper/pom.xml
@@ -23,7 +23,7 @@
              The branch floor tolerates one whole branch instead: the module has only 10
              branches, so one is worth 10 points and a 3-point cushion would fail on noise. -->
         <jacoco.line.min>0.92</jacoco.line.min>
-        <jacoco.branch.min>0.80</jacoco.branch.min>
+        <jacoco.branch.min>0.87</jacoco.branch.min>
     </properties>
 
     <dependencies>

--- a/pos-documents/pom.xml
+++ b/pos-documents/pom.xml
@@ -16,11 +16,11 @@
     <description>PDF rendering service with multi-format support</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 72.9% line / 75.0% branch by the gate's own
+        <!-- Coverage ratchet: measured 73.3% line / 75.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.69</jacoco.line.min>
+        <jacoco.line.min>0.70</jacoco.line.min>
         <jacoco.branch.min>0.72</jacoco.branch.min>
     </properties>
 

--- a/pos-events/pom.xml
+++ b/pos-events/pom.xml
@@ -14,12 +14,12 @@
     <description>Shared library for event emission and domain event tracking across Positivity microservices</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 59.8% line / 57.1% branch by the gate's own
+        <!-- Coverage ratchet: measured 75.4% line / 74.4% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.56</jacoco.line.min>
-        <jacoco.branch.min>0.54</jacoco.branch.min>
+        <jacoco.line.min>0.72</jacoco.line.min>
+        <jacoco.branch.min>0.71</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-image/pom.xml
+++ b/pos-image/pom.xml
@@ -12,14 +12,14 @@
     <description>POS Image module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 31.1% line / 100.0% branch by the gate's own
+        <!-- Coverage ratchet: measured 76.1% line / 91.7% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see.
              The branch floor tolerates one whole branch (6 branches total, one = 17 points).
              The line figure is held down by Spring config classes; the controller is covered. -->
-        <jacoco.line.min>0.28</jacoco.line.min>
-        <jacoco.branch.min>0.83</jacoco.branch.min>
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.88</jacoco.branch.min>
     </properties>
 
     <packaging>jar</packaging>

--- a/pos-image/pom.xml
+++ b/pos-image/pom.xml
@@ -14,9 +14,13 @@
     <properties>
         <!-- Coverage ratchet: measured 76.1% line / 91.7% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
-             Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
-             IT-inclusive measurement describes coverage the gate cannot see.
-             The branch floor tolerates one whole branch (6 branches total, one = 17 points).
+             Floors sit 3 points under, the same standard cushion every module gets.
+             Re-derive them ONLY from a -DskipITs run — an IT-inclusive measurement
+             describes coverage the gate cannot see.
+             Note: this module has 48 branches (jacoco.csv), not the 6 an earlier version
+             of this comment claimed — that stale figure was never consistent with a
+             measured 91.7% (impossible at 6 branches), and put the branch floor further
+             below measured than the standard cushion the script now writes.
              The line figure is held down by Spring config classes; the controller is covered. -->
         <jacoco.line.min>0.73</jacoco.line.min>
         <jacoco.branch.min>0.88</jacoco.branch.min>

--- a/pos-supplier/pom.xml
+++ b/pos-supplier/pom.xml
@@ -14,12 +14,12 @@
     <description>POS Supplier integration module (outbound supplier connectivity, ADR-0049..0052)</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 87.3% line / 73.5% branch by the gate's own
+        <!-- Coverage ratchet: measured 87.1% line / 74.8% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
         <jacoco.line.min>0.84</jacoco.line.min>
-        <jacoco.branch.min>0.70</jacoco.branch.min>
+        <jacoco.branch.min>0.71</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelxml/EdiwheelXmlSupportTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelxml/EdiwheelXmlSupportTest.java
@@ -1,0 +1,149 @@
+package com.positivity.supplier.internal.adapter.ediwheelxml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The JAXB plumbing shared by every EDIWheel XML family: one context per document type, a
+ * qualified writer, and a namespace-normalising, externally-inert reader.
+ *
+ * <p>Uses a small fixture root type local to this test rather than a package-private family wire
+ * class (ADR-0051 §2 keeps those {@code final}/package-private to their own adapter), which also
+ * keeps these tests about the shared plumbing rather than any one family's document shape.
+ */
+@DisplayName("EdiwheelXmlSupport — shared JAXB plumbing for the EDIWheel adapters")
+class EdiwheelXmlSupportTest {
+
+    // Every field is explicitly qualified into EdiwheelXmlSupport.NAMESPACE: JAXB binds an
+    // unqualified fixture to no namespace by default, but the reader always rewrites incoming
+    // elements INTO that namespace (that is the behaviour under test), so the fixture must expect
+    // to be found there too -- exactly like every real family wire type, which gets this from its
+    // package-info's @XmlSchema instead of a per-annotation namespace.
+    @XmlRootElement(name = "widget", namespace = EdiwheelXmlSupport.NAMESPACE)
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Widget {
+        @XmlElement(name = "name", namespace = EdiwheelXmlSupport.NAMESPACE)
+        String name;
+
+        @XmlElement(name = "quantity", namespace = EdiwheelXmlSupport.NAMESPACE)
+        int quantity;
+
+        // JAXB requires a no-arg constructor to unmarshal into.
+        Widget() {}
+
+        Widget(String name, int quantity) {
+            this.name = name;
+            this.quantity = quantity;
+        }
+    }
+
+    @XmlRootElement(name = "gadget", namespace = EdiwheelXmlSupport.NAMESPACE)
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Gadget {
+        @XmlElement(name = "name", namespace = EdiwheelXmlSupport.NAMESPACE)
+        String name;
+    }
+
+    private final JAXBContext widgetContext = EdiwheelXmlSupport.contextFor(Widget.class);
+
+    @Test
+    @DisplayName("contextFor builds a usable JAXB context for a bindable type")
+    void contextForBuildsAUsableContext() {
+        assertThat(EdiwheelXmlSupport.contextFor(Widget.class)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("contextFor wraps an unbindable type in IllegalStateException, at startup not first use")
+    void contextForWrapsAnUnbindableTypeFailure() {
+        assertThatThrownBy(() -> EdiwheelXmlSupport.contextFor(java.io.Closeable.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Closeable");
+    }
+
+    @Test
+    @DisplayName("marshal emits a fully qualified document under the EDIWheel namespace")
+    void marshalEmitsAQualifiedDocument() {
+        String xml = EdiwheelXmlSupport.marshal(widgetContext, new Widget("tyre", 4));
+
+        assertThat(xml).contains("<?xml");
+        assertThat(xml).contains(EdiwheelXmlSupport.NAMESPACE);
+        assertThat(xml).contains("tyre");
+        assertThat(xml).contains("<quantity>4</quantity>");
+    }
+
+    @Test
+    @DisplayName("unmarshal round-trips a document this class itself produced")
+    void unmarshalRoundTripsOwnOutput() {
+        String xml = EdiwheelXmlSupport.marshal(widgetContext, new Widget("brake pad", 12));
+
+        Widget parsed = EdiwheelXmlSupport.unmarshal(widgetContext, Widget.class, xml);
+
+        assertThat(parsed.name).isEqualTo("brake pad");
+        assertThat(parsed.quantity).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("unmarshal normalises an unqualified document into the EDIWheel namespace before binding")
+    void unmarshalNormalisesAnUnqualifiedDocument() {
+        String unqualified = "<widget><name>filter</name><quantity>3</quantity></widget>";
+
+        Widget parsed = EdiwheelXmlSupport.unmarshal(widgetContext, Widget.class, unqualified);
+
+        assertThat(parsed.name).isEqualTo("filter");
+        assertThat(parsed.quantity).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("unmarshal normalises a document qualified under a vendor's own, unrelated namespace")
+    void unmarshalNormalisesAVendorNamespacedDocument() {
+        String vendorQualified =
+                "<widget xmlns=\"urn:some-vendor-namespace\">" + "<name>gasket</name><quantity>7</quantity></widget>";
+
+        Widget parsed = EdiwheelXmlSupport.unmarshal(widgetContext, Widget.class, vendorQualified);
+
+        assertThat(parsed.name).isEqualTo("gasket");
+        assertThat(parsed.quantity).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("unmarshal rejects an unrelated root element instead of silently binding an empty instance")
+    void unmarshalRejectsAnUnexpectedRootElement() {
+        String xml = EdiwheelXmlSupport.marshal(EdiwheelXmlSupport.contextFor(Gadget.class), new Gadget());
+
+        // Whether the unrecognised root fails inside JAXB itself or comes back as some other type
+        // that the isInstance check then rejects is a JAXB-implementation detail; either way it
+        // must not silently bind an empty Widget with no error code (see the method Javadoc).
+        assertThatThrownBy(() -> EdiwheelXmlSupport.unmarshal(widgetContext, Widget.class, xml))
+                .isInstanceOf(EdiwheelXmlException.class)
+                .hasMessageContaining("Widget");
+    }
+
+    @Test
+    @DisplayName("unmarshal reports unparseable input as an EdiwheelXmlException, not a raw SAX/JAXB error")
+    void unmarshalReportsUnparseableBodyAsATypedException() {
+        assertThatThrownBy(() -> EdiwheelXmlSupport.unmarshal(widgetContext, Widget.class, "not xml at all"))
+                .isInstanceOf(EdiwheelXmlException.class)
+                .hasMessageContaining("Widget");
+    }
+
+    @Test
+    @DisplayName("unmarshal refuses external entity expansion, closing the file-read/SSRF vector")
+    void unmarshalRefusesExternalEntities() {
+        String withExternalEntity = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE widget [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+                + "<widget><name>&xxe;</name><quantity>1</quantity></widget>";
+
+        // DOCTYPE declarations are disallowed outright, so this fails closed as unparseable
+        // rather than silently reading a local file into the response.
+        assertThatThrownBy(() -> EdiwheelXmlSupport.unmarshal(widgetContext, Widget.class, withExternalEntity))
+                .isInstanceOf(EdiwheelXmlException.class);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/exception/SupplierExceptionHandlerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/exception/SupplierExceptionHandlerTest.java
@@ -1,0 +1,417 @@
+package com.positivity.supplier.internal.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.positivity.shared.error.ApiError;
+import com.positivity.supplier.internal.audit.SupplierCorrelationContext;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+/**
+ * ApiError mapping for every {@code pos-supplier} controller advice (ADR-0017). Every failure
+ * this module's controllers can produce passes through one of these handlers, so the
+ * exception-to-status table pinned here <em>is</em> the module's public error contract — a
+ * status or code drifting here is a breaking change for every caller that branches on it.
+ */
+@DisplayName("SupplierExceptionHandler — ApiError mapping")
+class SupplierExceptionHandlerTest {
+
+    private static final String CORRELATION_HEADER = "X-Correlation-Id";
+    private static final Instant NOW = Instant.parse("2026-08-25T09:00:00Z");
+
+    private final SupplierExceptionHandler handler = new SupplierExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+
+    @AfterEach
+    void clearAmbientScope() {
+        // Belt and braces: a test that opens a correlation scope and fails before closing it must
+        // not leak that scope into the next test in this class.
+        SupplierCorrelationContext.current().ifPresent(id -> {
+            throw new AssertionError("test left an open correlation scope: " + id);
+        });
+    }
+
+    private static void assertEnvelope(ResponseEntity<ApiError> response, HttpStatus status, String code) {
+        assertThat(response.getStatusCode()).isEqualTo(status);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo(code);
+        assertThat(response.getBody().status()).isEqualTo(status.value());
+        assertThat(response.getBody().timestamp()).isEqualTo(NOW.toString());
+        assertThat(response.getHeaders().getFirst(CORRELATION_HEADER))
+                .isEqualTo(response.getBody().correlationId());
+    }
+
+    @Test
+    @DisplayName("maps a not-found domain resource to 404, preserving its typed code")
+    void notFoundMapsTo404() {
+        assertEnvelope(
+                handler.handleNotFound(
+                        new SupplierNotFoundException(SupplierNotFoundException.PROFILE_NOT_FOUND, "no such profile"),
+                        null),
+                HttpStatus.NOT_FOUND,
+                SupplierNotFoundException.PROFILE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("maps semantically invalid profile data to 400, preserving its typed code")
+    void validationMapsTo400() {
+        assertEnvelope(
+                handler.handleValidation(
+                        new SupplierValidationException(
+                                SupplierValidationException.UNKNOWN_CAPABILITY, "bad capability"),
+                        null),
+                HttpStatus.BAD_REQUEST,
+                SupplierValidationException.UNKNOWN_CAPABILITY);
+    }
+
+    @Test
+    @DisplayName("maps a marketing-catalogue import failure to 422, distinct from an empty catalogue")
+    void mktCatImportFailureMapsTo422() {
+        assertEnvelope(
+                handler.handleMktCatImportFailure(new MktCatImportException("catalogue unreadable"), null),
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "SUPPLIER_MKTCAT_IMPORT_FAILED");
+    }
+
+    @Test
+    @DisplayName("maps an unanswerable fleet lookup to 422, not a 502")
+    void fleetLookupFailureMapsTo422() {
+        assertEnvelope(
+                handler.handleFleetLookupFailure(new FleetLookupException("vendor unreachable"), null),
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "SUPPLIER_FLEET_LOOKUP_FAILED");
+    }
+
+    @Test
+    @DisplayName("maps an unfetchable invoice window to 422")
+    void invoiceFetchFailureMapsTo422() {
+        assertEnvelope(
+                handler.handleInvoiceFetch(new InvoiceFetchException("window fetch failed"), null),
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "SUPPLIER_INVOICE_FETCH_FAILED");
+    }
+
+    @Test
+    @DisplayName("maps a configuration-state collision to 409, preserving its typed code")
+    void conflictMapsTo409() {
+        assertEnvelope(
+                handler.handleConflict(
+                        new SupplierConflictException(SupplierConflictException.SUPPLIER_REF_CONFLICT, "ref taken"),
+                        null),
+                HttpStatus.CONFLICT,
+                SupplierConflictException.SUPPLIER_REF_CONFLICT);
+    }
+
+    @Nested
+    @DisplayName("handleConfiguration — code-to-status table (ADR-0050 §3/§4/§5)")
+    class ConfigurationExceptionMapping {
+
+        @Test
+        @DisplayName("a caller-actionable code maps to its table status and keeps the domain message")
+        void callerActionableCodeKeepsDomainMessage() {
+            ResponseEntity<ApiError> response = handler.handleConfiguration(
+                    new SupplierConfigurationException(
+                            SupplierConfigurationException.PROFILE_DISABLED, "profile disabled"),
+                    null);
+
+            assertEnvelope(response, HttpStatus.CONFLICT, SupplierConfigurationException.PROFILE_DISABLED);
+            assertThat(response.getBody().message()).isEqualTo("profile disabled");
+        }
+
+        @Test
+        @DisplayName("a deployment-defect code maps to 500 with the generic message, never the raw detail")
+        void deploymentDefectCodeHidesItsDetail() {
+            ResponseEntity<ApiError> response = handler.handleConfiguration(
+                    new SupplierConfigurationException(
+                            SupplierConfigurationException.SECRET_REFERENCE_INVALID, "env var FOO_SECRET unset"),
+                    null);
+
+            assertEnvelope(
+                    response,
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    SupplierConfigurationException.SECRET_REFERENCE_INVALID);
+            assertThat(response.getBody().message()).isEqualTo(SupplierExceptionHandler.CONFIGURATION_DEFECT_MESSAGE);
+            assertThat(response.getBody().message()).doesNotContain("FOO_SECRET");
+        }
+
+        @Test
+        @DisplayName("a code with no table entry fails closed to 500 rather than inheriting a wrong status")
+        void unmappedCodeFailsClosedTo500() {
+            ResponseEntity<ApiError> response = handler.handleConfiguration(
+                    new SupplierConfigurationException("SUPPLIER_NOT_YET_CATALOGUED", "?"), null);
+
+            assertEnvelope(response, HttpStatus.INTERNAL_SERVER_ERROR, "SUPPLIER_NOT_YET_CATALOGUED");
+            assertThat(response.getBody().message()).isEqualTo(SupplierExceptionHandler.CONFIGURATION_DEFECT_MESSAGE);
+        }
+    }
+
+    @Nested
+    @DisplayName("handlePayloadUnreadable — decryption failures (ADR-0050 §7)")
+    class PayloadUnreadableMapping {
+
+        @Test
+        @DisplayName("a failed authentication tag maps to 500 with the generic message, code preserved for the log")
+        void authenticationFailureMapsTo500() {
+            ResponseEntity<ApiError> response = handler.handlePayloadUnreadable(
+                    new PayloadUnreadableException(
+                            PayloadUnreadableException.AUTHENTICATION_FAILED, "GCM tag mismatch"),
+                    null);
+
+            assertEnvelope(
+                    response, HttpStatus.INTERNAL_SERVER_ERROR, PayloadUnreadableException.AUTHENTICATION_FAILED);
+            assertThat(response.getBody().message()).isEqualTo(SupplierExceptionHandler.PAYLOAD_UNREADABLE_MESSAGE);
+        }
+
+        @Test
+        @DisplayName("an unknown key id also maps to 500 with the generic message, on the routine-log path")
+        void unknownKeyIdMapsTo500() {
+            ResponseEntity<ApiError> response = handler.handlePayloadUnreadable(
+                    new PayloadUnreadableException(PayloadUnreadableException.UNKNOWN_KEY_ID, "no key for id 7"), null);
+
+            assertEnvelope(response, HttpStatus.INTERNAL_SERVER_ERROR, PayloadUnreadableException.UNKNOWN_KEY_ID);
+            assertThat(response.getBody().message()).isEqualTo(SupplierExceptionHandler.PAYLOAD_UNREADABLE_MESSAGE);
+        }
+    }
+
+    @Test
+    @DisplayName("body validation lists every rejected field, defaulting a null message rather than emitting null")
+    void bodyValidationListsFieldErrors() throws NoSuchMethodException {
+        BindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+        binding.addError(new FieldError("request", "supplierRef", "must not be blank"));
+        binding.addError(new FieldError("request", "capability", null));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(
+                new org.springframework.core.MethodParameter(
+                        SupplierExceptionHandlerTest.class.getDeclaredMethod("bodyValidationListsFieldErrors"), -1),
+                binding);
+
+        ResponseEntity<ApiError> response = handler.handleBodyValidation(ex, null);
+
+        assertEnvelope(response, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("Request validation failed");
+        assertThat(response.getBody().fieldErrors())
+                .extracting(ApiError.FieldError::field, ApiError.FieldError::message)
+                .containsExactly(tuple("supplierRef", "must not be blank"), tuple("capability", "invalid value"));
+    }
+
+    @Test
+    @DisplayName("a constraint violation maps to 400 VALIDATION_ERROR with the violation detail")
+    void constraintViolationMapsTo400() {
+        assertEnvelope(
+                handler.handleConstraintViolation(
+                        new jakarta.validation.ConstraintViolationException("must be positive", java.util.Set.of()),
+                        null),
+                HttpStatus.BAD_REQUEST,
+                "VALIDATION_ERROR");
+    }
+
+    @Test
+    @DisplayName("a missing request parameter names only the parameter, not attacker-controlled input")
+    void missingParameterNamesTheParameter() {
+        ResponseEntity<ApiError> response = handler.handleMissingParameter(
+                new MissingServletRequestParameterException("supplierRef", "String"), null);
+
+        assertEnvelope(response, HttpStatus.BAD_REQUEST, "MISSING_PARAMETER");
+        assertThat(response.getBody().message()).isEqualTo("Required request parameter 'supplierRef' is missing");
+    }
+
+    @Test
+    @DisplayName("a parameter type mismatch names only the parameter, never the submitted value")
+    void typeMismatchNamesTheParameterOnly() {
+        ResponseEntity<ApiError> response = handler.handleTypeMismatch(
+                new MethodArgumentTypeMismatchException(
+                        "<script>alert(1)</script>",
+                        UUID.class,
+                        "supplierProfileId",
+                        null,
+                        new IllegalArgumentException("bad uuid")),
+                null);
+
+        assertEnvelope(response, HttpStatus.BAD_REQUEST, "INVALID_PARAMETER");
+        assertThat(response.getBody().message()).isEqualTo("Parameter 'supplierProfileId' has an invalid value");
+        assertThat(response.getBody().message()).doesNotContain("script");
+    }
+
+    @Nested
+    @DisplayName("handleUnreadableBody — unwraps a canonical-constructor rejection from Jackson's wrapper")
+    class UnreadableBodyMapping {
+
+        @Test
+        @DisplayName("an IllegalArgumentException cause surfaces as VALIDATION_ERROR with its own message")
+        void illegalArgumentCauseIsUnwrapped() {
+            org.springframework.http.converter.HttpMessageNotReadableException ex =
+                    new org.springframework.http.converter.HttpMessageNotReadableException(
+                            "JSON parse error", new IllegalArgumentException("supplierRef must not be blank"), null);
+
+            ResponseEntity<ApiError> response = handler.handleUnreadableBody(ex, null);
+
+            assertEnvelope(response, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+            assertThat(response.getBody().message()).isEqualTo("supplierRef must not be blank");
+        }
+
+        @Test
+        @DisplayName("a NullPointerException cause is unwrapped the same way as an IllegalArgumentException")
+        void nullPointerCauseIsUnwrapped() {
+            org.springframework.http.converter.HttpMessageNotReadableException ex =
+                    new org.springframework.http.converter.HttpMessageNotReadableException(
+                            "JSON parse error", new NullPointerException(), null);
+
+            ResponseEntity<ApiError> response = handler.handleUnreadableBody(ex, null);
+
+            assertEnvelope(response, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+            assertThat(response.getBody().message()).isEqualTo("Request validation failed");
+        }
+
+        @Test
+        @DisplayName(
+                "a cause chain with no IllegalArgumentException or NullPointerException falls back to a generic parse failure")
+        void unrelatedCauseFallsBackToGenericMessage() {
+            org.springframework.http.converter.HttpMessageNotReadableException ex =
+                    new org.springframework.http.converter.HttpMessageNotReadableException(
+                            "JSON parse error", new RuntimeException("truncated stream"), null);
+
+            ResponseEntity<ApiError> response = handler.handleUnreadableBody(ex, null);
+
+            assertEnvelope(response, HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST");
+            assertThat(response.getBody().message()).isEqualTo("Request body could not be parsed");
+        }
+
+        @Test
+        @DisplayName("no cause at all also falls back to the generic parse failure")
+        void noCauseFallsBackToGenericMessage() {
+            org.springframework.http.converter.HttpMessageNotReadableException ex =
+                    new org.springframework.http.converter.HttpMessageNotReadableException(
+                            "JSON parse error", (Throwable) null, null);
+
+            ResponseEntity<ApiError> response = handler.handleUnreadableBody(ex, null);
+
+            assertEnvelope(response, HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST");
+        }
+    }
+
+    @Test
+    @DisplayName("an illegal argument outside a controller-body context still maps to 400 VALIDATION_ERROR")
+    void illegalArgumentMapsTo400() {
+        ResponseEntity<ApiError> response =
+                handler.handleIllegalArgument(new IllegalArgumentException("bad price"), null);
+
+        assertEnvelope(response, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("bad price");
+    }
+
+    @Test
+    @DisplayName("a permission denial maps to 403, never the 500 catch-all")
+    void accessDeniedMapsTo403() {
+        assertEnvelope(
+                handler.handleAccessDenied(new AccessDeniedException("denied"), null),
+                HttpStatus.FORBIDDEN,
+                "FORBIDDEN");
+    }
+
+    @Test
+    @DisplayName("a Spring optimistic-lock failure on a @Version-ed row maps to a retryable 409")
+    void objectOptimisticLockingFailureMapsTo409() {
+        assertEnvelope(
+                handler.handleOptimisticLockConflict(
+                        new ObjectOptimisticLockingFailureException(SupplierExceptionHandlerTest.class, "id"), null),
+                HttpStatus.CONFLICT,
+                "CONFLICT");
+    }
+
+    @Test
+    @DisplayName("a JPA optimistic-lock exception maps to the same retryable 409")
+    void jpaOptimisticLockExceptionMapsTo409() {
+        assertEnvelope(
+                handler.handleOptimisticLockConflict(new OptimisticLockException("stale"), null),
+                HttpStatus.CONFLICT,
+                "CONFLICT");
+    }
+
+    @Test
+    @DisplayName("an unanticipated exception falls through to 500 INTERNAL_ERROR, never leaking its message")
+    void unexpectedExceptionMapsTo500() {
+        ResponseEntity<ApiError> response =
+                handler.handleUnexpected(new IllegalStateException("stack trace detail nobody should see"), null);
+
+        assertEnvelope(response, HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("An unexpected error occurred");
+    }
+
+    @Nested
+    @DisplayName("correlation id resolution — ambient scope, then inbound header, then generated")
+    class CorrelationIdResolution {
+
+        @Test
+        @DisplayName("an ambient scope wins even when the request carries a different header value")
+        void ambientScopeTakesPrecedenceOverTheHeader() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader(CORRELATION_HEADER, "header-value-should-be-ignored");
+
+            try (SupplierCorrelationContext.CorrelationScope scope = SupplierCorrelationContext.open("scope-value")) {
+                ResponseEntity<ApiError> response =
+                        handler.handleNotFound(new SupplierNotFoundException("X", "not found"), request);
+
+                assertThat(response.getBody().correlationId()).isEqualTo(scope.correlationId());
+                assertThat(response.getBody().correlationId()).isEqualTo("scope-value");
+            }
+        }
+
+        @Test
+        @DisplayName("with no ambient scope, a non-blank inbound header is reused")
+        void inboundHeaderIsReusedWithNoAmbientScope() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader(CORRELATION_HEADER, "inbound-trace-id");
+
+            ResponseEntity<ApiError> response =
+                    handler.handleNotFound(new SupplierNotFoundException("X", "not found"), request);
+
+            assertThat(response.getBody().correlationId()).isEqualTo("inbound-trace-id");
+        }
+
+        @Test
+        @DisplayName("with no ambient scope and no request, a fresh id is generated rather than left blank")
+        void generatesAFreshIdWithNoScopeAndNoRequest() {
+            ResponseEntity<ApiError> first =
+                    handler.handleNotFound(new SupplierNotFoundException("X", "not found"), (HttpServletRequest) null);
+            ResponseEntity<ApiError> second =
+                    handler.handleNotFound(new SupplierNotFoundException("X", "not found"), (HttpServletRequest) null);
+
+            assertThat(first.getBody().correlationId()).isNotBlank();
+            assertThat(second.getBody().correlationId()).isNotBlank();
+            // Independently generated per call -- nothing carries state between two unrelated requests.
+            assertThat(first.getBody().correlationId())
+                    .isNotEqualTo(second.getBody().correlationId());
+        }
+
+        @Test
+        @DisplayName("a blank inbound header counts as absent and a fresh id is generated instead")
+        void blankInboundHeaderIsTreatedAsAbsent() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader(CORRELATION_HEADER, "   ");
+
+            ResponseEntity<ApiError> response =
+                    handler.handleNotFound(new SupplierNotFoundException("X", "not found"), request);
+
+            assertThat(response.getBody().correlationId()).isNotBlank();
+            assertThat(response.getBody().correlationId()).isNotEqualTo("   ");
+        }
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/order/service/OrderEventMapperTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/order/service/OrderEventMapperTest.java
@@ -1,0 +1,195 @@
+package com.positivity.supplier.internal.order.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.domainevents.supplier.SupplierOrderConfirmedLine;
+import com.positivity.domainevents.supplier.SupplierOrderStatusChangedV1;
+import com.positivity.domainevents.supplier.SupplierOrderStatusDespatch;
+import com.positivity.domainevents.supplier.SupplierOrderStatusLine;
+import com.positivity.domainevents.supplier.SupplierOrderStatusSchedule;
+import com.positivity.supplier.internal.domain.model.SupplierDeliverySchedule;
+import com.positivity.supplier.internal.domain.model.SupplierDespatch;
+import com.positivity.supplier.internal.domain.model.SupplierOrderResult;
+import com.positivity.supplier.internal.domain.model.SupplierOrderStatusResult;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Field-for-field translation from the canonical supplier model to the cross-module event
+ * payloads (ADR-0049 §3, ADR-0044). The mapper promises nothing is invented in translation —
+ * these tests pin that a missing value in the canonical model stays missing in the event, not
+ * defaulted, and that every field lands in the right place rather than merely "some value".
+ */
+@DisplayName("OrderEventMapper — canonical model to event payload translation")
+class OrderEventMapperTest {
+
+    private static final SupplierDespatch DESPATCH =
+            new SupplierDespatch(LocalDate.of(2026, 8, 1), "ASN-1", "ASN-1-L1", 4);
+
+    private static final SupplierDeliverySchedule SCHEDULE =
+            new SupplierDeliverySchedule(LocalDate.of(2026, 8, 5), 4, 1, 2, 0, 7, 4, List.of(DESPATCH));
+
+    @Test
+    @DisplayName("toEventStatusLines carries every field verbatim, schedules included")
+    void toEventStatusLinesCarriesEveryField() {
+        SupplierOrderStatusResult.Line line = new SupplierOrderStatusResult.Line(
+                "L1",
+                "CLI-1",
+                "0000000000001",
+                "VEND-1",
+                "BUY-1",
+                "Tyre",
+                10,
+                LocalDate.of(2026, 8, 3),
+                List.of(SCHEDULE),
+                "E1",
+                "vendor error text");
+
+        List<SupplierOrderStatusLine> result = OrderEventMapper.toEventStatusLines(List.of(line));
+
+        assertThat(result).hasSize(1);
+        SupplierOrderStatusLine event = result.get(0);
+        assertThat(event.lineId()).isEqualTo("L1");
+        assertThat(event.customerLineItemNumber()).isEqualTo("CLI-1");
+        assertThat(event.articleEan()).isEqualTo("0000000000001");
+        assertThat(event.supplierArticleCode()).isEqualTo("VEND-1");
+        assertThat(event.buyersArticleId()).isEqualTo("BUY-1");
+        assertThat(event.description()).isEqualTo("Tyre");
+        assertThat(event.orderedQuantity()).isEqualTo(10);
+        assertThat(event.requestedDeliveryDate()).isEqualTo(LocalDate.of(2026, 8, 3));
+        assertThat(event.vendorErrorCode()).isEqualTo("E1");
+        assertThat(event.vendorErrorText()).isEqualTo("vendor error text");
+        assertThat(event.schedules()).hasSize(1);
+        assertThat(event.schedules().get(0).deliveryDate()).isEqualTo(LocalDate.of(2026, 8, 5));
+    }
+
+    @Test
+    @DisplayName("toEventStatusLines maps an empty line list to an empty event list")
+    void toEventStatusLinesHandlesEmptyInput() {
+        assertThat(OrderEventMapper.toEventStatusLines(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toEventConfirmedLines carries ordered/confirmed/killed quantities separately")
+    void toEventConfirmedLinesCarriesEveryField() {
+        SupplierOrderResult.Line line = new SupplierOrderResult.Line(
+                "L2", "0000000000002", "VEND-2", 5, 3, 2, List.of(SCHEDULE), "E2", "vendor rejected 2");
+
+        List<SupplierOrderConfirmedLine> result = OrderEventMapper.toEventConfirmedLines(List.of(line));
+
+        assertThat(result).hasSize(1);
+        SupplierOrderConfirmedLine event = result.get(0);
+        assertThat(event.lineId()).isEqualTo("L2");
+        assertThat(event.articleEan()).isEqualTo("0000000000002");
+        assertThat(event.supplierArticleCode()).isEqualTo("VEND-2");
+        assertThat(event.orderedQuantity()).isEqualTo(5);
+        assertThat(event.confirmedQuantity()).isEqualTo(3);
+        assertThat(event.killedQuantity()).isEqualTo(2);
+        assertThat(event.vendorErrorCode()).isEqualTo("E2");
+        assertThat(event.vendorErrorText()).isEqualTo("vendor rejected 2");
+        assertThat(event.schedules()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("toEventConfirmedLinesFromStatus never invents a killedQuantity — it is always null")
+    void toEventConfirmedLinesFromStatusNeverStatesKilledQuantity() {
+        SupplierOrderStatusResult.Line line = new SupplierOrderStatusResult.Line(
+                "L3", null, null, null, null, null, 6, null, List.of(SCHEDULE), null, null);
+
+        List<SupplierOrderConfirmedLine> result = OrderEventMapper.toEventConfirmedLinesFromStatus(List.of(line));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).killedQuantity()).isNull();
+        assertThat(result.get(0).orderedQuantity()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("toEventConfirmedLinesFromStatus totals confirmed quantity across every schedule")
+    void toEventConfirmedLinesFromStatusTotalsConfirmedQuantityAcrossSchedules() {
+        SupplierDeliverySchedule first = new SupplierDeliverySchedule(null, 3, null, null, null, null, null, List.of());
+        SupplierDeliverySchedule second =
+                new SupplierDeliverySchedule(null, 4, null, null, null, null, null, List.of());
+        SupplierOrderStatusResult.Line line = new SupplierOrderStatusResult.Line(
+                "L4", null, null, null, null, null, null, null, List.of(first, second), null, null);
+
+        List<SupplierOrderConfirmedLine> result = OrderEventMapper.toEventConfirmedLinesFromStatus(List.of(line));
+
+        assertThat(result.get(0).confirmedQuantity()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("toEventConfirmedLinesFromStatus leaves confirmedQuantity null, not zero, when no schedule stated one")
+    void toEventConfirmedLinesFromStatusLeavesConfirmedQuantityNullWhenUnstated() {
+        SupplierDeliverySchedule noQuantity =
+                new SupplierDeliverySchedule(null, null, null, null, null, null, null, List.of());
+        SupplierOrderStatusResult.Line line = new SupplierOrderStatusResult.Line(
+                "L5", null, null, null, null, null, null, null, List.of(noQuantity), null, null);
+
+        List<SupplierOrderConfirmedLine> result = OrderEventMapper.toEventConfirmedLinesFromStatus(List.of(line));
+
+        assertThat(result.get(0).confirmedQuantity()).isNull();
+    }
+
+    @Test
+    @DisplayName("toEventConfirmedLinesFromStatus with no schedules at all totals to null, not zero")
+    void toEventConfirmedLinesFromStatusTotalsNullWithNoSchedules() {
+        SupplierOrderStatusResult.Line line = new SupplierOrderStatusResult.Line(
+                "L6", null, null, null, null, null, null, null, List.of(), null, null);
+
+        List<SupplierOrderConfirmedLine> result = OrderEventMapper.toEventConfirmedLinesFromStatus(List.of(line));
+
+        assertThat(result.get(0).confirmedQuantity()).isNull();
+        assertThat(result.get(0).schedules()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toEventSchedules carries every quantity field and nested despatches")
+    void toEventSchedulesCarriesEveryField() {
+        List<SupplierOrderStatusSchedule> result = OrderEventMapper.toEventSchedules(List.of(SCHEDULE));
+
+        assertThat(result).hasSize(1);
+        SupplierOrderStatusSchedule event = result.get(0);
+        assertThat(event.deliveryDate()).isEqualTo(LocalDate.of(2026, 8, 5));
+        assertThat(event.confirmedQuantity()).isEqualTo(4);
+        assertThat(event.cancelledQuantity()).isEqualTo(1);
+        assertThat(event.openQuantity()).isEqualTo(2);
+        assertThat(event.backorderedQuantity()).isEqualTo(0);
+        assertThat(event.scheduledQuantity()).isEqualTo(7);
+        assertThat(event.shippedQuantity()).isEqualTo(4);
+        assertThat(event.despatches()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("toEventDespatches keeps the despatch advice reference verbatim, never parsed")
+    void toEventDespatchesCarriesEveryField() {
+        List<SupplierOrderStatusDespatch> result = OrderEventMapper.toEventDespatches(List.of(DESPATCH));
+
+        assertThat(result).hasSize(1);
+        SupplierOrderStatusDespatch event = result.get(0);
+        assertThat(event.despatchDate()).isEqualTo(LocalDate.of(2026, 8, 1));
+        assertThat(event.despatchAdviceDocumentId()).isEqualTo("ASN-1");
+        assertThat(event.despatchAdviceLineId()).isEqualTo("ASN-1-L1");
+        assertThat(event.despatchedQuantity()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("toEventDespatches maps an empty despatch list to an empty event list")
+    void toEventDespatchesHandlesEmptyInput() {
+        assertThat(OrderEventMapper.toEventDespatches(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toEventStatus maps every canonical status to its event counterpart, one-for-one")
+    void toEventStatusMapsEveryEnumValue() {
+        assertThat(OrderEventMapper.toEventStatus(SupplierOrderStatusResult.Status.NOT_FOUND))
+                .isEqualTo(SupplierOrderStatusChangedV1.Status.NOT_FOUND);
+        assertThat(OrderEventMapper.toEventStatus(SupplierOrderStatusResult.Status.IN_PROGRESS))
+                .isEqualTo(SupplierOrderStatusChangedV1.Status.IN_PROGRESS);
+        assertThat(OrderEventMapper.toEventStatus(SupplierOrderStatusResult.Status.CONFIRMED))
+                .isEqualTo(SupplierOrderStatusChangedV1.Status.CONFIRMED);
+        assertThat(OrderEventMapper.toEventStatus(SupplierOrderStatusResult.Status.REJECTED))
+                .isEqualTo(SupplierOrderStatusChangedV1.Status.REJECTED);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/service/SupplierOutboxPublisherTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/service/SupplierOutboxPublisherTest.java
@@ -1,0 +1,253 @@
+package com.positivity.supplier.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.entity.SupplierOutboxEventEntity;
+import com.positivity.supplier.internal.repository.SupplierOutboxEventRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+/**
+ * The at-least-once outbox drain (ADR-0044 §4). The two properties that matter most are that a
+ * row is marked published only once Kafka has acknowledged it, and that a batch stops at its
+ * first failure rather than reordering a PRICAT completion event ahead of a stuck chunk.
+ */
+@DisplayName("SupplierOutboxPublisher — draining supplier_event_outbox to Kafka")
+class SupplierOutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-25T09:00:00Z");
+
+    private final SupplierOutboxEventRepository repository = mock(SupplierOutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @AfterEach
+    void clearInterruptFlag() {
+        // The InterruptedException test below deliberately sets this; leaving it set would corrupt
+        // whichever test runs next on this thread.
+        Thread.interrupted();
+    }
+
+    private static SupplierOutboxEventEntity pendingEvent(String topic) {
+        return SupplierOutboxEventEntity.builder()
+                .topic(topic)
+                .recordKey("key-1")
+                .eventType("SUPPLIER_TEST_EVENT")
+                .payload("{}")
+                .attempts(0)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<SendResult<String, String>> acknowledged() {
+        return CompletableFuture.completedFuture((SendResult<String, String>) mock(SendResult.class));
+    }
+
+    @Test
+    @DisplayName("an empty outbox does nothing: no send, no save")
+    void emptyOutboxPublishesNothing() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a successful send marks the row published at the clock's instant and resets attempts/lastError")
+    void successfulSendMarksRowPublished() {
+        SupplierOutboxEventEntity event = pendingEvent("supplier.events.v1");
+        event.setAttempts(2);
+        event.setLastError("previous failure");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(event));
+        when(kafkaTemplate.send("supplier.events.v1", "key-1", "{}")).thenReturn(acknowledged());
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, provider(registry));
+
+        publisher.publishPending();
+
+        assertThat(event.getPublishedAt()).isEqualTo(NOW);
+        assertThat(event.getAttempts()).isZero();
+        assertThat(event.getLastError()).isNull();
+        verify(repository).save(event);
+        assertThat(registry.get("supplier.outbox.published").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("a batch of several rows all publishes in order when every send succeeds")
+    void publishesEveryPendingRowInOrder() {
+        SupplierOutboxEventEntity first = pendingEvent("topic-a");
+        SupplierOutboxEventEntity second = pendingEvent("topic-b");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenReturn(acknowledged());
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("a broker failure records the attempt and error, but does not mark the row published")
+    void brokerFailureRecordsAttemptAndError() {
+        SupplierOutboxEventEntity event = pendingEvent("supplier.events.v1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(event));
+        CompletableFuture<SendResult<String, String>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("broker unavailable"));
+        when(kafkaTemplate.send("supplier.events.v1", "key-1", "{}")).thenReturn(failed);
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, provider(registry));
+
+        publisher.publishPending();
+
+        assertThat(event.getPublishedAt()).isNull();
+        assertThat(event.getAttempts()).isEqualTo(1);
+        assertThat(event.getLastError()).contains("broker unavailable");
+        verify(repository).save(event);
+        assertThat(registry.get("supplier.outbox.publish.failures").counter().count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("a batch stops at the first failure, so a later event never overtakes a stuck one")
+    void batchStopsAtFirstFailure() {
+        SupplierOutboxEventEntity stuck = pendingEvent("topic-a");
+        SupplierOutboxEventEntity later = pendingEvent("topic-b");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(stuck, later));
+        CompletableFuture<SendResult<String, String>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("broker unavailable"));
+        when(kafkaTemplate.send("topic-a", "key-1", "{}")).thenReturn(failed);
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate, never()).send("topic-b", "key-1", "{}");
+        assertThat(later.getPublishedAt()).isNull();
+        assertThat(later.getAttempts()).isZero();
+    }
+
+    @Test
+    @DisplayName("an error message over 2000 characters is truncated, not stored unbounded")
+    void longErrorMessageIsTruncated() {
+        SupplierOutboxEventEntity event = pendingEvent("supplier.events.v1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(event));
+        String longMessage = "x".repeat(2500);
+        CompletableFuture<SendResult<String, String>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException(longMessage));
+        when(kafkaTemplate.send("supplier.events.v1", "key-1", "{}")).thenReturn(failed);
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        assertThat(event.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("an exception with no message (a bare send timeout) falls back to its class's simple name")
+    void exceptionWithNoMessageFallsBackToClassName() {
+        // Future.get() wraps a completeExceptionally cause in ExecutionException, whose own
+        // message is the cause's toString() -- never null. The one checked exception `.get()`
+        // throws un-wrapped with no message by default is a genuine send timeout, so that is what
+        // exercises the "no message" branch here rather than an unreachable completeExceptionally
+        // case.
+        SupplierOutboxEventEntity event = pendingEvent("supplier.events.v1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(event));
+        CompletableFuture<SendResult<String, String>> timingOut = new CompletableFuture<>() {
+            @Override
+            public SendResult<String, String> get(long timeout, TimeUnit unit)
+                    throws java.util.concurrent.TimeoutException {
+                throw new java.util.concurrent.TimeoutException();
+            }
+        };
+        when(kafkaTemplate.send("supplier.events.v1", "key-1", "{}")).thenReturn(timingOut);
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        assertThat(event.getLastError()).isEqualTo("TimeoutException");
+    }
+
+    @Test
+    @DisplayName("an interrupted send restores the thread's interrupt flag and records the failure")
+    void interruptedSendRestoresInterruptFlagAndRecordsFailure() {
+        SupplierOutboxEventEntity event = pendingEvent("supplier.events.v1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(event));
+        CompletableFuture<SendResult<String, String>> interrupting = new CompletableFuture<>() {
+            @Override
+            public SendResult<String, String> get(long timeout, TimeUnit unit) throws InterruptedException {
+                throw new InterruptedException("interrupted mid-send");
+            }
+        };
+        when(kafkaTemplate.send("supplier.events.v1", "key-1", "{}")).thenReturn(interrupting);
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        assertThat(event.getAttempts()).isEqualTo(1);
+        assertThat(event.getLastError()).contains("interrupted mid-send");
+    }
+
+    @Test
+    @DisplayName("with no MeterRegistry bean available, counters stay null and publishing still works")
+    void worksWithNoMeterRegistryAvailable() {
+        SupplierOutboxEventEntity event = pendingEvent("supplier.events.v1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(event));
+        when(kafkaTemplate.send("supplier.events.v1", "key-1", "{}")).thenReturn(acknowledged());
+        SupplierOutboxPublisher publisher =
+                new SupplierOutboxPublisher(repository, kafkaTemplate, clock, noMeterRegistry());
+
+        publisher.publishPending();
+
+        assertThat(event.getPublishedAt()).isEqualTo(NOW);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<io.micrometer.core.instrument.MeterRegistry> noMeterRegistry() {
+        ObjectProvider<io.micrometer.core.instrument.MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        return provider;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<io.micrometer.core.instrument.MeterRegistry> provider(
+            io.micrometer.core.instrument.MeterRegistry registry) {
+        ObjectProvider<io.micrometer.core.instrument.MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        return provider;
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/service/SupplierOutboxPublisherTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/service/SupplierOutboxPublisherTest.java
@@ -3,6 +3,7 @@ package com.positivity.supplier.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -21,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
@@ -112,7 +114,12 @@ class SupplierOutboxPublisherTest {
 
         assertThat(first.getPublishedAt()).isEqualTo(NOW);
         assertThat(second.getPublishedAt()).isEqualTo(NOW);
-        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        // times(2) alone would not catch topic-b going out before topic-a -- pin the exact
+        // sequence with InOrder, which is the property "in order" actually promises.
+        InOrder inOrder = inOrder(kafkaTemplate);
+        inOrder.verify(kafkaTemplate).send("topic-a", "key-1", "{}");
+        inOrder.verify(kafkaTemplate).send("topic-b", "key-1", "{}");
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/pos-vehicle-inventory/pom.xml
+++ b/pos-vehicle-inventory/pom.xml
@@ -14,12 +14,12 @@
     <description>POS Vehicle module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 79.6% line / 74.7% branch by the gate's own
+        <!-- Coverage ratchet: measured 79.2% line / 75.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
         <jacoco.line.min>0.76</jacoco.line.min>
-        <jacoco.branch.min>0.71</jacoco.branch.min>
+        <jacoco.branch.min>0.72</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-vehicle-reference-carapi/pom.xml
+++ b/pos-vehicle-reference-carapi/pom.xml
@@ -14,9 +14,12 @@
     <properties>
         <!-- Coverage ratchet: measured 78.3% line / 88.9% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
-             Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
-             IT-inclusive measurement describes coverage the gate cannot see.
-             The branch floor tolerates one whole branch (18 branches total, one = 5.6 points). -->
+             Floors sit 3 points under, the same standard cushion every module gets.
+             Re-derive them ONLY from a -DskipITs run — an IT-inclusive measurement
+             describes coverage the gate cannot see.
+             Note: this module has only 18 branches (jacoco.csv), so each one is worth
+             about 5.6 points of the branch percentage — a single branch regression can
+             move the measured figure by more than the 3-point cushion. -->
         <jacoco.line.min>0.75</jacoco.line.min>
         <jacoco.branch.min>0.85</jacoco.branch.min>
     </properties>

--- a/pos-vehicle-reference-carapi/pom.xml
+++ b/pos-vehicle-reference-carapi/pom.xml
@@ -18,7 +18,7 @@
              IT-inclusive measurement describes coverage the gate cannot see.
              The branch floor tolerates one whole branch (18 branches total, one = 5.6 points). -->
         <jacoco.line.min>0.75</jacoco.line.min>
-        <jacoco.branch.min>0.83</jacoco.branch.min>
+        <jacoco.branch.min>0.85</jacoco.branch.min>
     </properties>
 
     <packaging>jar</packaging>

--- a/pos-web-common/pom.xml
+++ b/pos-web-common/pom.xml
@@ -13,6 +13,16 @@
     <description>Shared web MVC concerns: global exception handling with the canonical ApiError envelope</description>
     <packaging>jar</packaging>
 
+    <properties>
+        <!-- Coverage ratchet: measured 84.6% line / 63.4% branch by the gate's own
+             command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
+             Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
+             IT-inclusive measurement describes coverage the gate cannot see.
+             Regenerate with scripts/update-coverage-floors.sh. -->
+        <jacoco.line.min>0.81</jacoco.line.min>
+        <jacoco.branch.min>0.60</jacoco.branch.min>
+    </properties>
+
     <dependencies>
         <!-- Spring Web MVC (advice, servlet API) -->
         <dependency>

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -13,12 +13,12 @@
     <description>Module to manage workorders for a shop</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 77.7% line / 63.1% branch by the gate's own
+        <!-- Coverage ratchet: measured 78.8% line / 65.0% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.74</jacoco.line.min>
-        <jacoco.branch.min>0.60</jacoco.branch.min>
+        <jacoco.line.min>0.75</jacoco.line.min>
+        <jacoco.branch.min>0.62</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <pluginRepositories>


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — CI maintenance (nightly build repair, no feature capability)
- Parent STORY (durion): N/A
- Child issue: N/A — fixes scheduled run failure https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32815736048
- Domain: `domain:build/coverage` (touches pom coverage floors across modules; new tests in supplier)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): N/A — no API or event contract semantics changed (reference kept for the sync check: BACKEND_CONTRACT_GUIDE.md). Changes are pom.xml JaCoCo floor properties and new unit tests only.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- What changed:
  - Ratcheted `jacoco.line.min` / `jacoco.branch.min` floors in 12 module poms to measured coverage minus the standard 3-pt cushion, via `scripts/update-coverage-floors.sh --apply` (adds the previously missing floors to `pos-web-common`).
  - Added 4 unit test classes to `pos-supplier` (`OrderEventMapperTest`, `SupplierExceptionHandlerTest`, `EdiwheelXmlSupportTest`, `SupplierOutboxPublisherTest`), lifting line coverage 85.4% → 87.1% and branch coverage 73.2% → 74.8%.
- Why: the scheduled Backend CI/CD run failed at the "Enforce coverage floor drift" gate — floors were STALE in `pos-events`, `pos-image`, `pos-document-helper`, UNGUARDED in `pos-web-common`, and `pos-supplier` line coverage had genuinely regressed (87.3% → 85.4%), leaving a THIN 1.4-pt cushion. Per `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §6.2 the regression is closed with tests rather than by lowering the floor (`--allow-lower` was not used).

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run:
  - `./mvnw -pl pos-supplier -am verify -DskipITs -Darchunit.skipTests=true` (1148 tests, 0 failures)
  - `./mvnw -pl pos-coverage-aggregate -am verify -DskipITs -Darchunit.skipTests=true -T 1C && python3 scripts/coverage_floors.py --check` → exits 0: "38 measured module(s); every floor sits 2-6 pts under its coverage."

## Risk & Rollback
- Risk level: Low — pom coverage-threshold properties and new test code only; no production code changed.
- Rollback plan: revert the two commits; floors return to prior values (the drift gate would fail again on the next scheduled run until re-ratcheted).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, CI-repair branch `claude/build-run-failure-a0waxr`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability
- [x] Links to parent + child issues are present (failed run linked above)
- [ ] Contract guide updated — N/A, no contract semantics changed
- [x] Required CI checks passing (verified locally; CI pending on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjyK1LWKZcKbhkkmfDUdy2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjyK1LWKZcKbhkkmfDUdy2)_