### PR TITLE
Define equal-aggregateVersion semantics and make catalog/location versions strictly advance (#1486)

### DIFF
--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -304,20 +304,18 @@ already satisfies the strictly-advancing contract:
 | `warranty.events.v1` | pos-warranty `WarrantyClaim` `@Version`, flushed and force-incremented on otherwise-clean mutations | Yes | Yes — pos-accounting's `>=` flipped in #1486 |
 | `workorder.events.v1` | `Instant.now(clock)` epoch millis; `Workorder` has no `@Version` | **No** | Scoped out — see below |
 | `customer.events.v1` | `Instant.now(clock)` epoch millis; party entities carry no optimistic-lock version | **No** | Scoped out — see below |
-| `location.events.v1` | `Instant.now(clock)` epoch millis — `Location` *has* an unused `@Version` the publisher ignores | **No** | Scoped out — see below |
+| `location.events.v1` | pos-location `Location`/`StorageLocationEntity` `@Version`, flushed before emit, seeded at migration time from wall-clock millis (#1486 follow-up) | Yes | Yes — pos-order's `>=` flipped |
 
-**Scoped out, and why:** the `>=` guards consuming `workorder.events.v1`,
-`customer.events.v1`, and `location.events.v1` (pos-order's workorder/customer/location
-listeners, pos-accounting's customer listener) keep their skip-on-equal behavior for now.
-Those publishers still stamp wall-clock millis, so their versions can tie or even invert
-across instances; a `>=` guard at least fails closed on a tie, and none of those topics has a
-regenerate-from-current-state replay whose repairs the guard could be blocking (their
-`OutboxReplayServiceImpl` re-sends existing outbox rows under the original `eventId`, which
-consumers drop by idempotency regardless of any version guard). Adopting the rule on such a
-topic means fixing its publisher first — the `@Version`-flush pattern above; for
-`location.events.v1` that is one line, since the column already exists — and only then moving
-its consumers to `ReplicaVersionGuard`. Doing it in the other order reintroduces the
-same-millisecond race #1486 closed.
+**Scoped out, and why:** the `>=` guards consuming `workorder.events.v1` and
+`customer.events.v1` (pos-order's workorder/customer listeners, pos-accounting's customer
+listener) keep their skip-on-equal behavior for now. Those publishers still stamp wall-clock
+millis, so their versions can tie or even invert across instances; a `>=` guard at least fails
+closed on a tie, and neither topic has a regenerate-from-current-state replay whose repairs the
+guard could be blocking (their `OutboxReplayServiceImpl` re-sends existing outbox rows under
+the original `eventId`, which consumers drop by idempotency regardless of any version guard).
+Adopting the rule on such a topic means fixing its publisher first — the `@Version`-flush
+pattern above — and only then moving its consumers to `ReplicaVersionGuard`. Doing it in the
+other order reintroduces the same-millisecond race #1486 closed.
 
 ---
 

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -292,14 +292,32 @@ past every fact the aggregate ever emitted.
 
 ### Other domains' topics
 
-Consumers of topics whose publishers still derive `aggregateVersion` from wall-clock
-timestamps keep their current guards for now: flipping a `>=` guard to `>` without a
-strictly-advancing publisher would reintroduce the same-millisecond race on that topic, and
-none of those topics has a replay endpoint whose repairs a `>=` guard could be blocking.
-Adopting the rule on such a topic means fixing its publisher first (the `@Version` pattern
-above), then moving its consumers to `ReplicaVersionGuard` — in that order.
+Every fact topic was surveyed (#1486) for the same guard split and for whether its publisher
+already satisfies the strictly-advancing contract:
 
-<!-- SURVEY_TABLE -->
+| Topic | Publisher version source | Strictly advancing? | Consumers on the rule? |
+|---|---|---|---|
+| `catalog.events.v1` | pos-catalog `@Version`, flushed before emit (#1486) | Yes | Yes — all seven use `ReplicaVersionGuard` |
+| `vehicle.events.v1` (`VehicleUpdatedV1`) | pos-vehicle-inventory `VehicleRecord` `@Version`, flushed before emit | Yes | Yes — former `>=` guards (pos-order, pos-customer) flipped in #1486 |
+| `vehicle.events.v1` (`VehicleCarePreferenceUpdatedV1`) | Epoch millis by design (rows are hard-deleted and re-created, so an entity version would restart at 0) | No | Its one consumer already applies on equal; acceptable for a last-writer-wins preference fact |
+| `invoice.events.v1` | pos-invoice `Invoice`/`BillingRules` `@Version`, flushed before emit | Yes | Yes — pos-accounting's `>=` flipped in #1486 |
+| `warranty.events.v1` | pos-warranty `WarrantyClaim` `@Version`, flushed and force-incremented on otherwise-clean mutations | Yes | Yes — pos-accounting's `>=` flipped in #1486 |
+| `workorder.events.v1` | `Instant.now(clock)` epoch millis; `Workorder` has no `@Version` | **No** | Scoped out — see below |
+| `customer.events.v1` | `Instant.now(clock)` epoch millis; party entities carry no optimistic-lock version | **No** | Scoped out — see below |
+| `location.events.v1` | `Instant.now(clock)` epoch millis — `Location` *has* an unused `@Version` the publisher ignores | **No** | Scoped out — see below |
+
+**Scoped out, and why:** the `>=` guards consuming `workorder.events.v1`,
+`customer.events.v1`, and `location.events.v1` (pos-order's workorder/customer/location
+listeners, pos-accounting's customer listener) keep their skip-on-equal behavior for now.
+Those publishers still stamp wall-clock millis, so their versions can tie or even invert
+across instances; a `>=` guard at least fails closed on a tie, and none of those topics has a
+regenerate-from-current-state replay whose repairs the guard could be blocking (their
+`OutboxReplayServiceImpl` re-sends existing outbox rows under the original `eventId`, which
+consumers drop by idempotency regardless of any version guard). Adopting the rule on such a
+topic means fixing its publisher first — the `@Version`-flush pattern above; for
+`location.events.v1` that is one line, since the column already exists — and only then moving
+its consumers to `ReplicaVersionGuard`. Doing it in the other order reintroduces the
+same-millisecond race #1486 closed.
 
 ---
 

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -7,9 +7,10 @@ This document covers the architectural patterns, Docker configuration, service c
 1. [Port Strategy](#port-strategy)
 2. [Docker Configuration](#docker-configuration)
 3. [Inter-Service Communication](#inter-service-communication)
-4. [Observability](#observability)
-5. [Correlation ID Implementation](#correlation-id-implementation)
-6. [PostgreSQL Setup](#postgresql-setup)
+4. [Event Replication: `aggregateVersion` Semantics](#event-replication-aggregateversion-semantics)
+5. [Observability](#observability)
+6. [Correlation ID Implementation](#correlation-id-implementation)
+7. [PostgreSQL Setup](#postgresql-setup)
 
 ---
 
@@ -240,6 +241,65 @@ public class LoadBalancedClientConfig {
 | pos-workorder | `workorder` | `/workorder/**` |
 | pos-security-service | `security-service` | `/security-service/**` |
 | pos-shop-manager | `shop-manager` | `/shop-manager/**` |
+
+---
+
+## Event Replication: `aggregateVersion` Semantics
+
+Replica-maintaining consumers guard against out-of-order delivery by comparing the envelope's
+`aggregateVersion` with the version their replica row already holds. #1486 found the six
+`catalog.events.v1` consumers split between `>` and `>=` guards, and the epoch-millis version
+convention able to tie inside one millisecond — a combination that made replays silently
+repair some replicas and no-op on others. This section states the one rule; the split must
+not come back.
+
+### The rule
+
+**An equal `aggregateVersion` applies. A consumer skips a fact only when the version it
+already holds is *strictly greater* than the incoming one.**
+
+The canonical implementation is `com.positivity.domainevents.ReplicaVersionGuard.isStale(held,
+incoming)` in `pos-domain-events`, whose unit test pins these semantics once for every
+consumer. Listeners must delegate to it rather than hand-rolling the comparison — the `>` /
+`>=` split is exactly what hand-rolling produced. A replica row that does not exist holds
+nothing to protect; the fact lands.
+
+The rule covers both cases an equal version can arise:
+
+- **Live traffic**: publishers must emit *strictly advancing* versions (see below), so an
+  equal version means the fact describes state the consumer already holds — applying it is an
+  idempotent no-op, never a regression.
+- **Replay**: a replayed fact deliberately carries the *same* version as the state it
+  describes (that is what makes it indistinguishable from the live fact). Applying on equal
+  is what lets `POST /v1/products/facts/replay` (#1309) and
+  `POST /v1/catalog-items/services/facts/replay` (#1306) repair a replica whose rows are
+  wrong or missing even though it holds the right version number. A `>=` guard turns that
+  replay into a `200` that repairs nothing — the operational trap #1486 closed.
+
+### The publisher contract
+
+The rule above is only safe because publishers guarantee the version *strictly advances* on
+every committed mutation of an aggregate. Wall-clock timestamps do not satisfy this: two
+mutations in one millisecond tie, and a tie plus "equal applies" lets an older snapshot
+overwrite a newer one when outbox rows drain out of order.
+
+pos-catalog (the `catalog.events.v1` owner) satisfies the contract with a JPA optimistic-lock
+`@Version` column on `ProductEntity`, `ServiceEntity`, and `SupplierArticleCodeEntity`
+(#1486). Migration `V15` seeds the column from each row's legacy `updatedAt` epoch millis, so
+the published sequence continues monotonically from the versions consumers already hold — no
+consumer-side migration was needed. Delete tombstones publish `version + 1`, deterministically
+past every fact the aggregate ever emitted.
+
+### Other domains' topics
+
+Consumers of topics whose publishers still derive `aggregateVersion` from wall-clock
+timestamps keep their current guards for now: flipping a `>=` guard to `>` without a
+strictly-advancing publisher would reintroduce the same-millisecond race on that topic, and
+none of those topics has a replay endpoint whose repairs a `>=` guard could be blocking.
+Adopting the rule on such a topic means fixing its publisher first (the `@Version` pattern
+above), then moving its consumers to `ReplicaVersionGuard` — in that order.
+
+<!-- SURVEY_TABLE -->
 
 ---
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InvoiceEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InvoiceEventsListener.java
@@ -6,6 +6,7 @@ import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
 import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.invoice.InvoiceUpdatedV1;
 import com.positivity.domainevents.invoice.TaxBreakdownLine;
 import io.micrometer.core.instrument.Counter;
@@ -32,8 +33,15 @@ import tools.jackson.databind.ObjectMapper;
  * #842).
  *
  * <p>Same contract as {@link CustomerEventsListener}: idempotent via {@code processed_events} in
- * the upsert transaction, stale envelopes (aggregateVersion at or below the replica's) skipped,
+ * the upsert transaction, stale envelopes (aggregateVersion strictly below the replica's) skipped,
  * transient DB errors rethrown for container retry/DLQ, malformed payloads logged and skipped.
+ *
+ * <p>The stale guard is {@link ReplicaVersionGuard} (#1486): pos-invoice's {@code
+ * InvoiceEventPublisher} flushes the invoice's JPA {@code @Version} before emit, so the version
+ * strictly advances — an equal version applies rather than skips: it is an idempotent no-op for
+ * live traffic, and it is what would let a regenerate-from-state replay (the catalog/vehicle
+ * {@code facts/replay} pattern, should pos-invoice grow one) repair a replica that holds the
+ * version number but wrong or missing rows.
  */
 @Slf4j
 @Component
@@ -125,7 +133,10 @@ public class InvoiceEventsListener {
         // Versions are strictly increasing per invoice (committed JPA @Version, flushed before
         // emit), so version 0 (the create) participates in the comparison too — a late or
         // replayed version-0 event must never overwrite a newer replica row (PR #850 review).
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — equal
+        // means identical content, and replay resends the held version deliberately to repair
+        // wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug(
                     "Skipping stale invoice event invoiceId={} eventVersion={} replicaVersion={}",
                     invoiceId,

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/WarrantyEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/WarrantyEventsListener.java
@@ -4,6 +4,7 @@ import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.entity.WarrantyReimbursementExpectation;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.accounting.internal.repository.WarrantyReimbursementExpectationRepository;
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.warranty.WarrantyReimbursementResolvedV1;
 import com.positivity.domainevents.warranty.WarrantyReimbursementSubmittedV1;
 import io.micrometer.core.instrument.Counter;
@@ -27,11 +28,18 @@ import tools.jackson.databind.ObjectMapper;
  * expected-credit records (issue #927).
  *
  * <p>Same contract as {@link InvoiceEventsListener}: idempotent via {@code processed_events} in
- * the upsert transaction, stale envelopes (aggregateVersion at or below the row's) skipped,
+ * the upsert transaction, stale envelopes (aggregateVersion strictly below the row's) skipped,
  * transient DB errors rethrown for container retry/DLQ, malformed payloads logged and skipped.
  * The topic also carries claim-lifecycle facts ({@code warranty.claim.settled},
  * {@code warranty.claim.snapshot}, part-return facts) this module ignores — their eventIds are
  * still recorded so redelivery stays cheap.
+ *
+ * <p>The stale guard is {@link ReplicaVersionGuard} (#1486): pos-warranty's
+ * {@code ReimbursementServiceImpl} flushes — and even force-increments — the claim's JPA
+ * {@code @Version} to stay strictly monotonic, so an equal version applies rather than skips: it
+ * is an idempotent no-op for live traffic, and it is what would let a regenerate-from-state replay
+ * (the catalog/vehicle {@code facts/replay} pattern, should pos-warranty grow one) repair a row
+ * that holds the version number but wrong or missing data.
  */
 @Slf4j
 @Component
@@ -182,9 +190,11 @@ public class WarrantyEventsListener {
     }
 
     private boolean isStale(WarrantyReimbursementExpectation existing, long aggregateVersion, String reimbursementId) {
-        // Claim aggregate versions are strictly increasing per emitted fact, so an equal or lower
-        // version is a replay and must never overwrite a newer row (mirrors InvoiceEventsListener).
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Claim aggregate versions are strictly increasing per emitted fact (mirrors
+        // InvoiceEventsListener). Strictly-newer-only skip: equal versions APPLY (#1486,
+        // ReplicaVersionGuard) — equal means identical content, and replay resends the held
+        // version deliberately to repair wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug(
                     "Skipping stale warranty reimbursement event reimbursementId={} eventVersion={} rowVersion={}",
                     reimbursementId,

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InvoiceEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InvoiceEventsListenerTest.java
@@ -186,7 +186,7 @@ class InvoiceEventsListenerTest {
     }
 
     @Test
-    @DisplayName("Skips stale events whose aggregateVersion is at or below the replica's")
+    @DisplayName("Skips stale events whose aggregateVersion is strictly below the replica's")
     void skipsStaleVersions() {
         when(processedEvents.existsById("e-old")).thenReturn(false);
         when(replica.findById(INVOICE_ID))
@@ -203,6 +203,31 @@ class InvoiceEventsListenerTest {
         verify(replica, never()).save(any());
         // Still recorded as processed so redelivery does not reprocess it.
         verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Applies an event with an equal version stamp (#1486, ReplicaVersionGuard)")
+    void appliesEqualVersion() {
+        // Load-bearing: aggregateVersion strictly advances (committed JPA @Version, flushed before
+        // emit), so an equal version means identical content, and POST .../facts/replay
+        // deliberately resends a fact at the held version to repair a replica with wrong or
+        // missing rows. Skipping on equal (the old `>=` guard) silently turned replay into a no-op
+        // (#1486).
+        when(processedEvents.existsById("e-eq")).thenReturn(false);
+        when(replica.findById(INVOICE_ID))
+                .thenReturn(Optional.of(ExtInvoice.builder()
+                        .invoiceId(INVOICE_ID)
+                        .workorderId(WORKORDER_ID)
+                        .status("POSTED")
+                        .aggregateVersion(9L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+
+        listener.onInvoiceEvent(event("e-eq", 9));
+
+        ArgumentCaptor<ExtInvoice> saved = ArgumentCaptor.forClass(ExtInvoice.class);
+        verify(replica).save(saved.capture());
+        assertThat(saved.getValue().getAggregateVersion()).isEqualTo(9L);
     }
 
     @Test

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/WarrantyEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/WarrantyEventsListenerTest.java
@@ -172,7 +172,7 @@ class WarrantyEventsListenerTest {
     }
 
     @Test
-    @DisplayName("Skips stale events whose aggregateVersion is at or below the row's")
+    @DisplayName("Skips stale events whose aggregateVersion is strictly below the row's")
     void skipsStaleVersions() {
         when(processedEvents.existsById("e-old")).thenReturn(false);
         when(expectations.findById(REIMBURSEMENT_ID)).thenReturn(Optional.of(expectedRow(9)));
@@ -182,6 +182,25 @@ class WarrantyEventsListenerTest {
         verify(expectations, never()).save(any());
         // Still recorded as processed so redelivery does not reprocess it.
         verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Applies an event with an equal version stamp (#1486, ReplicaVersionGuard)")
+    void appliesEqualVersion() {
+        // Load-bearing: pos-warranty flushes — and even force-increments — the claim's JPA
+        // @Version to stay strictly monotonic, so an equal version means identical content, and
+        // POST .../facts/replay deliberately resends a fact at the held version to repair a row
+        // with wrong or missing data. Skipping on equal (the old `>=` guard) silently turned
+        // replay into a no-op (#1486).
+        when(processedEvents.existsById("e-eq")).thenReturn(false);
+        when(expectations.findById(REIMBURSEMENT_ID)).thenReturn(Optional.of(expectedRow(9)));
+
+        listener.onWarrantyEvent(resolved("e-eq", 9, "APPROVED"));
+
+        ArgumentCaptor<WarrantyReimbursementExpectation> saved =
+                ArgumentCaptor.forClass(WarrantyReimbursementExpectation.class);
+        verify(expectations).save(saved.capture());
+        assertThat(saved.getValue().getAggregateVersion()).isEqualTo(9L);
     }
 
     @Test

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
@@ -130,7 +130,8 @@ public class CatalogFactPublisher {
         publishProduct(writer, product, false, product.getVersion() + 1);
     }
 
-    private void publishProduct(OutboxEventWriter writer, ProductEntity product, boolean active, long aggregateVersion) {
+    private void publishProduct(
+            OutboxEventWriter writer, ProductEntity product, boolean active, long aggregateVersion) {
         Category category = product.getCategory();
         ProductTrackingLevel trackingLevel =
                 product.getTrackingLevel() == null ? ProductTrackingLevel.NONE : product.getTrackingLevel();
@@ -222,7 +223,11 @@ public class CatalogFactPublisher {
     }
 
     private void publishService(
-            OutboxEventWriter writer, ServiceEntity service, boolean active, @Nullable Instant updatedAt, long aggregateVersion) {
+            OutboxEventWriter writer,
+            ServiceEntity service,
+            boolean active,
+            @Nullable Instant updatedAt,
+            long aggregateVersion) {
         CatalogServiceUpdatedV1 payload = new CatalogServiceUpdatedV1(
                 service.getId(),
                 service.getName(),

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
@@ -14,6 +14,7 @@ import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.catalog.CatalogServiceUpdatedV1;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.domainevents.catalog.SupplierArticleCodeUpdatedV1;
+import jakarta.persistence.EntityManager;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -39,10 +40,17 @@ import org.springframework.stereotype.Component;
  * the payload is always assembled here from entity state, any replay/re-emit path that goes
  * through {@link #publishProductUpdated(ProductEntity)} automatically includes the full contract.
  *
- * <p>pos-catalog's {@code ProductEntity} has no JPA {@code @Version}; the envelope's
- * {@code aggregateVersion} carries {@code updatedAt} as epoch millis (monotonic per product), which
- * consumers use as the stale-event guard. Callers mutating only attribute tables (product_uom,
- * substitution_group_member) must bump the product's {@code updatedAt} before publishing.
+ * <p>The three fact-carrying entities ({@code ProductEntity}, {@code ServiceEntity},
+ * {@code SupplierArticleCodeEntity}) each carry a JPA {@code @Version}, and the envelope's
+ * {@code aggregateVersion} is that counter (#1486): it strictly increments on every committed
+ * mutation, so — unlike the retired {@code updatedAt}-epoch-millis convention — it can never tie
+ * when two mutations land in the same millisecond. Migration V15 seeded it from the legacy
+ * epoch-millis values, so the published sequence continues monotonically from what consumers
+ * already hold. An update publisher flushes the pending mutation before reading the version, so
+ * the increment Hibernate is about to apply is already reflected in the emitted fact. Callers
+ * mutating only attribute tables (product_uom, substitution_group_member) must still dirty the
+ * product row (bumping {@code updatedAt} does this) before publishing, so the flush here has an
+ * actual increment to pick up.
  */
 @Slf4j
 @Component
@@ -52,16 +60,19 @@ public class CatalogFactPublisher {
     private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
     private final ProductUomRepository productUomRepository;
     private final SubstitutionGroupMemberRepository substitutionGroupMemberRepository;
+    private final EntityManager entityManager;
 
     public CatalogFactPublisher(
             Clock clock,
             ObjectProvider<OutboxEventWriter> outboxEventWriter,
             ProductUomRepository productUomRepository,
-            SubstitutionGroupMemberRepository substitutionGroupMemberRepository) {
+            SubstitutionGroupMemberRepository substitutionGroupMemberRepository,
+            EntityManager entityManager) {
         this.clock = clock;
         this.outboxEventWriter = outboxEventWriter;
         this.productUomRepository = productUomRepository;
         this.substitutionGroupMemberRepository = substitutionGroupMemberRepository;
+        this.entityManager = entityManager;
     }
 
     /**
@@ -77,10 +88,21 @@ public class CatalogFactPublisher {
         return outboxEventWriter.getIfAvailable() != null;
     }
 
+    /**
+     * Emits {@code catalog.product.updated} after a product is created or updated.
+     *
+     * <p>Flushed before reading {@code aggregateVersion}: the mutation that triggered this call is
+     * still pending in the persistence context, and flushing here forces Hibernate to apply the
+     * {@code @Version} increment (and stamp {@code updatedAt}) so the envelope carries the version
+     * the row is about to commit as, not the one it held before this write (#1486).
+     */
     public void publishProductUpdated(@NonNull ProductEntity product) {
-        long aggregateVersion =
-                product.getUpdatedAt() == null ? 0L : product.getUpdatedAt().toEpochMilli();
-        publishProduct(product, product.getStatus() == ProductStatus.ACTIVE, aggregateVersion);
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        entityManager.flush();
+        publishProduct(writer, product, product.getStatus() == ProductStatus.ACTIVE, product.getVersion());
     }
 
     /**
@@ -96,21 +118,19 @@ public class CatalogFactPublisher {
      * product's UoM and substitution-group rows, which the delete takes with it. Same transaction
      * either way, so the fact and the deletion still commit together.
      *
-     * <p>Versioned like the service tombstone — the delete time, floored to one millisecond past
-     * the last update, so a product created and deleted inside one millisecond cannot emit a
-     * tombstone that consumers' stale guard reads as no newer than the upsert it supersedes.
+     * <p>Versioned deterministically as {@code version + 1} (#1486) — one past every fact this
+     * aggregate has ever published, without needing a clock comparison: the delete never persists a
+     * new row, so there is no flush to pick a fresh {@code @Version} up from.
      */
     public void publishProductRemoved(@NonNull ProductEntity product) {
-        long lastKnown =
-                product.getUpdatedAt() == null ? 0L : product.getUpdatedAt().toEpochMilli();
-        publishProduct(product, false, Math.max(clock.millis(), lastKnown + 1));
-    }
-
-    private void publishProduct(ProductEntity product, boolean active, long aggregateVersion) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
+        publishProduct(writer, product, false, product.getVersion() + 1);
+    }
+
+    private void publishProduct(OutboxEventWriter writer, ProductEntity product, boolean active, long aggregateVersion) {
         Category category = product.getCategory();
         ProductTrackingLevel trackingLevel =
                 product.getTrackingLevel() == null ? ProductTrackingLevel.NONE : product.getTrackingLevel();
@@ -166,15 +186,17 @@ public class CatalogFactPublisher {
      * — the form a campaign's {@code catalogFocusRef} most often takes — to be resolvable without
      * a synchronous read across the catalog domain wall (ADR-0044 R1).
      *
-     * <p>Called after the entity is saved, so auditing has stamped {@code updatedAt} and the
-     * envelope's {@code aggregateVersion} can carry it as epoch millis — the same monotonic
-     * stale-event guard {@link #publishProductUpdated} uses, for the same reason: there is no JPA
-     * {@code @Version} on catalog entities.
+     * <p>Flushed before reading {@code aggregateVersion}, the same way {@link #publishProductUpdated}
+     * is: the {@code @Version} increment and the {@code updatedAt} stamp are both pending until then,
+     * and the envelope must carry the version the row is about to commit as (#1486).
      */
     public void publishServiceUpdated(@NonNull ServiceEntity service) {
-        long aggregateVersion =
-                service.getUpdatedAt() == null ? 0L : service.getUpdatedAt().toEpochMilli();
-        publishService(service, true, service.getUpdatedAt(), aggregateVersion);
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        entityManager.flush();
+        publishService(writer, service, true, service.getUpdatedAt(), service.getVersion());
     }
 
     /**
@@ -186,23 +208,21 @@ public class CatalogFactPublisher {
      * replica answer "that service was removed" rather than either resolving it or forgetting it
      * ever existed.
      *
-     * <p>The row is gone, so there is no fresh {@code updatedAt} to version the fact with. The
-     * delete time is used instead, floored to one millisecond past the last update: a service
-     * created and deleted inside the same millisecond would otherwise emit a tombstone that
-     * consumers' strictly-below stale guard reads as no newer than the upsert it must supersede.
+     * <p>The row is gone, so there is no fresh state to flush. Versioned deterministically as
+     * {@code version + 1} (#1486) — one past every fact this aggregate has ever published, which is
+     * why a service created and deleted inside the same millisecond still gets a tombstone that
+     * outranks the upsert it supersedes.
      */
     public void publishServiceRemoved(@NonNull ServiceEntity service) {
-        long lastKnown =
-                service.getUpdatedAt() == null ? 0L : service.getUpdatedAt().toEpochMilli();
-        publishService(service, false, null, Math.max(clock.millis(), lastKnown + 1));
-    }
-
-    private void publishService(
-            ServiceEntity service, boolean active, @Nullable Instant updatedAt, long aggregateVersion) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
+        publishService(writer, service, false, null, service.getVersion() + 1);
+    }
+
+    private void publishService(
+            OutboxEventWriter writer, ServiceEntity service, boolean active, @Nullable Instant updatedAt, long aggregateVersion) {
         CatalogServiceUpdatedV1 payload = new CatalogServiceUpdatedV1(
                 service.getId(),
                 service.getName(),
@@ -231,9 +251,10 @@ public class CatalogFactPublisher {
 
     /**
      * Emits {@code catalog.supplier-article-code.updated} for one vendor+product pair (CAP-320
-     * #1347). Called after {@code entry} is persisted, so {@code updatedAt} is already stamped by
-     * auditing and can carry the same monotonic epoch-millis version scheme as
-     * {@link #publishProductUpdated}.
+     * #1347). Flushed before reading {@code aggregateVersion}, the same way
+     * {@link #publishProductUpdated} is: {@code entry}'s pending {@code @Version} increment is
+     * applied by the flush, so the envelope carries the version the row is about to commit as
+     * (#1486).
      *
      * <p>The envelope's {@code aggregateId} is {@code entry.getId()}, not the product id: the same
      * product legitimately has a row per vendor, and using the product id would let two vendors'
@@ -247,8 +268,8 @@ public class CatalogFactPublisher {
         if (writer == null) {
             return;
         }
-        long aggregateVersion =
-                entry.getUpdatedAt() == null ? 0L : entry.getUpdatedAt().toEpochMilli();
+        entityManager.flush();
+        long aggregateVersion = entry.getVersion();
         SupplierArticleCodeUpdatedV1 payload = new SupplierArticleCodeUpdatedV1(
                 entry.getVendorProfileId(),
                 entry.getSupplierRef(),

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
@@ -204,4 +204,16 @@ public class ProductEntity implements CatalogItem {
     @LastModifiedDate
     @Schema(description = "Timestamp when product was last updated")
     private Instant updatedAt;
+
+    /**
+     * The fact-envelope aggregate version (#1486). JPA optimistic-lock counter that strictly
+     * increments on every committed mutation, so it can never tie the way the legacy
+     * {@code updatedAt}-epoch-millis convention could when two mutations landed in the same
+     * millisecond. Seeded from those legacy values by migration V15 so the published sequence
+     * never regresses for consumers already holding a replica.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    @Schema(description = "Fact-envelope aggregate version; strictly increments per committed mutation (#1486)")
+    private long version;
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ServiceEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ServiceEntity.java
@@ -32,6 +32,17 @@ public class ServiceEntity implements CatalogItem {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
+    /**
+     * The fact-envelope aggregate version (#1486). JPA optimistic-lock counter that strictly
+     * increments on every committed mutation, so it can never tie the way the legacy
+     * {@code updatedAt}-epoch-millis convention could when two mutations landed in the same
+     * millisecond. Seeded from those legacy values by migration V15 so the published sequence
+     * never regresses for consumers already holding a replica.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+
     @Override
     public String getLongDescription() {
         return this.longDescription;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SupplierArticleCodeEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SupplierArticleCodeEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -77,4 +78,15 @@ public class SupplierArticleCodeEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
+
+    /**
+     * The fact-envelope aggregate version (#1486). JPA optimistic-lock counter that strictly
+     * increments on every committed mutation, so it can never tie the way the legacy
+     * {@code updatedAt}-epoch-millis convention could when two mutations landed in the same
+     * millisecond. Seeded from those legacy values by migration V15 so the published sequence
+     * never regresses for consumers already holding a replica.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
@@ -150,18 +150,13 @@ public class CatalogServiceImpl implements CatalogService {
         return switch (normalizeType(type)) {
             case PRODUCT ->
                 productRepository.findById(catalogId).map(existing -> {
-                    ProductEntity updated = toProductEntity(request);
-                    updated.setId(catalogId);
-                    return toCatalogItemResponse(PRODUCT, productRepository.save(updated));
+                    copyOntoProductEntity(request, existing);
+                    return toCatalogItemResponse(PRODUCT, productRepository.save(existing));
                 });
             case SERVICE ->
                 serviceRepository.findById(catalogId).map(existing -> {
-                    ServiceEntity updated = toServiceEntity(request);
-                    updated.setId(catalogId);
-                    // The request carries no createdAt, and merging a detached entity would blank
-                    // the in-memory value the published fact reads from.
-                    updated.setCreatedAt(existing.getCreatedAt());
-                    return toCatalogItemResponse(SERVICE, saveService(updated));
+                    copyOntoServiceEntity(request, existing);
+                    return toCatalogItemResponse(SERVICE, saveService(existing));
                 });
             case NONINVENTORY ->
                 nonInventoryProductRepository.findById(catalogId).map(existing -> {
@@ -217,6 +212,19 @@ public class CatalogServiceImpl implements CatalogService {
 
     private ProductEntity toProductEntity(CatalogItemRequestDto dto) {
         ProductEntity product = new ProductEntity();
+        copyOntoProductEntity(dto, product);
+        return product;
+    }
+
+    /**
+     * Copies the request's fields onto an already-loaded (managed or previously-loaded) entity
+     * rather than building a fresh detached one, so an update goes through Hibernate's ordinary
+     * dirty-checked save path instead of a merge. {@code ProductEntity} carries a JPA
+     * {@code @Version} (#1486): merging a detached instance whose {@code version} field defaults to
+     * 0 against a row the seeding migration gave a non-zero version throws an optimistic-lock
+     * failure on every update.
+     */
+    private void copyOntoProductEntity(CatalogItemRequestDto dto, ProductEntity product) {
         product.setName(dto.getName());
         product.setShortDescription(dto.getShortDescription());
         product.setLongDescription(dto.getLongDescription());
@@ -237,15 +245,24 @@ public class CatalogServiceImpl implements CatalogService {
         product.setSpecifications(dto.getSpecifications());
         product.setAttributes(dto.getSpecifications());
         product.setDescription(dto.getLongDescription());
-        return product;
     }
 
     private ServiceEntity toServiceEntity(CatalogItemRequestDto dto) {
         ServiceEntity service = new ServiceEntity();
+        copyOntoServiceEntity(dto, service);
+        return service;
+    }
+
+    /**
+     * Copies the request's fields onto an already-loaded entity, for the same reason
+     * {@link #copyOntoProductEntity} does: {@code ServiceEntity} also carries a {@code @Version}
+     * (#1486), and mutating the loaded row in place — rather than merging a detached replacement —
+     * is what keeps {@code createdAt} and the current {@code version} intact for free.
+     */
+    private void copyOntoServiceEntity(CatalogItemRequestDto dto, ServiceEntity service) {
         service.setName(dto.getName());
         service.setShortDescription(dto.getShortDescription());
         service.setLongDescription(dto.getLongDescription());
-        return service;
     }
 
     private NonInventoryProductEntity toNonInventoryEntity(CatalogItemRequestDto dto) {

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductFactReplayServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductFactReplayServiceImpl.java
@@ -31,11 +31,14 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * <h2>Ordering and the stale guard</h2>
  *
- * {@code aggregateVersion} stays the product's {@code updatedAt} epoch millis, so a replayed fact
- * carries the same version as the live fact for that state. Consumers skip strictly-lower versions,
- * which means a replay can never regress a replica that already holds something newer — the guard
- * they already have is the guard this relies on. New {@code eventId}s per re-emit are expected;
- * consumers dedupe on them for redelivery, not for replay.
+ * {@code aggregateVersion} is now the product's JPA {@code @Version} (#1486), not the retired
+ * {@code updatedAt} epoch-millis convention, but the property this relies on is unchanged: a
+ * replayed fact carries exactly the version the live row holds. Consumers apply on an equal
+ * version and skip only when the version they already hold is strictly greater, so a replay can
+ * never regress a replica that already holds something newer — and applying on equal is what makes
+ * replay-as-repair real: a replica that silently dropped a field can be made whole again without
+ * the replay looking like a no-op to the consumer's guard. New {@code eventId}s per re-emit are
+ * expected; consumers dedupe on them for redelivery, not for replay.
  *
  * <h2>Why paged rather than fire-and-forget</h2>
  *

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductUomServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductUomServiceImpl.java
@@ -103,9 +103,10 @@ public class ProductUomServiceImpl implements ProductUomService {
     }
 
     /**
-     * Bump the product row's {@code updatedAt} before re-emitting its fact: the envelope's
-     * {@code aggregateVersion} is {@code updatedAt} epoch millis, so attribute-only changes must
-     * advance it for consumers' stale-event guards.
+     * Bump the product row's {@code updatedAt} before re-emitting its fact: the mutation must dirty
+     * the row for the envelope's {@code aggregateVersion} — the product's JPA {@code @Version}
+     * (#1486) — to actually advance when {@link CatalogFactPublisher} flushes, so attribute-only
+     * changes still advance it for consumers' stale-event guards.
      */
     private void touchAndPublish(ProductEntity product) {
         product.setUpdatedAt(Instant.now(clock));

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ServiceFactReplayServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ServiceFactReplayServiceImpl.java
@@ -29,10 +29,13 @@ import org.springframework.transaction.annotation.Transactional;
  *       live one. A parallel replay-specific serializer would drift from the first the moment the
  *       payload gained a field.
  *   <li><b>The consumers' existing stale guard is the ordering guarantee.</b>
- *       {@code aggregateVersion} stays the service's {@code updatedAt} epoch millis, so a replayed
- *       fact carries the same version as the live fact for that state and cannot regress a replica
- *       holding something newer. New {@code eventId}s per re-emit are expected; consumers dedupe on
- *       them for redelivery, not for replay.
+ *       {@code aggregateVersion} is now the service's JPA {@code @Version} (#1486), not the retired
+ *       {@code updatedAt} epoch-millis convention, so a replayed fact carries exactly the version
+ *       the live row holds. Consumers apply on an equal version and skip only when they already
+ *       hold something strictly greater — which is what makes replay-as-repair real rather than a
+ *       silent no-op, and still cannot regress a replica holding something newer. New
+ *       {@code eventId}s per re-emit are expected; consumers dedupe on them for redelivery, not for
+ *       replay.
  *   <li><b>Paged rather than fire-and-forget,</b> so one call cannot bury live traffic behind a
  *       burst on the outbox and an operator can tell a slow replay from a stuck one. The cursor is
  *       the service id, not an offset, because offsets shift under concurrent writes.

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SubstitutionGroupServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SubstitutionGroupServiceImpl.java
@@ -110,9 +110,10 @@ public class SubstitutionGroupServiceImpl implements SubstitutionGroupService {
     }
 
     /**
-     * Bump the product row's {@code updatedAt} before re-emitting its fact: the envelope's
-     * {@code aggregateVersion} is {@code updatedAt} epoch millis, so membership-only changes must
-     * advance it for consumers' stale-event guards.
+     * Bump the product row's {@code updatedAt} before re-emitting its fact: the mutation must dirty
+     * the row for the envelope's {@code aggregateVersion} — the product's JPA {@code @Version}
+     * (#1486) — to actually advance when {@link CatalogFactPublisher} flushes, so membership-only
+     * changes still advance it for consumers' stale-event guards.
      */
     private void touchAndPublish(ProductEntity product) {
         product.setUpdatedAt(Instant.now(clock));

--- a/pos-catalog/src/main/resources/db/migration/V15__catalog_aggregate_version_columns.sql
+++ b/pos-catalog/src/main/resources/db/migration/V15__catalog_aggregate_version_columns.sql
@@ -1,0 +1,24 @@
+-- #1486: pos-catalog's fact envelope aggregateVersion was the row's updated_at as epoch millis,
+-- which can tie when two mutations land in the same millisecond. Replaced with a JPA optimistic-
+-- lock @Version counter on the three fact-carrying entities (product, service,
+-- supplier_article_code), so the published sequence strictly advances per committed mutation.
+--
+-- Seeded from the legacy epoch-millis values rather than starting at 0: consumers of
+-- catalog.events.v1 already hold replicas keyed on that convention, and a fresh 0 would look like
+-- a regression to their stale-event guard. Postgres-only syntax is fine here — tests run with
+-- Flyway disabled (ddl-auto: create-drop against H2), so this migration never runs against H2.
+
+ALTER TABLE product ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE product
+SET version = CAST(EXTRACT(EPOCH FROM updated_at) * 1000 AS BIGINT)
+WHERE updated_at IS NOT NULL;
+
+ALTER TABLE service ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE service
+SET version = CAST(EXTRACT(EPOCH FROM updated_at) * 1000 AS BIGINT)
+WHERE updated_at IS NOT NULL;
+
+ALTER TABLE supplier_article_code ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE supplier_article_code
+SET version = CAST(EXTRACT(EPOCH FROM updated_at) * 1000 AS BIGINT)
+WHERE updated_at IS NOT NULL;

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogFactPublisherTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogFactPublisherTest.java
@@ -20,6 +20,7 @@ import com.positivity.catalog.internal.repository.SubstitutionGroupMemberReposit
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.catalog.CatalogServiceUpdatedV1;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -69,6 +70,9 @@ class CatalogFactPublisherTest {
     @Mock
     private SubstitutionGroupMemberRepository substitutionGroupMemberRepository;
 
+    @Mock
+    private EntityManager entityManager;
+
     private CatalogFactPublisher publisher;
 
     private final ObjectMapper objectMapper = JsonMapper.builder().build();
@@ -80,7 +84,8 @@ class CatalogFactPublisherTest {
                 Clock.fixed(NOW, ZoneOffset.UTC),
                 outboxEventWriterProvider,
                 productUomRepository,
-                substitutionGroupMemberRepository);
+                substitutionGroupMemberRepository,
+                entityManager);
     }
 
     @Test
@@ -114,7 +119,10 @@ class CatalogFactPublisherTest {
         assertThat(envelope.eventType()).isEqualTo("catalog.product.updated");
         assertThat(envelope.schemaVersion()).isEqualTo(2);
         assertThat(envelope.aggregateId()).isEqualTo(product.getId());
-        assertThat(envelope.aggregateVersion()).isEqualTo(product.getUpdatedAt().toEpochMilli());
+        // Flushed before the version is read (#1486), so the fact carries the entity's current
+        // @Version rather than the retired updatedAt-epoch-millis value.
+        verify(entityManager).flush();
+        assertThat(envelope.aggregateVersion()).isEqualTo(product.getVersion());
 
         JsonNode payload =
                 objectMapper.readTree(objectMapper.writeValueAsString(envelope)).path("payload");
@@ -191,8 +199,10 @@ class CatalogFactPublisherTest {
             assertThat(envelope.eventType()).isEqualTo("catalog.service.updated");
             assertThat(envelope.schemaVersion()).isEqualTo(1);
             assertThat(envelope.aggregateId()).isEqualTo(entity.getId());
-            assertThat(envelope.aggregateVersion())
-                    .isEqualTo(entity.getUpdatedAt().toEpochMilli());
+            // Flushed before the version is read (#1486), so the fact carries the entity's current
+            // @Version rather than the retired updatedAt-epoch-millis value.
+            verify(entityManager).flush();
+            assertThat(envelope.aggregateVersion()).isEqualTo(entity.getVersion());
 
             JsonNode payload = objectMapper
                     .readTree(objectMapper.writeValueAsString(envelope))
@@ -276,6 +286,9 @@ class CatalogFactPublisherTest {
         product.setTrackingLevel(ProductTrackingLevel.LOT);
         product.setCreatedAt(NOW.minusSeconds(3600));
         product.setUpdatedAt(NOW);
+        // Deliberately distinct from updatedAt's epoch millis, so a test asserting on the retired
+        // convention would fail loudly rather than passing by coincidence.
+        product.setVersion(42L);
         Category category = new Category();
         product.setCategory(category);
         return product;

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogFactPublisherTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogFactPublisherTest.java
@@ -3,6 +3,7 @@ package com.positivity.catalog.internal.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,11 +16,13 @@ import com.positivity.catalog.internal.entity.ProductUomType;
 import com.positivity.catalog.internal.entity.ServiceEntity;
 import com.positivity.catalog.internal.entity.SubstitutionGroupEntity;
 import com.positivity.catalog.internal.entity.SubstitutionGroupMemberEntity;
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
 import com.positivity.catalog.internal.repository.ProductUomRepository;
 import com.positivity.catalog.internal.repository.SubstitutionGroupMemberRepository;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.catalog.CatalogServiceUpdatedV1;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import com.positivity.domainevents.catalog.SupplierArticleCodeUpdatedV1;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -236,13 +239,18 @@ class CatalogFactPublisherTest {
         @DisplayName("the tombstone outranks the upsert it supersedes, even within one millisecond")
         void tombstoneVersionOutranksTheLastUpdate() {
             ServiceEntity entity = serviceEntity();
-            // A service created and deleted inside the same millisecond as the fixed clock: the
-            // delete time alone would tie, and a consumer's stale guard would keep resolving it.
+            // A service created and deleted inside the same millisecond as the fixed clock used to
+            // make the retired updatedAt-floor scheme tie; version + 1 (#1486) is deterministic and
+            // does not depend on the clock at all.
             entity.setUpdatedAt(NOW);
+            entity.setVersion(7L);
 
             publisher.publishServiceRemoved(entity);
 
-            assertThat(capturedServiceEnvelope().aggregateVersion()).isEqualTo(NOW.toEpochMilli() + 1);
+            assertThat(capturedServiceEnvelope().aggregateVersion()).isEqualTo(8L);
+            // No flush for a tombstone: the row is about to be deleted, not re-saved, so there is
+            // no pending @Version increment to pick up.
+            verify(entityManager, never()).flush();
         }
 
         private DomainEventEnvelope<?> capturedServiceEnvelope() {
@@ -262,7 +270,46 @@ class CatalogFactPublisherTest {
             entity.setLongDescription("Four wheel alignment");
             entity.setCreatedAt(NOW.minusSeconds(7200));
             entity.setUpdatedAt(NOW.minusSeconds(60));
+            // Deliberately distinct from updatedAt's epoch millis, so a test asserting on the
+            // retired convention would fail loudly rather than passing by coincidence.
+            entity.setVersion(3L);
             return entity;
+        }
+    }
+
+    @Nested
+    @DisplayName("catalog.supplier-article-code.updated (CAP-320 #1347)")
+    class SupplierArticleCodeFact {
+
+        @Test
+        @DisplayName("flushes before reading the version, so the fact carries the current @Version (#1486)")
+        void publishesTheCurrentVersionAfterFlush() {
+            SupplierArticleCodeEntity entry = SupplierArticleCodeEntity.builder()
+                    .id(UUID.fromString("00000000-0000-0000-0000-0000000006a1"))
+                    .vendorProfileId(UUID.fromString("00000000-0000-0000-0000-0000000006b1"))
+                    .supplierRef("michelin-eu")
+                    .productId(UUID.fromString("00000000-0000-0000-0000-0000000006c1"))
+                    .supplierArticleCode("CODE-1")
+                    .updatedAt(NOW.minusSeconds(60))
+                    .version(9L)
+                    .build();
+
+            publisher.publishSupplierArticleCodeUpdated(entry);
+
+            verify(entityManager).flush();
+            DomainEventEnvelope<?> envelope = capturedSupplierArticleCodeEnvelope();
+            assertThat(envelope.eventType()).isEqualTo("catalog.supplier-article-code.updated");
+            assertThat(envelope.aggregateId()).isEqualTo(entry.getId());
+            assertThat(envelope.aggregateVersion()).isEqualTo(9L);
+        }
+
+        private DomainEventEnvelope<?> capturedSupplierArticleCodeEnvelope() {
+            @SuppressWarnings("rawtypes")
+            ArgumentCaptor<DomainEventEnvelope> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+            verify(outboxEventWriter).publish(eq("catalog.events.v1"), captor.capture());
+            DomainEventEnvelope<?> envelope = captor.getValue();
+            assertThat(envelope.payload()).isInstanceOf(SupplierArticleCodeUpdatedV1.class);
+            return envelope;
         }
     }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
@@ -11,6 +11,7 @@ import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepos
 import com.positivity.customer.internal.repository.ExtVehicleRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1;
 import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
 import io.micrometer.core.instrument.Counter;
@@ -47,6 +48,13 @@ import tools.jackson.databind.ObjectMapper;
  * (ADR-0012): the event's {@code accountId} is the owning party, so the VIN is added to that
  * party's set and removed from any other party still holding it (ownership transfer), and a
  * deactivation removes the VIN everywhere.
+ *
+ * <p>The {@code ext_vehicle} stale guard is {@link ReplicaVersionGuard} (#1486): the vehicle
+ * event's {@code aggregateVersion} strictly advances (committed JPA {@code @Version}, flushed
+ * before emit), so a held row is stale only when its version is strictly greater than the incoming
+ * fact's — an equal version applies, both as an idempotent no-op for live traffic and because
+ * {@code POST .../facts/replay} depends on it to repair a replica that holds the version number but
+ * wrong or missing rows.
  */
 @Slf4j
 @Component
@@ -150,8 +158,10 @@ public class VehicleEventsListener {
         ExtVehicle existing = extVehicleRepository.findById(vehicleId).orElse(null);
         // Versions are strictly increasing per vehicle (committed JPA @Version, flushed before
         // emit), so version 0 (the create) participates in the comparison too — a late or
-        // replayed version-0 event must never overwrite a newer replica row.
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // replayed version-0 event must never overwrite a newer replica row. Strictly-newer-only
+        // skip: equal versions APPLY (#1486, ReplicaVersionGuard) — equal means identical content,
+        // and replay resends the held version deliberately to repair wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug(
                     "Skipping stale vehicle event vehicleId={} eventVersion={} replicaVersion={}",
                     vehicleId,

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/VehicleEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/VehicleEventsListenerTest.java
@@ -182,7 +182,7 @@ class VehicleEventsListenerTest {
     }
 
     @Test
-    @DisplayName("Skips stale events whose aggregateVersion is at or below the replica's")
+    @DisplayName("Skips stale events whose aggregateVersion is strictly below the replica's")
     void skipsStaleVersions() {
         when(processedEvents.existsById("e-old")).thenReturn(false);
         when(replica.findById(VEHICLE_ID))
@@ -201,6 +201,37 @@ class VehicleEventsListenerTest {
         verify(replica, never()).save(any());
         // Still recorded as processed so redelivery does not reprocess it.
         verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Applies an event with an equal version stamp (#1486, ReplicaVersionGuard)")
+    void appliesEqualVehicleVersion() {
+        // Load-bearing: aggregateVersion strictly advances (committed JPA @Version, flushed before
+        // emit), so an equal version means identical content, and POST .../facts/replay
+        // deliberately resends a fact at the held version to repair a replica with wrong or
+        // missing rows. Skipping on equal (the old `>=` guard) silently turned replay into a no-op
+        // (#1486).
+        when(processedEvents.existsById("e-eq")).thenReturn(false);
+        when(replica.findById(VEHICLE_ID))
+                .thenReturn(Optional.of(ExtVehicle.builder()
+                        .vehicleId(VEHICLE_ID)
+                        .accountId(ACCOUNT_ID)
+                        .vin(VIN)
+                        .vinNormalized(VIN)
+                        .active(true)
+                        .aggregateVersion(9L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+        when(personParties.findByVehicleVin(VIN)).thenReturn(List.of());
+        when(commercialParties.findByVehicleVin(VIN)).thenReturn(List.of());
+        when(personParties.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+        when(commercialParties.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+
+        listener.onVehicleEvent(event("e-eq", 9, ACCOUNT_ID, true));
+
+        ArgumentCaptor<ExtVehicle> captor = ArgumentCaptor.forClass(ExtVehicle.class);
+        verify(replica).save(captor.capture());
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(9L);
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
@@ -3,7 +3,7 @@ package com.positivity.domainevents;
 /**
  * The platform's canonical staleness rule for a replica {@code aggregateVersion} guard (#1486).
  * It applies to every topic whose publisher guarantees a strictly-advancing version — as of
- * #1486 that is catalog, vehicle, invoice, and warranty facts; see "Event Replication:
+ * #1486 that is catalog, vehicle, invoice, warranty, and location facts; see "Event Replication:
  * aggregateVersion Semantics" in {@code docs/ARCHITECTURE_GUIDE.md} for the per-topic survey.
  *
  * <p>pos-catalog's {@code aggregateVersion}, for example, is a JPA {@code @Version}-backed
@@ -24,9 +24,9 @@ package com.positivity.domainevents;
  *
  * <p>Every consumer stale guard on a strictly-advancing topic must use this class rather than
  * re-deriving the comparison, so the rule stays in exactly one place. Consumers of topics whose
- * publishers still stamp wall-clock millis (workorder, customer, location facts) are explicitly
- * out of scope until those publishers adopt the {@code @Version}-flush pattern — see the
- * architecture guide section above.
+ * publishers still stamp wall-clock millis (workorder, customer facts) are explicitly out of
+ * scope until those publishers adopt the {@code @Version}-flush pattern — see the architecture
+ * guide section above.
  */
 public final class ReplicaVersionGuard {
 

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
@@ -1,0 +1,47 @@
+package com.positivity.domainevents;
+
+/**
+ * The platform's canonical staleness rule for a {@code catalog.events.v1} consumer's replica
+ * {@code aggregateVersion} guard (#1486).
+ *
+ * <p>pos-catalog's {@code aggregateVersion} is a JPA {@code @Version}-backed counter that
+ * strictly advances on every write to the aggregate; it was seeded from the legacy
+ * {@code updatedAt} epoch-millis values so magnitudes continue seamlessly across the migration.
+ * Because the publisher's contract is strictly-advancing, two facts for the same aggregate can
+ * carry the same version only when they describe the same content — an equal version is never
+ * evidence of a newer or older state, so a consumer that skips on it is discarding nothing.
+ *
+ * <p>That is also what makes {@code POST .../facts/replay} work as a repair tool: a replayed fact
+ * deliberately carries the same version as the state it describes, specifically so it can rewrite
+ * a replica row that already holds that version number but wrong or missing data. A consumer that
+ * skips on equal ({@code >=}) turns replay into a silent no-op — the replica keeps the version it
+ * already had and the bad row is never corrected. That silent no-op was #1486's operational trap:
+ * an operator would run replay, see it "succeed", and the replica would stay broken. Applying on
+ * equal costs nothing for live traffic (it is an idempotent overwrite with identical content) and
+ * is the only thing that makes replay-as-repair actually repair anything.
+ *
+ * <p>Every {@code catalog.events.v1} consumer's stale guard must use this class rather than
+ * re-deriving the comparison, so the rule stays in exactly one place.
+ */
+public final class ReplicaVersionGuard {
+
+    private ReplicaVersionGuard() {}
+
+    /**
+     * Whether a held replica version is stale relative to an incoming fact's version.
+     *
+     * <p>Returns {@code true} only when {@code heldVersion} is strictly greater than
+     * {@code incomingVersion} — the held row describes a state newer than the fact, so the fact
+     * must be discarded. An equal version is NOT stale: per the strictly-advancing publisher
+     * contract (see the class javadoc), equal means identical content, and applying is both a
+     * safe no-op for live traffic and required for {@code facts/replay} to repair a replica.
+     *
+     * @param heldVersion     {@code aggregateVersion} currently stored on the replica row, or the
+     *                        version implied by "no row held" per the caller's own convention
+     * @param incomingVersion {@code aggregateVersion} carried by the incoming fact
+     * @return {@code true} only if the held version is strictly newer than the incoming one
+     */
+    public static boolean isStale(long heldVersion, long incomingVersion) {
+        return heldVersion > incomingVersion;
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
@@ -1,15 +1,17 @@
 package com.positivity.domainevents;
 
 /**
- * The platform's canonical staleness rule for a {@code catalog.events.v1} consumer's replica
- * {@code aggregateVersion} guard (#1486).
+ * The platform's canonical staleness rule for a replica {@code aggregateVersion} guard (#1486).
+ * It applies to every topic whose publisher guarantees a strictly-advancing version — as of
+ * #1486 that is catalog, vehicle, invoice, and warranty facts; see "Event Replication:
+ * aggregateVersion Semantics" in {@code docs/ARCHITECTURE_GUIDE.md} for the per-topic survey.
  *
- * <p>pos-catalog's {@code aggregateVersion} is a JPA {@code @Version}-backed counter that
- * strictly advances on every write to the aggregate; it was seeded from the legacy
+ * <p>pos-catalog's {@code aggregateVersion}, for example, is a JPA {@code @Version}-backed
+ * counter that strictly advances on every write to the aggregate; it was seeded from the legacy
  * {@code updatedAt} epoch-millis values so magnitudes continue seamlessly across the migration.
  * Because the publisher's contract is strictly-advancing, two facts for the same aggregate can
  * carry the same version only when they describe the same content — an equal version is never
- * evidence of a newer or older state, so a consumer that skips on it is discarding nothing.
+ * evidence of an older state, so applying it can regress nothing.
  *
  * <p>That is also what makes {@code POST .../facts/replay} work as a repair tool: a replayed fact
  * deliberately carries the same version as the state it describes, specifically so it can rewrite
@@ -20,8 +22,11 @@ package com.positivity.domainevents;
  * equal costs nothing for live traffic (it is an idempotent overwrite with identical content) and
  * is the only thing that makes replay-as-repair actually repair anything.
  *
- * <p>Every {@code catalog.events.v1} consumer's stale guard must use this class rather than
- * re-deriving the comparison, so the rule stays in exactly one place.
+ * <p>Every consumer stale guard on a strictly-advancing topic must use this class rather than
+ * re-deriving the comparison, so the rule stays in exactly one place. Consumers of topics whose
+ * publishers still stamp wall-clock millis (workorder, customer, location facts) are explicitly
+ * out of scope until those publishers adopt the {@code @Version}-flush pattern — see the
+ * architecture guide section above.
  */
 public final class ReplicaVersionGuard {
 

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/ReplicaVersionGuardTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/ReplicaVersionGuardTest.java
@@ -38,7 +38,8 @@ class ReplicaVersionGuardTest {
 
     @Test
     void heldOneBelowLongMaxIsNotStaleAgainstLongMax() {
-        assertThat(ReplicaVersionGuard.isStale(Long.MAX_VALUE - 1, Long.MAX_VALUE)).isFalse();
+        assertThat(ReplicaVersionGuard.isStale(Long.MAX_VALUE - 1, Long.MAX_VALUE))
+                .isFalse();
     }
 
     @Test

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/ReplicaVersionGuardTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/ReplicaVersionGuardTest.java
@@ -1,0 +1,48 @@
+package com.positivity.domainevents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ReplicaVersionGuardTest {
+
+    @Test
+    void heldOlderThanIncomingIsNotStale() {
+        assertThat(ReplicaVersionGuard.isStale(1L, 2L)).isFalse();
+    }
+
+    @Test
+    void heldEqualToIncomingIsNotStale() {
+        // Load-bearing (#1486): the publisher contract strictly advances aggregateVersion, so an
+        // equal version means identical content, and POST .../facts/replay deliberately resends a
+        // fact at the version already held to repair a replica row that is wrong or missing.
+        // Treating equal as stale (the old `>=` skip) silently turns replay into a no-op — that was
+        // #1486's operational trap. Equal MUST apply, not skip.
+        assertThat(ReplicaVersionGuard.isStale(5L, 5L)).isFalse();
+    }
+
+    @Test
+    void heldNewerThanIncomingIsStale() {
+        assertThat(ReplicaVersionGuard.isStale(3L, 2L)).isTrue();
+    }
+
+    @Test
+    void boundaryValuesAtZeroAreNotStale() {
+        assertThat(ReplicaVersionGuard.isStale(0L, 0L)).isFalse();
+    }
+
+    @Test
+    void boundaryValuesAtLongMaxAreNotStale() {
+        assertThat(ReplicaVersionGuard.isStale(Long.MAX_VALUE, Long.MAX_VALUE)).isFalse();
+    }
+
+    @Test
+    void heldOneBelowLongMaxIsNotStaleAgainstLongMax() {
+        assertThat(ReplicaVersionGuard.isStale(Long.MAX_VALUE - 1, Long.MAX_VALUE)).isFalse();
+    }
+
+    @Test
+    void heldAtLongMaxIsStaleAgainstAnyLowerIncoming() {
+        assertThat(ReplicaVersionGuard.isStale(Long.MAX_VALUE, 0L)).isTrue();
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CatalogEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CatalogEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.inventory.internal.entity.ExtProductCodeReplica;
 import com.positivity.inventory.internal.entity.ExtProductReplica;
@@ -44,9 +45,12 @@ import tools.jackson.databind.ObjectMapper;
  * <p>Two catalog-specific contract points (X1 producer guidance):
  *
  * <ul>
- *   <li>{@code aggregateVersion} is the product's {@code updatedAt} epoch millis; the guard skips
- *       ONLY strictly-lower versions — equal versions apply, because group-membership changes fan
- *       out multiple facts with the same millisecond timestamp.
+ *   <li>{@code aggregateVersion} is pos-catalog's strictly-advancing {@code @Version} counter
+ *       (seeded from the legacy {@code updatedAt} epoch millis, so magnitudes continue seamlessly);
+ *       the guard is {@link ReplicaVersionGuard} (#1486) and skips ONLY strictly-lower versions —
+ *       equal versions apply, both because group-membership changes can fan out multiple facts at
+ *       the same version and because {@code POST .../facts/replay} depends on equal-applies to
+ *       repair a replica that holds the version number but wrong or missing rows.
  *   <li>Null tolerance for pre-v2 facts: {@code trackingLevel} null ⇒ {@code NONE};
  *       {@code uomConversions} / {@code substitutionProductIds} null ⇒ empty (children cleared —
  *       the fact carries the full sets, replace wholesale).
@@ -149,9 +153,10 @@ public class CatalogEventsListener {
         UUID productId = payload.productId();
         ExtProductReplica existing =
                 extProductReplicaRepository.findById(productId).orElse(null);
-        // Strictly-lower-only skip: equal versions APPLY. Catalog stamps updatedAt epoch millis
-        // as the version and fans out same-millisecond facts on group-membership changes.
-        if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
+        // Strictly-lower-only skip: equal versions APPLY (#1486, ReplicaVersionGuard). Catalog's
+        // aggregateVersion strictly advances; equal means identical content, and replay relies on
+        // equal-applies to repair a replica that holds the version number but wrong/missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
 

--- a/pos-location/src/main/java/com/positivity/location/internal/entity/StorageLocationEntity.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/entity/StorageLocationEntity.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -89,6 +90,18 @@ public class StorageLocationEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
+
+    /**
+     * JPA optimistic-lock counter, also published as the {@code location.storage-location.updated}
+     * envelope's {@code aggregateVersion} (#1486): it strictly increments on every committed
+     * mutation, replacing the retired {@code Instant.now(clock)}-stamped emission timestamp that
+     * could tie when two mutations landed in the same millisecond. Migration V6 seeded it from
+     * wall-clock millis at migration time, not {@code updated_at}, so the published sequence
+     * continues above every version consumers already hold.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
 
     @PrePersist
     void onCreate() {

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationFactPublisher.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationFactPublisher.java
@@ -8,8 +8,8 @@ import com.positivity.location.internal.config.OutboxEventWriter;
 import com.positivity.location.internal.entity.Location;
 import com.positivity.location.internal.entity.StorageLocationEntity;
 import com.positivity.location.internal.repository.LocationParentRepository;
+import jakarta.persistence.EntityManager;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -27,8 +27,18 @@ import org.springframework.stereotype.Component;
  * When Kafka publishing is disabled ({@code pos.location.kafka.enabled=false}) the outbox writer
  * bean is absent and every method is a no-op, so callers never need their own guard.
  *
- * <p>The envelope's {@code aggregateVersion} is the emission timestamp in epoch millis — the
- * platform-wide last-writer-wins hint consumers apply their strictly-below stale guard to.
+ * <p>{@code Location} and {@code StorageLocationEntity} each carry a JPA {@code @Version}, and the
+ * envelope's {@code aggregateVersion} is that counter (#1486): it strictly increments on every
+ * committed mutation, so — unlike the retired {@code Instant.now(clock)}-stamped emission
+ * timestamp — two mutations landing in the same millisecond can never tie. Migration V6 seeded
+ * both columns from wall-clock millis at migration time (not {@code updated_at} — see the
+ * migration header for why), so the published sequence continues above every version consumers
+ * already hold. An update publisher flushes the pending mutation before reading the version, so
+ * the increment Hibernate is about to apply is already reflected in the emitted fact. A consumer
+ * skips a fact only when the version it already holds is strictly greater than the incoming one —
+ * an equal version applies, both because it is an idempotent no-op for live traffic and because it
+ * is what would let a future regenerate-from-state replay repair a replica that holds the version
+ * number but wrong or missing data.
  */
 @Slf4j
 @Component
@@ -40,6 +50,7 @@ public class LocationFactPublisher {
     private final LocationParentRepository locationParentRepository;
     private final Clock clock;
     private final String eventsTopic;
+    private final EntityManager entityManager;
 
     public LocationFactPublisher(
             ObjectProvider<OutboxEventWriter> outboxEventWriter,
@@ -47,19 +58,31 @@ public class LocationFactPublisher {
             Clock clock,
             // Same property ManifestPublisher scans event_outbox by, so an override can never
             // desync the outbox rows from the manifest computation.
-            @Value("${pos.location.kafka.events-topic:location.events.v1}") String eventsTopic) {
+            @Value("${pos.location.kafka.events-topic:location.events.v1}") String eventsTopic,
+            EntityManager entityManager) {
         this.outboxEventWriter = outboxEventWriter;
         this.locationParentRepository = locationParentRepository;
         this.clock = clock;
         this.eventsTopic = eventsTopic;
+        this.entityManager = entityManager;
     }
 
-    /** Emit {@code location.location.updated} for a just-saved location. */
+    /**
+     * Emit {@code location.location.updated} for a just-saved location.
+     *
+     * <p>Flushed before reading {@code aggregateVersion}: the mutation that triggered this call is
+     * still pending in the persistence context, and flushing here forces Hibernate to apply the
+     * {@code @Version} increment so the envelope carries the version the row is about to commit as,
+     * not the one it held before this write (#1486). {@code version} is null-safe-read as 0 for the
+     * pre-persist in-memory edge only — a location that has actually gone through Hibernate always
+     * has a non-null version by the time this method's flush returns.
+     */
     public void locationChanged(@NonNull Location location) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
+        entityManager.flush();
         LocationUpdatedV1 payload = new LocationUpdatedV1(
                 location.getId(),
                 location.getName(),
@@ -84,32 +107,53 @@ public class LocationFactPublisher {
                 parentRefs(location.getId()),
                 location.getCreatedAt(),
                 location.getUpdatedAt());
-        publish(writer, LocationUpdatedV1.EVENT_TYPE, LocationUpdatedV1.SCHEMA_VERSION, location.getId(), payload);
+        publish(
+                writer,
+                LocationUpdatedV1.EVENT_TYPE,
+                LocationUpdatedV1.SCHEMA_VERSION,
+                location.getId(),
+                payload,
+                location.getVersion() == null ? 0L : location.getVersion());
     }
 
-    /** Emit {@code location.location.deleted} for a location removed in the current transaction. */
-    public void locationDeleted(@NonNull UUID locationId) {
+    /**
+     * Emit {@code location.location.deleted} for a location removed in the current transaction.
+     *
+     * <p>Takes the deleted {@code Location} entity, not just its id, so the fact can be versioned
+     * deterministically as {@code version + 1} (#1486) — one past every fact this aggregate has
+     * ever published — the same tombstone pattern pos-catalog uses. The caller must have loaded the
+     * entity before deleting it; a delete of an id nothing was found for has nothing to version and
+     * must not call this method at all (see {@code LocationServiceImpl.deleteLocation}).
+     */
+    public void locationDeleted(@NonNull Location location) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
+        long version = location.getVersion() == null ? 0L : location.getVersion();
         publish(
                 writer,
                 LocationDeletedV1.EVENT_TYPE,
                 LocationDeletedV1.SCHEMA_VERSION,
-                locationId,
-                new LocationDeletedV1(locationId));
+                location.getId(),
+                new LocationDeletedV1(location.getId()),
+                version + 1);
     }
 
     /**
      * Emit {@code location.storage-location.updated} for a just-saved storage location. Storage
      * locations are never hard-deleted — decommissioning is a status change on this same fact.
+     *
+     * <p>Flushed before reading {@code aggregateVersion}, the same way {@link #locationChanged} is:
+     * the pending {@code @Version} increment is applied by the flush, so the envelope carries the
+     * version the row is about to commit as (#1486).
      */
     public void storageLocationChanged(@NonNull StorageLocationEntity storageLocation) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
+        entityManager.flush();
         StorageLocationUpdatedV1 payload = new StorageLocationUpdatedV1(
                 storageLocation.getId(),
                 storageLocation.getSite() != null ? storageLocation.getSite().getId() : null,
@@ -132,7 +176,8 @@ public class LocationFactPublisher {
                 StorageLocationUpdatedV1.EVENT_TYPE,
                 StorageLocationUpdatedV1.SCHEMA_VERSION,
                 storageLocation.getId(),
-                payload);
+                payload,
+                storageLocation.getVersion());
     }
 
     private List<LocationUpdatedV1.ParentRef> parentRefs(@NonNull UUID locationId) {
@@ -147,17 +192,10 @@ public class LocationFactPublisher {
             @NonNull String eventType,
             int schemaVersion,
             @NonNull UUID aggregateId,
-            Object payload) {
+            Object payload,
+            long aggregateVersion) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
-                eventType,
-                schemaVersion,
-                aggregateId,
-                Instant.now(clock).toEpochMilli(),
-                SOURCE,
-                null,
-                null,
-                payload,
-                clock);
+                eventType, schemaVersion, aggregateId, aggregateVersion, SOURCE, null, null, payload, clock);
         writer.publish(eventsTopic, envelope);
         log.debug("Queued {} for aggregate {}", eventType, aggregateId);
     }

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
@@ -25,7 +25,9 @@ import com.positivity.location.internal.repository.LocationParentRepository;
 import com.positivity.location.internal.repository.LocationRepository;
 import com.positivity.location.internal.repository.LocationTypeRepository;
 import com.positivity.location.service.LocationService;
+import java.time.Clock;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -65,6 +67,7 @@ public class LocationServiceImpl implements LocationService {
 
     private static final ObjectMapper JSON_MAPPER = JsonMapper.builder().build();
 
+    private final Clock clock;
     private final LocationRepository locationRepository;
     private final LocationParentRepository locationParentRepository;
     private final LocationTypeRepository locationTypeRepository;
@@ -419,7 +422,13 @@ public class LocationServiceImpl implements LocationService {
             throw new IllegalStateException("Circular relationship detected after save");
         }
         // Parent edges travel on the child's location.location.updated fact (issue #892), so
-        // replica consumers see hierarchy changes without a dedicated edge event.
+        // replica consumers see hierarchy changes without a dedicated edge event. The edge write
+        // alone leaves the child row clean, and a clean row gives the publisher's flush no
+        // @Version increment to apply — the fact would carry changed parentRefs under an unchanged
+        // aggregateVersion, breaking the strictly-advancing contract (#1486). Dirty the child
+        // first, the same convention catalog's attribute-table mutations follow.
+        child.setUpdatedAt(Instant.now(clock));
+        locationRepository.saveAndFlush(child);
         locationFactPublisher.locationChanged(child);
         return saved;
     }

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
@@ -349,10 +349,24 @@ public class LocationServiceImpl implements LocationService {
         return all.toString();
     }
 
+    /**
+     * Deletes a location and emits the {@code location.location.deleted} tombstone.
+     *
+     * <p>Loads the row before deleting it so the fact can be versioned from its final
+     * {@code @Version} (#1486) — the tombstone publisher needs the entity, not just the id. An id
+     * that resolves to nothing has no state to version and no delete to announce, so this is now a
+     * silent no-op for a missing location; previously {@code deleteById} was itself a no-op on a
+     * missing row (Spring Data does not throw), but the fact was still published unconditionally,
+     * so a caller retrying a delete for an id that never existed produced a tombstone every time.
+     */
     @Transactional
     public void deleteLocation(UUID id) {
-        locationRepository.deleteById(id);
-        locationFactPublisher.locationDeleted(id);
+        Location location = locationRepository.findById(id).orElse(null);
+        if (location == null) {
+            return;
+        }
+        locationRepository.delete(location);
+        locationFactPublisher.locationDeleted(location);
     }
 
     @Transactional

--- a/pos-location/src/main/resources/db/migration/V6__location_aggregate_version_columns.sql
+++ b/pos-location/src/main/resources/db/migration/V6__location_aggregate_version_columns.sql
@@ -1,0 +1,30 @@
+-- #1486 follow-up: pos-location's location.events.v1 envelope stamped
+-- Instant.now(clock).toEpochMilli() as aggregateVersion on every emit -- an emission-time
+-- value, not the aggregate's own state version, so two mutations landing in the same
+-- millisecond tied. Replaced with JPA optimistic-lock @Version counters on Location and
+-- StorageLocationEntity, so the published sequence strictly advances per committed mutation
+-- and the platform's equal-applies consumer rule (ReplicaVersionGuard) is safe to adopt here.
+--
+-- location.version already existed as a column (an @Version the publisher never read), but its
+-- values are ordinary Hibernate optimistic-lock counters -- small integers counting each row's
+-- updates, nothing like the epoch-millis magnitudes consumers already hold. Left alone, the
+-- first fact emitted post-migration would report a version far BELOW what every replica
+-- already holds, and every consumer's stale guard would then discard it -- and everything
+-- after it -- as an out-of-order regression, forever. storage_location has no version column
+-- at all yet.
+--
+-- Both are therefore (re)seeded here, unconditionally, from wall-clock millis at MIGRATION
+-- time -- deliberately NOT from updated_at, unlike catalog's V15. The versions consumers
+-- currently hold are EMISSION-time clock millis, which can exceed a row's updated_at by a few
+-- milliseconds (the gap between the mutation commit and the publish call reading the clock);
+-- only migration-time now() upper-bounds every version ever emitted for these facts, so the
+-- first post-migration fact (seed+1 or greater, once flushed) can never regress a replica.
+-- Postgres-only syntax is fine here -- tests run with Flyway disabled (ddl-auto: create-drop
+-- against H2), so this migration never runs against H2.
+
+UPDATE location
+SET version = CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT);
+
+ALTER TABLE storage_location ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE storage_location
+SET version = CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT);

--- a/pos-location/src/test/java/com/positivity/location/internal/service/LocationFactPublisherTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/service/LocationFactPublisherTest.java
@@ -20,6 +20,7 @@ import com.positivity.location.internal.entity.StorageLocationEntity;
 import com.positivity.location.internal.enums.StorageLocationStatus;
 import com.positivity.location.internal.enums.StorageLocationType;
 import com.positivity.location.internal.repository.LocationParentRepository;
+import jakarta.persistence.EntityManager;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -43,6 +44,7 @@ class LocationFactPublisherTest {
 
     private final OutboxEventWriter writer = mock(OutboxEventWriter.class);
     private final LocationParentRepository locationParentRepository = mock(LocationParentRepository.class);
+    private final EntityManager entityManager = mock(EntityManager.class);
 
     private LocationFactPublisher publisher;
 
@@ -50,12 +52,12 @@ class LocationFactPublisherTest {
     void setUp() {
         when(writerProvider.getIfAvailable()).thenReturn(writer);
         when(locationParentRepository.findByChild_Id(any())).thenReturn(List.of());
-        publisher =
-                new LocationFactPublisher(writerProvider, locationParentRepository, TEST_CLOCK, "location.events.v1");
+        publisher = new LocationFactPublisher(
+                writerProvider, locationParentRepository, TEST_CLOCK, "location.events.v1", entityManager);
     }
 
     @Test
-    @DisplayName("Location fact carries the tax address and site defaults")
+    @DisplayName("Location fact carries the tax address and site defaults, versioned from the flushed @Version (#1486)")
     void locationFact() {
         Location location = new Location();
         location.setId(UUID.randomUUID());
@@ -69,6 +71,9 @@ class LocationFactPublisherTest {
         location.setState("VA");
         location.setPostalCode("22150");
         location.setCountry("US");
+        // Deliberately distinct from any clock-derived value, so a test asserting on the retired
+        // emission-timestamp convention would fail loudly rather than passing by coincidence.
+        location.setVersion(42L);
         StorageLocationEntity staging = StorageLocationEntity.builder()
                 .id(UUID.randomUUID())
                 .name("Staging")
@@ -85,9 +90,13 @@ class LocationFactPublisherTest {
 
         publisher.locationChanged(location);
 
+        // Flushed before the version is read (#1486), so the fact carries the entity's current
+        // @Version rather than the retired Instant.now(clock)-stamped emission timestamp.
+        verify(entityManager).flush();
         ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
         verify(writer).publish(eq("location.events.v1"), captor.capture());
         assertThat(captor.getValue().eventType()).isEqualTo(LocationUpdatedV1.EVENT_TYPE);
+        assertThat(captor.getValue().aggregateVersion()).isEqualTo(42L);
         LocationUpdatedV1 fact = (LocationUpdatedV1) captor.getValue().payload();
         assertThat(fact.locationId()).isEqualTo(location.getId());
         assertThat(fact.name()).isEqualTo("Main Shop");
@@ -102,21 +111,27 @@ class LocationFactPublisherTest {
     }
 
     @Test
-    @DisplayName("Location delete emits the deleted fact")
+    @DisplayName("Location delete emits the deleted fact versioned as version + 1 (#1486)")
     void locationDeleted() {
-        UUID id = UUID.randomUUID();
+        Location location = new Location();
+        location.setId(UUID.randomUUID());
+        location.setVersion(9L);
 
-        publisher.locationDeleted(id);
+        publisher.locationDeleted(location);
 
         ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
         verify(writer).publish(eq("location.events.v1"), captor.capture());
         assertThat(captor.getValue().eventType()).isEqualTo(LocationDeletedV1.EVENT_TYPE);
+        // Deterministic tombstone version (#1486) — one past every fact this aggregate has ever
+        // published, without needing a clock comparison or a flush (the row is being deleted, not
+        // re-saved, so there is no pending increment to pick up).
+        assertThat(captor.getValue().aggregateVersion()).isEqualTo(10L);
         assertThat(((LocationDeletedV1) captor.getValue().payload()).locationId())
-                .isEqualTo(id);
+                .isEqualTo(location.getId());
     }
 
     @Test
-    @DisplayName("Storage-location fact carries site + parent topology")
+    @DisplayName("Storage-location fact carries site + parent topology, versioned from the flushed @Version (#1486)")
     void storageLocationFact() {
         Location site = new Location();
         site.setId(UUID.randomUUID());
@@ -131,13 +146,18 @@ class LocationFactPublisherTest {
                 .site(site)
                 .parentStorageLocation(parent)
                 .capacity("{\"maxUnitCount\": 12}")
+                .version(7L)
                 .build();
 
         publisher.storageLocationChanged(storage);
 
+        // Flushed before the version is read (#1486), so the fact carries the entity's current
+        // @Version rather than the retired Instant.now(clock)-stamped emission timestamp.
+        verify(entityManager).flush();
         ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
         verify(writer).publish(eq("location.events.v1"), captor.capture());
         assertThat(captor.getValue().eventType()).isEqualTo(StorageLocationUpdatedV1.EVENT_TYPE);
+        assertThat(captor.getValue().aggregateVersion()).isEqualTo(7L);
         StorageLocationUpdatedV1 fact =
                 (StorageLocationUpdatedV1) captor.getValue().payload();
         assertThat(fact.storageLocationId()).isEqualTo(storage.getId());
@@ -152,12 +172,15 @@ class LocationFactPublisherTest {
     @DisplayName("All methods no-op when Kafka publishing is disabled")
     void noopWhenWriterAbsent() {
         when(writerProvider.getIfAvailable()).thenReturn(null);
+        Location location = new Location();
+        location.setId(UUID.randomUUID());
 
-        publisher.locationChanged(new Location());
-        publisher.locationDeleted(UUID.randomUUID());
+        publisher.locationChanged(location);
+        publisher.locationDeleted(location);
         publisher.storageLocationChanged(
                 StorageLocationEntity.builder().id(UUID.randomUUID()).build());
 
         verify(writer, never()).publish(any(), any());
+        verify(entityManager, never()).flush();
     }
 }

--- a/pos-location/src/test/java/com/positivity/location/service/LocationServiceTest.java
+++ b/pos-location/src/test/java/com/positivity/location/service/LocationServiceTest.java
@@ -3,6 +3,7 @@ package com.positivity.location.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -544,12 +545,28 @@ class LocationServiceTest {
     }
 
     @Test
-    void deleteLocation_existingId_delegatesToRepository() {
+    void deleteLocation_existingId_deletesAndPublishesTombstone() {
         UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Location location = Location.builder().id(id).build();
+        when(locationRepository.findById(id)).thenReturn(Optional.of(location));
 
         locationService.deleteLocation(id);
 
-        verify(locationRepository).deleteById(id);
+        verify(locationRepository).delete(location);
+        verify(locationFactPublisher).locationDeleted(location);
+    }
+
+    @Test
+    @DisplayName("a delete for an id nothing resolves to is a no-op — no delete, no fact (#1486)")
+    void deleteLocation_missingId_deletesNothingAndEmitsNoFact() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        when(locationRepository.findById(id)).thenReturn(Optional.empty());
+
+        locationService.deleteLocation(id);
+
+        verify(locationRepository, never()).delete(any());
+        verify(locationRepository, never()).deleteById(any());
+        verify(locationFactPublisher, never()).locationDeleted(any());
     }
 
     @Test

--- a/pos-location/src/test/java/com/positivity/location/service/LocationServiceTest.java
+++ b/pos-location/src/test/java/com/positivity/location/service/LocationServiceTest.java
@@ -3,6 +3,7 @@ package com.positivity.location.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -651,6 +652,13 @@ class LocationServiceTest {
         assertThat(result.getParentId()).isEqualTo(parentId);
         assertThat(result.getChildId()).isEqualTo(childId);
         assertThat(result.getParentType()).isEqualTo("HOME_OFFICE");
+        // The edge write alone leaves the child row clean, so the service must dirty it before
+        // publishing — otherwise the fact's parentRefs change under an unchanged aggregateVersion
+        // and the strictly-advancing publisher contract breaks (#1486).
+        assertThat(child.getUpdatedAt()).isEqualTo(TEST_CLOCK.instant());
+        var inOrder = inOrder(locationRepository, locationFactPublisher);
+        inOrder.verify(locationRepository).saveAndFlush(child);
+        inOrder.verify(locationFactPublisher).locationChanged(child);
     }
 
     @Test

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CatalogEventsListener.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CatalogEventsListener.java
@@ -159,7 +159,8 @@ public class CatalogEventsListener {
         // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — catalog's
         // aggregateVersion strictly advances, so equal means identical content, and replay resends
         // the held version deliberately to repair a replica with wrong or missing rows.
-        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), row.getAggregateVersion())) {
+        if (existing != null
+                && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), row.getAggregateVersion())) {
             log.debug(
                     "Ignoring stale catalog fact for {} (held {} > incoming {})",
                     row.getCatalogItemId(),

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CatalogEventsListener.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CatalogEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.marketing.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.CatalogServiceUpdatedV1;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.marketing.internal.entity.ExtCatalogReplica;
@@ -34,10 +35,14 @@ import tools.jackson.databind.ObjectMapper;
  *
  * <p>Consumer contract mirrors pos-warranty's listener on the same topic: {@code processed_events}
  * idempotency (owner {@code catalog}) written in the apply transaction, and a stale guard on the
- * fact's {@code aggregateVersion} so an out-of-order redelivery cannot undo a newer fact. Nothing
- * is swallowed — an unreadable envelope or a database failure reaches the container, which retries
- * and then dead-letters it, because a replica quietly missing an update is worse than a visible
- * poison message.
+ * fact's {@code aggregateVersion} so an out-of-order redelivery cannot undo a newer fact. The guard
+ * is {@link ReplicaVersionGuard} (#1486): pos-catalog's aggregateVersion strictly advances, so a
+ * held row is stale only when its version is strictly greater than the incoming fact's — an equal
+ * version applies, both as an idempotent no-op for live traffic and because
+ * {@code POST .../facts/replay} depends on it to repair a replica that holds the version number but
+ * wrong or missing rows. Nothing is swallowed — an unreadable envelope or a database failure
+ * reaches the container, which retries and then dead-letters it, because a replica quietly missing
+ * an update is worse than a visible poison message.
  */
 @Slf4j
 @Component
@@ -151,7 +156,10 @@ public class CatalogEventsListener {
     private void upsert(ExtCatalogReplica row) {
         ExtCatalogReplica existing =
                 catalogReplicaRepository.findById(row.getCatalogItemId()).orElse(null);
-        if (existing != null && existing.getAggregateVersion() > row.getAggregateVersion()) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — catalog's
+        // aggregateVersion strictly advances, so equal means identical content, and replay resends
+        // the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), row.getAggregateVersion())) {
             log.debug(
                     "Ignoring stale catalog fact for {} (held {} > incoming {})",
                     row.getCatalogItemId(),

--- a/pos-order/src/main/java/com/positivity/order/internal/service/LocationEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/LocationEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.location.LocationDeletedV1;
 import com.positivity.domainevents.location.LocationUpdatedV1;
 import com.positivity.order.internal.entity.ExtLocation;
@@ -24,6 +25,13 @@ import tools.jackson.databind.ObjectMapper;
  * Consumes {@code location.events.v1} into the {@code ext_location} replica (ADR-0044 §6, parity
  * story B3): shop address for tax jurisdiction resolution, mirroring pos-workorder's ext_location
  * pattern (#892).
+ *
+ * <p>The stale guard on the fact's {@code aggregateVersion} is {@link ReplicaVersionGuard}
+ * (#1486): pos-location's version strictly advances, so a held row is stale only when its version
+ * is strictly greater than the incoming fact's — an equal version applies, both because it is an
+ * idempotent no-op for live traffic and because it is what would let a future
+ * regenerate-from-state replay repair a replica that holds the version number but wrong or
+ * missing rows.
  */
 @Slf4j
 @Component
@@ -90,7 +98,10 @@ public class LocationEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtLocation existing = extLocationRepository.findById(locationId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — location's
+        // aggregateVersion strictly advances, so equal means identical content, and a future replay
+        // would resend the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
         ExtLocation replica = existing != null ? existing : new ExtLocation();

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ProductEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ProductEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.order.internal.entity.ExtProduct;
 import com.positivity.order.internal.entity.ExtProductCode;
@@ -27,6 +28,12 @@ import tools.jackson.databind.ObjectMapper;
  * Consumes {@code catalog.events.v1} into the {@code ext_product} replica (ADR-0044 §6, parity
  * story B1): SKU → productId/description/tracking-level resolution for pricing without synchronous
  * REST toward pos-catalog.
+ *
+ * <p>The stale guard on the fact's {@code aggregateVersion} is {@link ReplicaVersionGuard}
+ * (#1486): pos-catalog's version strictly advances, so a held row is stale only when its version
+ * is strictly greater than the incoming fact's — an equal version applies, both because it is an
+ * idempotent no-op for live traffic and because {@code POST .../facts/replay} depends on it to
+ * repair a replica that holds the version number but wrong or missing rows.
  */
 @Slf4j
 @Component
@@ -87,7 +94,10 @@ public class ProductEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtProduct existing = extProductRepository.findById(productId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — catalog's
+        // aggregateVersion strictly advances, so equal means identical content, and replay resends
+        // the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
         ExtProduct replica = existing != null ? existing : new ExtProduct();

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.SupplierArticleCodeUpdatedV1;
 import com.positivity.order.internal.entity.ExtSupplierArticleCode;
 import com.positivity.order.internal.entity.ProcessedEvent;
@@ -29,6 +30,12 @@ import tools.jackson.databind.ObjectMapper;
  * ({@code productId}), which is right for a fact that is one row per product. This fact is one row
  * per {@code (supplierRef, productId)} pair, so its existing-row lookup and its stale guard both
  * need the pair, not the id alone — a shape the other listener's contract does not fit.
+ *
+ * <p>The stale guard itself is {@link ReplicaVersionGuard} (#1486):
+ * pos-catalog's {@code aggregateVersion} strictly advances, so a held row is stale only when its
+ * version is strictly greater than the incoming fact's — an equal version applies, both because it
+ * is an idempotent no-op for live traffic and because {@code POST .../facts/replay} depends on it
+ * to repair a replica that holds the version number but wrong or missing rows.
  */
 @Slf4j
 @Component
@@ -106,7 +113,10 @@ public class SupplierArticleCodeEventsListener {
         ExtSupplierArticleCode existing = extSupplierArticleCodeRepository
                 .findBySupplierRefAndProductId(supplierRef, productId)
                 .orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — catalog's
+        // aggregateVersion strictly advances, so equal means identical content, and replay resends
+        // the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
         ExtSupplierArticleCode replica = existing != null ? existing : new ExtSupplierArticleCode();

--- a/pos-order/src/main/java/com/positivity/order/internal/service/VehicleEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/VehicleEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
 import com.positivity.order.internal.entity.ExtVehicle;
 import com.positivity.order.internal.entity.ProcessedEvent;
@@ -23,6 +24,13 @@ import tools.jackson.databind.ObjectMapper;
  * Consumes {@code vehicle.events.v1} into the {@code ext_vehicle} replica (ADR-0044 §6, parity
  * story I2 replica redesign). {@code accountId} is the owning customer party; the replica powers
  * vehicle existence + ownership validation in {@code ReplicaCustomerPortAdapter}.
+ *
+ * <p>The stale guard on the fact's {@code aggregateVersion} is {@link ReplicaVersionGuard}
+ * (#1486): pos-vehicle-inventory's {@code VehicleEventPublisher} flushes a JPA {@code @Version}
+ * before emit, so the version strictly advances — a held row is stale only when its version is
+ * strictly greater than the incoming fact's. An equal version applies, both as an idempotent no-op
+ * for live traffic and because {@code POST .../facts/replay} depends on it to repair a replica that
+ * holds the version number but wrong or missing rows.
  */
 @Slf4j
 @Component
@@ -81,7 +89,10 @@ public class VehicleEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtVehicle existing = extVehicleRepository.findById(vehicleId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — the
+        // publisher's aggregateVersion strictly advances, so equal means identical content, and
+        // replay resends the held version deliberately to repair wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
         ExtVehicle replica = existing != null ? existing : new ExtVehicle();

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
@@ -200,8 +200,26 @@ class ProductVehicleLocationReplicaTest {
         }
 
         @Test
-        @DisplayName("ignores a snapshot no newer than the replica it already holds")
+        @DisplayName("ignores a snapshot strictly older than the replica it already holds")
         void staleSnapshotIsIgnored() {
+            ExtVehicle existing = new ExtVehicle();
+            existing.setVehicleId(VEHICLE_ID);
+            existing.setAggregateVersion(3);
+            when(extVehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.of(existing));
+
+            listener().onVehicleEvent(envelope(1));
+
+            verify(extVehicleRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("applies a snapshot at the same version as the replica it already holds (#1486)")
+        void snapshotAtTheSameVersionIsApplied() {
+            // Load-bearing: pos-vehicle-inventory's publisher flushes a JPA @Version before emit,
+            // so aggregateVersion strictly advances and an equal version means identical content.
+            // POST .../facts/replay deliberately resends a fact at the held version to repair a
+            // replica with wrong or missing rows; skipping on equal (the old `>=` guard) silently
+            // turned replay into a no-op (#1486).
             ExtVehicle existing = new ExtVehicle();
             existing.setVehicleId(VEHICLE_ID);
             existing.setAggregateVersion(3);
@@ -209,7 +227,9 @@ class ProductVehicleLocationReplicaTest {
 
             listener().onVehicleEvent(envelope(3));
 
-            verify(extVehicleRepository, never()).save(any());
+            ArgumentCaptor<ExtVehicle> captor = ArgumentCaptor.forClass(ExtVehicle.class);
+            verify(extVehicleRepository).save(captor.capture());
+            assertThat(captor.getValue().getAggregateVersion()).isEqualTo(3);
         }
     }
 

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
@@ -279,7 +279,7 @@ class ProductVehicleLocationReplicaTest {
         }
 
         @Test
-        @DisplayName("ignores a snapshot no newer than the replica it already holds")
+        @DisplayName("ignores a snapshot strictly older than the replica it already holds")
         void staleSnapshotIsIgnored() {
             ExtLocation existing = new ExtLocation();
             existing.setLocationId(LOCATION_ID);
@@ -289,6 +289,25 @@ class ProductVehicleLocationReplicaTest {
             listener().onLocationEvent(envelope(5));
 
             verify(extLocationRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("applies a snapshot at the same version as the replica it already holds (#1486)")
+        void snapshotAtTheSameVersionIsApplied() {
+            // Load-bearing: pos-location's aggregateVersion strictly advances, so an equal version
+            // means identical content, and a future regenerate-from-state replay would deliberately
+            // resend a fact at the held version to repair a replica with wrong or missing rows.
+            // Skipping on equal (the old `>=` guard) would silently turn that into a no-op (#1486).
+            ExtLocation existing = new ExtLocation();
+            existing.setLocationId(LOCATION_ID);
+            existing.setAggregateVersion(6);
+            when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(existing));
+
+            listener().onLocationEvent(envelope(6));
+
+            ArgumentCaptor<ExtLocation> captor = ArgumentCaptor.forClass(ExtLocation.class);
+            verify(extLocationRepository).save(captor.capture());
+            assertThat(captor.getValue().getAggregateVersion()).isEqualTo(6);
         }
     }
 }

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
@@ -138,7 +138,7 @@ class ProductVehicleLocationReplicaTest {
         }
 
         @Test
-        @DisplayName("ignores a snapshot no newer than the replica it already holds")
+        @DisplayName("ignores a snapshot strictly older than the replica it already holds")
         void staleSnapshotIsIgnored() {
             ExtProduct existing = new ExtProduct();
             existing.setProductId(PRODUCT_ID);
@@ -149,6 +149,25 @@ class ProductVehicleLocationReplicaTest {
 
             verify(extProductRepository, never()).save(any());
             verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("applies a snapshot at the same version as the replica it already holds (#1486)")
+        void snapshotAtTheSameVersionIsApplied() {
+            // Load-bearing: pos-catalog's aggregateVersion strictly advances, so an equal version
+            // means identical content, and POST .../facts/replay deliberately resends a fact at the
+            // held version to repair a replica with wrong or missing rows. Skipping on equal would
+            // silently turn replay into a no-op (#1486) — the old `>=` guard did exactly that.
+            ExtProduct existing = new ExtProduct();
+            existing.setProductId(PRODUCT_ID);
+            existing.setAggregateVersion(2);
+            when(extProductRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(existing));
+
+            listener().onCatalogEvent(envelope(2, "true"));
+
+            ArgumentCaptor<ExtProduct> captor = ArgumentCaptor.forClass(ExtProduct.class);
+            verify(extProductRepository).save(captor.capture());
+            assertThat(captor.getValue().getAggregateVersion()).isEqualTo(2);
         }
     }
 

--- a/pos-order/src/test/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListenerTest.java
@@ -93,7 +93,7 @@ class SupplierArticleCodeEventsListenerTest {
     }
 
     @Test
-    void skipsAFactOlderThanTheReplicaItAlreadyHolds() {
+    void skipsAFactStrictlyOlderThanTheReplicaItAlreadyHolds() {
         when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("michelin-eu", PRODUCT_ID))
                 .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
                         .supplierRef("michelin-eu")
@@ -107,6 +107,30 @@ class SupplierArticleCodeEventsListenerTest {
 
         verify(extSupplierArticleCodeRepository, never()).save(any());
         // Still recorded as processed: the fact was delivered and deliberately not applied.
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    void appliesAFactAtTheSameVersionAsTheReplicaItAlreadyHolds() {
+        // Load-bearing (#1486): pos-catalog's aggregateVersion strictly advances, so an equal
+        // version means identical content, and POST .../facts/replay deliberately resends a fact
+        // at the held version to repair a replica with wrong or missing rows. Skipping on equal
+        // (the old `>=` guard) silently turned replay into a no-op — that was #1486's trap.
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("michelin-eu", PRODUCT_ID))
+                .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
+                        .supplierRef("michelin-eu")
+                        .vendorProfileId(VENDOR_PROFILE_ID)
+                        .productId(PRODUCT_ID)
+                        .supplierArticleCode("999908")
+                        .aggregateVersion(200L)
+                        .build()));
+
+        listener.onCatalogEvent(factEvent("e-3", 200L, "michelin-eu", "999999"));
+
+        ArgumentCaptor<ExtSupplierArticleCode> captor = ArgumentCaptor.forClass(ExtSupplierArticleCode.class);
+        verify(extSupplierArticleCodeRepository).save(captor.capture());
+        assertThat(captor.getValue().getSupplierArticleCode()).isEqualTo("999999");
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(200L);
         verify(processedEventRepository).save(any(ProcessedEvent.class));
     }
 

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/service/CatalogProductEventsListener.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/service/CatalogProductEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.supplier.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.supplier.internal.entity.ExtProductCodeReplica;
 import com.positivity.supplier.internal.entity.ProcessedEvent;
@@ -29,9 +30,12 @@ import tools.jackson.databind.ObjectMapper;
  * <p>Consumer contract mirrors the platform's other catalog consumers: {@code processed_events}
  * idempotency (owner {@code catalog}) written in the apply transaction, a stale guard on the fact's
  * {@code aggregateVersion} that skips only strictly-lower versions, and transient database errors
- * rethrown so the container retries rather than recording the event as processed. Unsupported event
- * types still record their eventId, so the owner's manifest reconciles instead of reporting facts
- * this module deliberately ignored as missing.
+ * rethrown so the container retries rather than recording the event as processed. The guard is
+ * {@link ReplicaVersionGuard} (#1486): pos-catalog's aggregateVersion strictly advances, so equal
+ * versions apply rather than skip — both as an idempotent no-op for live traffic and because
+ * {@code POST .../facts/replay} depends on it to repair a replica that holds the version number but
+ * wrong or missing rows. Unsupported event types still record their eventId, so the owner's
+ * manifest reconciles instead of reporting facts this module deliberately ignored as missing.
  */
 @Slf4j
 @Component
@@ -96,7 +100,10 @@ public class CatalogProductEventsListener {
         UUID productId = payload.productId();
 
         ExtProductCodeReplica existing = replicaRepository.findById(productId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — catalog's
+        // aggregateVersion strictly advances, so equal means identical content, and replay resends
+        // the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
 

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/CatalogEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/CatalogEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.warranty.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.warranty.internal.entity.ExtCatalogReplica;
 import com.positivity.warranty.internal.entity.ProcessedEvent;
@@ -27,10 +28,15 @@ import tools.jackson.databind.ObjectMapper;
  * product resolution and warranty eligibility read manufacturer / warranty terms from this replica.
  *
  * <p>Consumer contract mirrors the module's other listeners: {@code processed_events} idempotency
- * (owner {@code catalog}) in the apply transaction, strictly-below stale guard on the fact's
- * {@code aggregateVersion} (pos-catalog stamps {@code updatedAt} epoch millis there, monotonic per
- * product), transient DB errors rethrown for container retry/DLQ. Unsupported event types still
- * record their eventIds so the owner's manifest reconciles.
+ * (owner {@code catalog}) in the apply transaction, a strictly-below stale guard on the fact's
+ * {@code aggregateVersion} (pos-catalog's JPA {@code @Version}-backed counter, strictly advancing —
+ * seeded from the legacy {@code updatedAt} epoch millis so magnitudes continue seamlessly),
+ * transient DB errors rethrown for container retry/DLQ. Unsupported event types still record their
+ * eventIds so the owner's manifest reconciles.
+ *
+ * <p>The guard is {@link ReplicaVersionGuard} (#1486): equal versions apply rather than skip, both
+ * as an idempotent no-op for live traffic and because {@code POST .../facts/replay} depends on
+ * equal-applies to repair a replica that holds the version number but wrong or missing rows.
  */
 @Slf4j
 @Component
@@ -119,7 +125,10 @@ public class CatalogEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
         ExtCatalogReplica existing =
                 extCatalogReplicaRepository.findById(payload.productId()).orElse(null);
-        if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — catalog's
+        // aggregateVersion strictly advances, so equal means identical content, and replay resends
+        // the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             return;
         }
         extCatalogReplicaRepository.save(ExtCatalogReplica.builder()

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CatalogEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CatalogEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.workorder.internal.entity.ExtProductUomReplica;
 import com.positivity.workorder.internal.entity.ProcessedEvent;
@@ -93,13 +94,17 @@ public class CatalogEventsListener {
      * would leave a UoM catalog has retired still declared here, so a part could go on being judged
      * divisible against a scale its owner no longer publishes.
      *
-     * <p>The stale guard compares the fact's {@code aggregateVersion} — catalog stamps the product's
-     * {@code updatedAt} epoch millis there — against the highest version this module already holds
-     * for the product, and applies on equality because catalog fans out several facts for one
-     * product within the same millisecond. It is belt-and-braces: facts are keyed by product id, so
-     * a partition already delivers one product's facts in order, and what this guards is redelivery
-     * after a rebalance. A product that currently holds no rows has nothing to roll backwards, so
-     * the guard does not apply and the fact lands.
+     * <p>The stale guard compares the fact's {@code aggregateVersion} — pos-catalog's JPA
+     * {@code @Version}-backed counter, strictly advancing (seeded from the legacy {@code updatedAt}
+     * epoch millis so magnitudes continue seamlessly) — against the highest version this module
+     * already holds for the product, using {@link ReplicaVersionGuard} (#1486). It applies on
+     * equality rather than skipping: catalog's strictly-advancing contract means an equal version
+     * is identical content, and {@code POST .../facts/replay} deliberately resends a fact at the
+     * held version to repair a replica that holds the version number but wrong or missing rows —
+     * skipping on equal would silently turn replay into a no-op. It is belt-and-braces: facts are
+     * keyed by product id, so a partition already delivers one product's facts in order, and what
+     * this guards is redelivery after a rebalance. A product that currently holds no rows has
+     * nothing to roll backwards, so the guard does not apply and the fact lands.
      */
     private void applyUomConversions(JsonNode envelope) {
         JsonNode payload = envelope.path("payload");
@@ -107,7 +112,7 @@ public class CatalogEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         List<Long> heldVersions = productUomReplicaRepository.findAggregateVersions(productId);
-        if (heldVersions.stream().anyMatch(held -> held > aggregateVersion)) {
+        if (heldVersions.stream().anyMatch(held -> ReplicaVersionGuard.isStale(held, aggregateVersion))) {
             return;
         }
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (event-semantics remediation, no cap id)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1486
- Domain: `domain:catalog` (plus location publisher and consumer guards in order, inventory, marketing, supplier, warranty, workorder, customer, accounting)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/catalog/.business-rules/BACKEND_CONTRACT_GUIDE.md` — the `aggregateVersion` envelope semantics changed by this PR are documented in `docs/ARCHITECTURE_GUIDE.md` § "Event Replication: `aggregateVersion` Semantics" in this repo; no request/response DTO shape changed.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed:
  - **Rule, stated once**: an equal `aggregateVersion` applies; a consumer skips a fact only when the version it holds is strictly greater. Canonical implementation is the new `com.positivity.domainevents.ReplicaVersionGuard`, with a unit test pinning the semantics at the consumer boundary; documented in `docs/ARCHITECTURE_GUIDE.md` § "Event Replication: `aggregateVersion` Semantics" (including a per-topic publisher survey).
  - **pos-catalog publisher**: JPA `@Version` on `ProductEntity`, `ServiceEntity`, `SupplierArticleCodeEntity`; migration `V15` seeds the columns from the legacy `updatedAt` epoch millis so the published sequence continues monotonically from what replicas already hold. `CatalogFactPublisher` flushes the persistence context and publishes the entity version; delete tombstones publish `version + 1` deterministically (wall-clock flooring removed). `updateCatalogItem` rewritten load-and-mutate (detached merge would optimistic-lock-fail against seeded versions).
  - **pos-location publisher**: same pattern — `StorageLocationEntity` gains `@Version`, `Location`'s existing one is finally read; migration `V6` seeds both columns from migration-time wall-clock millis (old versions were *emission-time* millis, so `updated_at` would not upper-bound them); delete tombstone is `version + 1` from the loaded entity, and deleting a nonexistent id no longer emits a phantom tombstone.
  - **Consumers**: all seven `catalog.events.v1` guard sites delegate to `ReplicaVersionGuard`; pos-order's two `>=` guards (products, supplier article codes) flip to equal-applies. Consumers of other already-strictly-monotonic topics flip the same way: vehicle (pos-order, pos-customer), invoice and warranty (pos-accounting), location (pos-order). Workorder and customer fact consumers keep skip-on-equal, with the reason documented — those publishers still stamp wall-clock millis, and flipping before fixing them would reintroduce the same-millisecond race.
- Why: #1486 — `catalog.events.v1` consumers disagreed on what an equal version means (`>` vs `>=`), and the epoch-millis version could tie. In combination: a same-millisecond race let four consumers apply stale snapshots, and the replay endpoints silently repaired nothing for pos-order's replicas (a `200` with no effect). Strictly-advancing versions plus equal-applies closes the race at the source and makes replay-as-repair real for every consumer.

## Tests
- [x] Unit tests added/updated — `ReplicaVersionGuardTest` pins the rule; publisher tests assert flushed-version emission and `version + 1` tombstones (catalog and location); listener tests in pos-order/pos-customer/pos-accounting flip or add equal-version-applies cases; `CatalogServiceImpl`/`LocationServiceImpl` delete/update reworks covered.
- [ ] Integration tests added/updated — none; Failsafe suites unaffected (no IT touches version semantics).
- [ ] Provider behavioral contract tests added/updated — n/a; envelope schema unchanged, only the version source and its stated semantics.
- How to run: `./mvnw -pl pos-domain-events,pos-catalog,pos-location,pos-order,pos-customer,pos-accounting,pos-inventory,pos-marketing,pos-supplier,pos-warranty,pos-workorder test` and `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` (all green locally: ~6.6k tests, ArchUnit 16/16).

## Risk & Rollback
- Risk level: Medium — touches the stale-guard behavior of replicated state in 9 services and adds optimistic locking to five entities. Mitigations: version seeding guarantees no published version regresses below what replicas hold (catalog seeds from `updatedAt` millis, location from migration-time `now()` millis, both explained in the migration headers); equal-applies is an idempotent overwrite for live traffic; all detached-save paths for the versioned entities were audited and the two hazardous ones rewritten load-and-mutate.
- Rollback plan: revert the PR. The seeded `version` columns are additive and harmless if unread; consumers revert to their previous guards. No data migration needs undoing — `V15`/`V6` only add/update a bigint column that the reverted code ignores.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, no capability; branch is the #1486 solution branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present (#1486)
- [x] Contract guide updated (when contract semantics changed) — semantics documented in `docs/ARCHITECTURE_GUIDE.md` (this repo's canonical home; ADR-0044 body lives in the durion repo)
- [ ] Required CI checks passing — pending first run on this PR

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCEqZW4MVbUgxXpWuVk31Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCEqZW4MVbUgxXpWuVk31Q)_