### PR TITLE
fix: clear the S2259 reliability BLOCKER on inventory availability

### DIFF
--- a/docs/SONARQUBE_REMEDIATION_PLAN.md
+++ b/docs/SONARQUBE_REMEDIATION_PLAN.md
@@ -595,3 +595,21 @@ calls after each phase lands, and update the Status line at the top of this
 document. Every `file.java:NN` coordinate in this plan and in the CSV is the
 location SonarCloud reported at the analysis named above; fixing a file shifts
 the lines below it, so re-derive rather than trusting a stale number.
+
+## Post-baseline findings
+
+Issues registered by analyses after the 2026-08-24 06:30 baseline are tracked
+here rather than in the inventory CSV (which is frozen to the analysed
+snapshot).
+
+| Registered | Rule | Location | Status |
+| ---------- | ---- | -------- | ------ |
+| 2026-08-24 18:11 | `javabugs:S2259` (reliability BLOCKER) | `pos-inventory/…/InventoryAvailabilityServiceImpl` — `queryAvailability`'s ATP subtraction | fixed — all four `onHand`/`allocated` assignment arms routed through `Quantities.nz` |
+
+The S2259 finding is the dataflow engine's documented limitation, not a
+runtime bug: it models a bare `BigDecimal.ZERO` static-field read as possibly
+null (see `Quantities.nz`'s javadoc, which exists for exactly this), and both
+the scoped ternaries and the reduce identities assigned from one, so the
+engine proved an NPE path into the subtraction. `Quantities.nz` is the one
+shape the engine accepts as non-null; behaviour is identical.
+

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -176,22 +176,25 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
         UUID scopeLocationId = storageLocationId != null ? storageLocationId : locationId;
         BigDecimal onHand;
         BigDecimal allocated;
+        // Every arm routes through Quantities.nz: SonarCloud's dataflow engine models a bare
+        // BigDecimal.ZERO read as possibly null (see Quantities.nz), and proved an NPE at the
+        // ATP subtraction below from these assignments (javabugs:S2259).
         if (scopeLocationId == null) {
-            onHand = productRows.stream()
+            onHand = Quantities.nz(productRows.stream()
                     .map(InventoryStockSummary::getOnHand)
                     .map(Quantities::nz)
-                    .reduce(BigDecimal.ZERO, BigDecimal::add);
-            allocated = productRows.stream()
+                    .reduce(BigDecimal.ZERO, BigDecimal::add));
+            allocated = Quantities.nz(productRows.stream()
                     .map(InventoryStockSummary::getAllocated)
                     .map(Quantities::nz)
-                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+                    .reduce(BigDecimal.ZERO, BigDecimal::add));
         } else {
             InventoryStockSummary scoped = productRows.stream()
                     .filter(row -> scopeLocationId.equals(row.getLocationId()))
                     .findFirst()
                     .orElse(null);
-            onHand = scoped == null ? BigDecimal.ZERO : Quantities.nz(scoped.getOnHand());
-            allocated = scoped == null ? BigDecimal.ZERO : Quantities.nz(scoped.getAllocated());
+            onHand = Quantities.nz(scoped == null ? null : scoped.getOnHand());
+            allocated = Quantities.nz(scoped == null ? null : scoped.getAllocated());
         }
 
         // Forecast site scope (odoo-parity A2, #1028): the site parameter when present,


### PR DESCRIPTION
Addresses the reliability issue SonarCloud registered at 2026-08-24 18:11 UTC, after the remediation plan's baseline: `javabugs:S2259` (reliability **BLOCKER**) against `InventoryAvailabilityServiceImpl.queryAvailability`'s ATP subtraction — "Fix this access that will throw a NullPointerException when executed."

## Capability &amp; Traceability
- Capability: n/a — reliability finding, not a capability slice
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no contract semantics change; no controller, DTO, event payload, `openapi.yaml`, or validation/error model changes. The change is provably behaviour-identical (see Scope). Reference retained per the template so the Contract Sync Enforcement check can find `BACKEND_CONTRACT_GUIDE.md` in this body.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` regenerated — n/a
- [ ] Angular SDK regenerated — n/a

## Scope

**Diagnosis: the analyzer's documented limitation, not a runtime bug.** SonarCloud's dataflow engine models a bare `BigDecimal.ZERO` static-field read as possibly null — the codebase already knows this: `Quantities.nz`'s javadoc records it and wraps ZERO in `Objects.requireNonNull` as *"the one shape both prove non-null."* `queryAvailability` assigned `onHand`/`allocated` from bare `BigDecimal.ZERO` in two places the engine traces into the flagged line: the `scoped == null ? BigDecimal.ZERO : …` ternaries, and the `.reduce(BigDecimal.ZERO, BigDecimal::add)` identities. From those, the engine proves an NPE at `onHand.subtract(allocated).subtract(expiredDeduction)`. At runtime `BigDecimal.ZERO` is never null, so the NPE is unreachable — but the finding is a reliability BLOCKER on the quality gate and the fix is smaller than a suppression.

**Fix:** every arm of the four assignments now routes through `Quantities.nz` — the ternaries become `Quantities.nz(scoped == null ? null : scoped.getOnHand())` (which also reads better), and the reduce results are wrapped. One comment above the block names the constraint. Behaviour is identical: `nz(null)` **is** `BigDecimal.ZERO`.

Verification that the finding clears comes from this PR's own Incremental Code Quality Analysis; the fix targets the exact nullability sources the engine reported through.

Also adds a **Post-baseline findings** section to `docs/SONARQUBE_REMEDIATION_PLAN.md` — the inventory CSV is frozen to the 06:30 analysed snapshot, so later-registered issues are tracked there, starting with this one.

## Tests
- [ ] Unit tests added/updated — none needed: the change is behaviour-identical by construction (`nz(null)` = `ZERO`), and the existing suite covers `queryAvailability`
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run:**
```bash
./mvnw -pl pos-inventory -DskipTests=false -DskipITs verify
```
Verified green: **977 tests**, Spotless, Checkstyle, SpotBugs and the jacoco ratchet enforced; no coverage floors touched.

## Risk &amp; Rollback
- Risk level: **Low** — a 9-insertion/6-deletion change in one method, provably value-identical.
- Rollback plan: revert the commit.

## Checklist
- [ ] Branch name matches `cap/` — no; `claude/*` branch, consistent with the remediation series
- [ ] PR title starts with `[CAP:]` — no cap id for code-health work
- [ ] Links to parent + child issues are present — no tracking issue exists
- [x] Contract guide updated (when contract semantics changed) — n/a
- [ ] Required CI checks passing — pending first run

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKBxAj3zreJqYprAGvtXnS)_