### PR TITLE
Workorder and customer facts join the strictly-advancing aggregateVersion contract (#1486 follow-up)

### DIFF
--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -302,20 +302,22 @@ already satisfies the strictly-advancing contract:
 | `vehicle.events.v1` (`VehicleCarePreferenceUpdatedV1`) | Epoch millis by design (rows are hard-deleted and re-created, so an entity version would restart at 0) | No | Its one consumer already applies on equal; acceptable for a last-writer-wins preference fact |
 | `invoice.events.v1` | pos-invoice `Invoice`/`BillingRules` `@Version`, flushed before emit | Yes | Yes — pos-accounting's `>=` flipped in #1486 |
 | `warranty.events.v1` | pos-warranty `WarrantyClaim` `@Version`, flushed and force-incremented on otherwise-clean mutations | Yes | Yes — pos-accounting's `>=` flipped in #1486 |
-| `workorder.events.v1` | `Instant.now(clock)` epoch millis; `Workorder` has no `@Version` | **No** | Scoped out — see below |
-| `customer.events.v1` | `Instant.now(clock)` epoch millis; party entities carry no optimistic-lock version | **No** | Scoped out — see below |
+| `workorder.events.v1` (`WorkorderUpdatedV1`, `EstimateUpdatedV1`) | pos-workorder `Workorder.version` / `Estimate.aggregateVersion` `@Version`, flushed before emit, seeded at migration time from wall-clock millis (#1486 follow-up; `Estimate` already had an unrelated manual `version` revision counter, hence the distinct column) | Yes | Yes — pos-order's `>=` flipped |
+| `workorder.events.v1` (service-completion, fleet-auth, time/work-session facts) | Emission-timestamp epoch millis via `OutboxEventWriter`'s 4-arg form | No | No consumer version-guards these facts — acceptable until one does |
+| `customer.events.v1` (`CustomerPartyUpdatedV1`, `BillingRulesUpdatedV1`) | pos-customer `AbstractParty` `@Version` (TABLE_PER_CLASS root: `person_party` and `commercial_party` each carry the seeded column), flushed before emit; party deletes tombstone `version + 1` (#1486 follow-up) | Yes | Yes — pos-order's and pos-accounting's `>=` flipped (the legacy `aggregateVersion > 0` carve-out for versionless envelopes is retired) |
+| `customer.events.v1` (tag/segment/suppression/consent/redemption facts) | Emission-timestamp epoch millis | No | No consumer version-guards these facts — acceptable until one does |
 | `location.events.v1` | pos-location `Location`/`StorageLocationEntity` `@Version`, flushed before emit, seeded at migration time from wall-clock millis (#1486 follow-up) | Yes | Yes — pos-order's `>=` flipped |
 
-**Scoped out, and why:** the `>=` guards consuming `workorder.events.v1` and
-`customer.events.v1` (pos-order's workorder/customer listeners, pos-accounting's customer
-listener) keep their skip-on-equal behavior for now. Those publishers still stamp wall-clock
-millis, so their versions can tie or even invert across instances; a `>=` guard at least fails
-closed on a tie, and neither topic has a regenerate-from-current-state replay whose repairs the
-guard could be blocking (their `OutboxReplayServiceImpl` re-sends existing outbox rows under
-the original `eventId`, which consumers drop by idempotency regardless of any version guard).
-Adopting the rule on such a topic means fixing its publisher first — the `@Version`-flush
-pattern above — and only then moving its consumers to `ReplicaVersionGuard`. Doing it in the
-other order reintroduces the same-millisecond race #1486 closed.
+**Nothing is scoped out any more.** Every fact a consumer version-guards now rides a
+strictly-advancing JPA `@Version`, and every former `>=` guard has moved to
+`ReplicaVersionGuard`. The emission-timestamp rows above survive only on facts no consumer
+version-guards (and on `VehicleCarePreferenceUpdatedV1`, where it is by design); the moment a
+consumer wants to version-guard one of them, its publisher must first adopt the
+`@Version`-flush pattern — flipping the guard first would reintroduce the same-millisecond
+race #1486 closed. Note that each domain's `OutboxReplayServiceImpl` re-sends existing outbox
+rows under their original `eventId`s (dropped by consumer idempotency); a repair that must
+re-apply state needs a regenerate-from-current-state replay like catalog's, which the
+equal-applies rule is what makes effective.
 
 ---
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CustomerEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CustomerEventsListener.java
@@ -4,6 +4,7 @@ import com.positivity.accounting.internal.entity.ExtCustomerBillingRules;
 import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ExtCustomerBillingRulesRepository;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -27,11 +28,19 @@ import tools.jackson.databind.ObjectMapper;
  *
  * <p>Currently materializes {@code customer.billing-rules.updated} into
  * {@code ext_customer_billing_rules}; other event types are ignored. Idempotent via
- * {@code processed_events} (same transaction as the replica upsert), and stale events (envelope
- * {@code aggregateVersion} at or below the replica's) are skipped so out-of-order redelivery
- * cannot regress the replica. Transient DB errors propagate to the container error handler for
- * retry/DLQ; malformed payloads are logged and skipped (poison messages must not block the
- * partition).
+ * {@code processed_events} (same transaction as the replica upsert). Transient DB errors propagate
+ * to the container error handler for retry/DLQ; malformed payloads are logged and skipped (poison
+ * messages must not block the partition).
+ *
+ * <p>The stale guard is {@link ReplicaVersionGuard} (#1486): pos-customer's party
+ * {@code aggregateVersion} strictly advances, so a held row is stale only when its version is
+ * strictly greater than the incoming fact's — an equal version applies, both because it is an
+ * idempotent no-op for live traffic and because it is what would let a future
+ * regenerate-from-state replay repair a replica that holds the version number but wrong or missing
+ * data. A held version can never legitimately be beaten by an incoming {@code aggregateVersion} of
+ * 0: the publisher always stamps a real, flushed {@code @Version} now (never 0 once any mutation
+ * has actually been committed), so a 0 can only be a legacy or malformed envelope, and treating it
+ * as stale relative to any real held version is the safer read.
  */
 @Slf4j
 @Component
@@ -118,7 +127,15 @@ public class CustomerEventsListener {
 
         ExtCustomerBillingRules existing =
                 billingRulesRepository.findById(partyId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion && aggregateVersion > 0) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — the
+        // party's aggregateVersion strictly advances, so equal means identical content, and a
+        // future replay would resend the held version deliberately to repair a replica with wrong
+        // or missing rows. The old `&& aggregateVersion > 0` carve-out let a legacy version-0
+        // envelope always apply, no matter how far ahead the held replica already was; the
+        // publisher now always stamps a real, flushed @Version (never 0 once any mutation has
+        // actually committed), so a 0 is legacy/malformed, and letting the plain > comparison
+        // treat it as stale against any real held version is the safer behavior.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug(
                     "Skipping stale billing-rules event partyId={} eventVersion={} replicaVersion={}",
                     partyId,

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CustomerEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CustomerEventsListener.java
@@ -37,10 +37,10 @@ import tools.jackson.databind.ObjectMapper;
  * strictly greater than the incoming fact's — an equal version applies, both because it is an
  * idempotent no-op for live traffic and because it is what would let a future
  * regenerate-from-state replay repair a replica that holds the version number but wrong or missing
- * data. A held version can never legitimately be beaten by an incoming {@code aggregateVersion} of
- * 0: the publisher always stamps a real, flushed {@code @Version} now (never 0 once any mutation
- * has actually been committed), so a 0 can only be a legacy or malformed envelope, and treating it
- * as stale relative to any real held version is the safer read.
+ * data. An incoming {@code aggregateVersion} of 0 is legitimate only for a brand-new party (a
+ * fresh {@code @Version} row starts at 0), where no replica row exists yet and the guard is never
+ * consulted — the fact lands. Once a replica holds any higher version, an incoming 0 can only be a
+ * legacy or malformed envelope, and treating it as stale is the safer read.
  */
 @Slf4j
 @Component
@@ -131,10 +131,11 @@ public class CustomerEventsListener {
         // party's aggregateVersion strictly advances, so equal means identical content, and a
         // future replay would resend the held version deliberately to repair a replica with wrong
         // or missing rows. The old `&& aggregateVersion > 0` carve-out let a legacy version-0
-        // envelope always apply, no matter how far ahead the held replica already was; the
-        // publisher now always stamps a real, flushed @Version (never 0 once any mutation has
-        // actually committed), so a 0 is legacy/malformed, and letting the plain > comparison
-        // treat it as stale against any real held version is the safer behavior.
+        // envelope always apply, no matter how far ahead the held replica already was. A version-0
+        // fact is legitimate only for a brand-new party (a fresh @Version row starts at 0), and
+        // then no replica row exists so this guard is never consulted; against a replica already
+        // holding a higher version, a 0 can only be legacy/malformed, and letting the plain >
+        // comparison treat it as stale is the safer behavior.
         if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug(
                     "Skipping stale billing-rules event partyId={} eventVersion={} replicaVersion={}",

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CustomerEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CustomerEventsListenerTest.java
@@ -79,7 +79,7 @@ class CustomerEventsListenerTest {
     }
 
     @Test
-    @DisplayName("Stale event (version at or below replica) does not regress the replica")
+    @DisplayName("Stale event (version strictly below the replica's) does not regress the replica")
     void skipsStaleVersions() {
         when(processedEvents.existsById("e-2")).thenReturn(false);
         when(replica.findById(PARTY_ID))
@@ -93,6 +93,50 @@ class CustomerEventsListenerTest {
 
         verify(replica, never()).save(any());
         // Still recorded as processed so redelivery does not loop.
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Applies an event with an equal version stamp (#1486, ReplicaVersionGuard)")
+    void appliesEqualVersion() {
+        // Load-bearing: the party's aggregateVersion strictly advances (committed JPA @Version,
+        // flushed before emit), so an equal version means identical content, and
+        // POST .../facts/replay deliberately resends a fact at the held version to repair a
+        // replica with wrong or missing rows. Skipping on equal (the old `>=` guard) silently
+        // turned replay into a no-op (#1486).
+        when(processedEvents.existsById("e-eq")).thenReturn(false);
+        when(replica.findById(PARTY_ID))
+                .thenReturn(Optional.of(ExtCustomerBillingRules.builder()
+                        .partyId(PARTY_ID)
+                        .aggregateVersion(9L)
+                        .updatedAt(Instant.parse("2026-07-08T11:00:00Z"))
+                        .build()));
+
+        listener.onCustomerEvent(event("e-eq", 9));
+
+        ArgumentCaptor<ExtCustomerBillingRules> saved = ArgumentCaptor.forClass(ExtCustomerBillingRules.class);
+        verify(replica).save(saved.capture());
+        assertThat(saved.getValue().getAggregateVersion()).isEqualTo(9L);
+    }
+
+    @Test
+    @DisplayName("Skips a legacy version-0 event when the replica already holds a real version (#1486)")
+    void skipsVersionZeroEventAgainstARealHeldVersion() {
+        // The publisher always stamps a real, flushed @Version now, so a 0 here can only be a
+        // legacy or malformed envelope; ReplicaVersionGuard treats it as stale against any real
+        // held version rather than special-casing it to always apply (the retired
+        // `&& aggregateVersion > 0` carve-out).
+        when(processedEvents.existsById("e-zero")).thenReturn(false);
+        when(replica.findById(PARTY_ID))
+                .thenReturn(Optional.of(ExtCustomerBillingRules.builder()
+                        .partyId(PARTY_ID)
+                        .aggregateVersion(9L)
+                        .updatedAt(Instant.parse("2026-07-08T11:00:00Z"))
+                        .build()));
+
+        listener.onCustomerEvent(event("e-zero", 0));
+
+        verify(replica, never()).save(any());
         verify(processedEvents).save(any());
     }
 

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductUomServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductUomServiceImpl.java
@@ -13,10 +13,10 @@ import com.positivity.catalog.internal.exception.CatalogValidationException;
 import com.positivity.catalog.internal.repository.ProductRepository;
 import com.positivity.catalog.internal.repository.ProductUomRepository;
 import com.positivity.catalog.service.ProductUomService;
+import com.positivity.domainevents.AggregateTouch;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -109,7 +109,7 @@ public class ProductUomServiceImpl implements ProductUomService {
      * changes still advance it for consumers' stale-event guards.
      */
     private void touchAndPublish(ProductEntity product) {
-        product.setUpdatedAt(Instant.now(clock));
+        product.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(product.getUpdatedAt(), clock));
         productRepository.saveAndFlush(product);
         catalogFactPublisher.publishProductUpdated(product);
     }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SubstitutionGroupServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SubstitutionGroupServiceImpl.java
@@ -13,8 +13,8 @@ import com.positivity.catalog.internal.repository.ProductRepository;
 import com.positivity.catalog.internal.repository.SubstitutionGroupMemberRepository;
 import com.positivity.catalog.internal.repository.SubstitutionGroupRepository;
 import com.positivity.catalog.service.SubstitutionGroupService;
+import com.positivity.domainevents.AggregateTouch;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -116,7 +116,7 @@ public class SubstitutionGroupServiceImpl implements SubstitutionGroupService {
      * changes still advance it for consumers' stale-event guards.
      */
     private void touchAndPublish(ProductEntity product) {
-        product.setUpdatedAt(Instant.now(clock));
+        product.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(product.getUpdatedAt(), clock));
         productRepository.saveAndFlush(product);
         catalogFactPublisher.publishProductUpdated(product);
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/entity/AbstractParty.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/entity/AbstractParty.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Transient;
+import jakarta.persistence.Version;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -111,6 +112,20 @@ public abstract class AbstractParty implements Party {
     @LastModifiedBy
     @Column(name = "modified_by")
     private String modifiedBy;
+
+    /**
+     * The {@code customer.party.updated}/{@code customer.party.deleted} fact-envelope aggregate
+     * version (#1486). JPA optimistic-lock counter that strictly increments on every committed
+     * mutation of this row, so it can never tie the way the legacy {@code updatedAt}-epoch-millis
+     * convention could when two mutations landed in the same millisecond. Seeded from wall-clock
+     * millis at migration time (V30) so the published sequence never regresses for consumers
+     * already holding a replica. {@code TABLE_PER_CLASS} gives every concrete party table
+     * ({@code person_party}, {@code commercial_party}) its own independent column and counter.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    @Schema(description = "Fact-envelope aggregate version; strictly increments per committed mutation (#1486)")
+    private long version;
 
     /** Helper method to validate customer names */
     protected abstract void validateNames();

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
@@ -6,6 +6,7 @@ import com.positivity.customer.internal.entity.CommercialParty;
 import com.positivity.customer.internal.entity.PersonParty;
 import com.positivity.customer.internal.repository.PartyRelationshipRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.customer.CustomerConsentDecisionChangedV1;
 import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
@@ -184,7 +185,7 @@ public class CustomerFactPublisher {
             return;
         }
         personPartyRepository.findByPersonId(personId).ifPresent(person -> {
-            person.setUpdatedAt(Instant.now(clock));
+            person.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(person.getUpdatedAt(), clock));
             personPartyRepository.save(person);
             publishPartyUpdated(writer, person);
         });

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
@@ -441,7 +441,13 @@ public class CustomerFactPublisher {
             int schemaVersion,
             @NonNull UUID aggregateId,
             Object payload) {
-        publish(writer, eventType, schemaVersion, aggregateId, payload, Instant.now(clock).toEpochMilli());
+        publish(
+                writer,
+                eventType,
+                schemaVersion,
+                aggregateId,
+                payload,
+                Instant.now(clock).toEpochMilli());
     }
 
     /** {@code @Version}-backed {@code aggregateVersion} (#1486) — party-updated and -deleted. */

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
@@ -16,6 +16,7 @@ import com.positivity.domainevents.customer.CustomerRedemptionRecordedV1;
 import com.positivity.domainevents.customer.CustomerSegmentChangedV1;
 import com.positivity.domainevents.customer.CustomerSegmentResolvedV1;
 import com.positivity.domainevents.customer.CustomerSuppressionChangedV1;
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -42,9 +43,29 @@ import org.springframework.util.StringUtils;
  * When Kafka publishing is disabled ({@code pos.customer.kafka.enabled=false}) the outbox writer
  * bean is absent and every method is a no-op, so callers never need their own guard.
  *
- * <p>The envelope's {@code aggregateVersion} is the emission timestamp in epoch millis — parties
- * carry no optimistic-lock version, and millisecond last-writer-wins ordering matches the
- * established pattern of this module's billing-rules fact.
+ * <p>{@code AbstractParty} carries a JPA {@code @Version} (#1486), and {@code customer.party.updated}
+ * / {@code customer.party.deleted} — the two facts pos-order and pos-accounting version-guard —
+ * publish that counter as {@code aggregateVersion}: it strictly increments on every committed
+ * mutation, so unlike the retired {@code Instant.now(clock)}-stamped emission timestamp, two
+ * mutations landing in the same millisecond can never tie. Migration V30 seeded the column from
+ * wall-clock millis at migration time (not {@code updated_at} — see the migration header for why),
+ * so the published sequence continues above every version consumers already hold. {@link
+ * #publishPartyUpdated} flushes the pending mutation before reading the version, so the increment
+ * Hibernate is about to apply is already reflected in the emitted fact; {@link #partyDeleted}
+ * publishes {@code version + 1} from the entity loaded before the delete (the tombstone pattern —
+ * no flush needed, since the row is being removed, not re-saved). A consumer on these two facts
+ * skips a fact only when the version it already holds is strictly greater than the incoming one —
+ * an equal version applies, both because it is an idempotent no-op for live traffic and because it
+ * is what would let a future regenerate-from-state replay repair a replica that holds the version
+ * number but wrong or missing data.
+ *
+ * <p>Every other fact this class publishes (person-identity, tag-changed, suppression, redemption,
+ * consent-decision, segment-changed, segment-resolved) stays on the {@code Instant.now(clock)}
+ * emission-millis scheme: none of them is about the {@code Party} aggregate's own version (several
+ * describe a different aggregate entirely — a segment, a suppressed address, a resolved query), and
+ * a repo-wide survey (#1486 follow-up) found no consumer anywhere that version-guards any of them,
+ * so there is no strictly-advancing contract to violate and nothing that would benefit from moving
+ * off wall-clock millis yet.
  */
 @Slf4j
 @Component
@@ -58,6 +79,7 @@ public class CustomerFactPublisher {
     private final PersonPartyRepository personPartyRepository;
     private final PartyRelationshipRepository partyRelationshipRepository;
     private final String eventsTopic;
+    private final EntityManager entityManager;
 
     public CustomerFactPublisher(
             ObjectProvider<OutboxEventWriter> outboxEventWriter,
@@ -67,13 +89,15 @@ public class CustomerFactPublisher {
             PartyRelationshipRepository partyRelationshipRepository,
             // Same property ManifestPublisher scans event_outbox by, so an override can never
             // desync the outbox rows from the manifest computation.
-            @Value("${pos.customer.kafka.events-topic:customer.events.v1}") String eventsTopic) {
+            @Value("${pos.customer.kafka.events-topic:customer.events.v1}") String eventsTopic,
+            EntityManager entityManager) {
         this.outboxEventWriter = outboxEventWriter;
         this.clock = clock;
         this.personDirectoryService = personDirectoryService;
         this.personPartyRepository = personPartyRepository;
         this.partyRelationshipRepository = partyRelationshipRepository;
         this.eventsTopic = eventsTopic;
+        this.entityManager = entityManager;
     }
 
     /**
@@ -105,6 +129,11 @@ public class CustomerFactPublisher {
      * with the entity loaded <em>before</em> the delete so the person linkage is still available;
      * for person parties the person-identity fact is re-emitted with the individual-customer flag
      * cleared.
+     *
+     * <p>Versioned as {@code version + 1} from the entity loaded before the delete (#1486) — one
+     * past every fact this party has ever published, the same tombstone pattern pos-catalog and
+     * pos-location use. No flush here: the row is about to be deleted, not re-saved, so there is
+     * no pending {@code @Version} increment to pick up.
      */
     public void partyDeleted(@NonNull AbstractParty party) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
@@ -118,7 +147,8 @@ public class CustomerFactPublisher {
                 CustomerPartyDeletedV1.EVENT_TYPE,
                 CustomerPartyDeletedV1.SCHEMA_VERSION,
                 party.getPartyId(),
-                payload);
+                payload,
+                party.getVersion() + 1);
         if (personId != null) {
             publishPersonIdentity(writer, personId);
         }
@@ -140,13 +170,24 @@ public class CustomerFactPublisher {
      * Re-emit the party fact of the person's individual-customer record after the local
      * people-contact replica changed — the fact's {@code displayName} is materialized from that
      * replica, so name changes must propagate to {@code ext_customer_party} consumers.
+     *
+     * <p>The replica that actually changed ({@code ext_people_contact_person}) is a side table the
+     * {@code PersonParty} row has no mapped relationship to, so nothing here would otherwise dirty
+     * the party row — the publisher's flush would have no pending {@code @Version} increment to
+     * apply, and the fact would carry a changed {@code displayName} under an unchanged
+     * {@code aggregateVersion} (#1486). Bump {@code updatedAt} and save before publishing, the same
+     * convention pos-location's {@code addParentInternal} follows.
      */
     public void personReplicaChanged(@NonNull UUID personId) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
-        personPartyRepository.findByPersonId(personId).ifPresent(person -> publishPartyUpdated(writer, person));
+        personPartyRepository.findByPersonId(personId).ifPresent(person -> {
+            person.setUpdatedAt(Instant.now(clock));
+            personPartyRepository.save(person);
+            publishPartyUpdated(writer, person);
+        });
     }
 
     /**
@@ -304,7 +345,14 @@ public class CustomerFactPublisher {
                 payload);
     }
 
+    /**
+     * Flushed before reading {@code aggregateVersion} (#1486): the mutation that triggered this
+     * call is still pending in the persistence context, and flushing here forces Hibernate to
+     * apply the {@code @Version} increment so the envelope carries the version the row is about to
+     * commit as, not the one it held before this write.
+     */
     private void publishPartyUpdated(@NonNull OutboxEventWriter writer, @NonNull AbstractParty party) {
+        entityManager.flush();
         String displayName = null;
         String legalName = null;
         UUID personId = null;
@@ -349,7 +397,8 @@ public class CustomerFactPublisher {
                 CustomerPartyUpdatedV1.EVENT_TYPE,
                 CustomerPartyUpdatedV1.SCHEMA_VERSION,
                 party.getPartyId(),
-                payload);
+                payload,
+                party.getVersion());
     }
 
     private void publishPersonIdentity(@NonNull OutboxEventWriter writer, @NonNull UUID personId) {
@@ -385,22 +434,26 @@ public class CustomerFactPublisher {
         return displayName.isBlank() ? null : displayName;
     }
 
+    /** Emission-millis {@code aggregateVersion} — every fact except party-updated/deleted. */
     private void publish(
             @NonNull OutboxEventWriter writer,
             @NonNull String eventType,
             int schemaVersion,
             @NonNull UUID aggregateId,
             Object payload) {
+        publish(writer, eventType, schemaVersion, aggregateId, payload, Instant.now(clock).toEpochMilli());
+    }
+
+    /** {@code @Version}-backed {@code aggregateVersion} (#1486) — party-updated and -deleted. */
+    private void publish(
+            @NonNull OutboxEventWriter writer,
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull UUID aggregateId,
+            Object payload,
+            long aggregateVersion) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
-                eventType,
-                schemaVersion,
-                aggregateId,
-                Instant.now(clock).toEpochMilli(),
-                SOURCE,
-                null,
-                null,
-                payload,
-                clock);
+                eventType, schemaVersion, aggregateId, aggregateVersion, SOURCE, null, null, payload, clock);
         writer.publish(eventsTopic, envelope);
         log.debug("Queued {} for aggregate {}", eventType, aggregateId);
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -41,6 +41,7 @@ import com.positivity.customer.service.PartyService;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
 import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.EntityManager;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -96,6 +97,7 @@ public class PartyServiceImpl implements PartyService {
     private final CustomerFactPublisher customerFactPublisher;
     private final MarketingConsentService marketingConsentService;
     private final CustomerInteractionService customerInteractionService;
+    private final EntityManager entityManager;
 
     private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT.withLocale(Locale.US);
 
@@ -909,7 +911,7 @@ public class PartyServiceImpl implements PartyService {
         embedded.setDiscountPolicyRef(request.getDiscountPolicyRef());
         party.setBillingRules(embedded);
         partyRepository.save(party);
-        publishBillingRulesUpdated(partyId, embedded);
+        publishBillingRulesUpdated(party, embedded);
         // Credit hold feeds the party fact's requirementsMet verdict — re-emit it (#889).
         customerFactPublisher.partyChanged(party);
         return mapToBillingRuleRef(embedded);
@@ -918,17 +920,20 @@ public class PartyServiceImpl implements PartyService {
     /**
      * ADR-0044 (issue #842): billing-rule changes are facts owned by this module; consumers
      * (pos-accounting) maintain read-only replicas from customer.events.v1. Written through the
-     * outbox inside this transaction — no event on rollback. The envelope's aggregateVersion uses
-     * the update timestamp (epoch millis): CommercialParty has no optimistic-lock version, and
-     * millisecond ordering is sufficient for replica staleness checks on this low-frequency data.
+     * outbox inside this transaction — no event on rollback. The envelope's {@code aggregateVersion}
+     * is {@code CommercialParty}'s JPA {@code @Version} (#1486): {@code billingRules} is
+     * {@code @Embedded} on the party row, so setting it above already dirtied the row this flush
+     * picks up — the increment Hibernate is about to apply is reflected in the emitted fact, the
+     * same as {@link CustomerFactPublisher#partyChanged}.
      */
-    private void publishBillingRulesUpdated(UUID partyId, BillingRulesEmbeddable embedded) {
+    private void publishBillingRulesUpdated(CommercialParty party, BillingRulesEmbeddable embedded) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
         if (writer == null) {
             return;
         }
+        entityManager.flush();
         BillingRulesUpdatedV1 payload = new BillingRulesUpdatedV1(
-                partyId,
+                party.getPartyId(),
                 embedded.getPoRequired(),
                 embedded.getTaxExempt(),
                 embedded.getCreditHold(),
@@ -944,8 +949,8 @@ public class PartyServiceImpl implements PartyService {
         DomainEventEnvelope<BillingRulesUpdatedV1> envelope = DomainEventEnvelope.of(
                 BillingRulesUpdatedV1.EVENT_TYPE,
                 BillingRulesUpdatedV1.SCHEMA_VERSION,
-                partyId,
-                java.time.Instant.now(clock).toEpochMilli(),
+                party.getPartyId(),
+                party.getVersion(),
                 "pos-customer",
                 null,
                 null,

--- a/pos-customer/src/main/resources/db/migration/V30__party_aggregate_version_columns.sql
+++ b/pos-customer/src/main/resources/db/migration/V30__party_aggregate_version_columns.sql
@@ -1,0 +1,28 @@
+-- #1486 follow-up: pos-customer's customer.events.v1 party facts (customer.party.updated,
+-- customer.party.deleted) and the billing-rules fact (customer.billing-rules.updated) stamped
+-- Instant.now(clock).toEpochMilli() as aggregateVersion on every emit -- an emission-time value,
+-- not the aggregate's own state version, so two mutations landing in the same millisecond tied.
+-- Replaced with a JPA optimistic-lock @Version counter on the party hierarchy root
+-- (AbstractParty), so the published sequence strictly advances per committed mutation and the
+-- platform's equal-applies consumer rule (ReplicaVersionGuard) is safe to adopt on the two facts
+-- pos-order and pos-accounting version-guard (party-updated, billing-rules).
+--
+-- Party uses InheritanceType.TABLE_PER_CLASS: there is no shared "party" table, so each concrete
+-- table gets its own version column and its own independent counter.
+--
+-- Seeded from wall-clock millis at MIGRATION time -- deliberately NOT from updated_at, the same
+-- reasoning as pos-location's V6. The versions consumers currently hold are EMISSION-time clock
+-- millis, which can exceed a row's updated_at by a few milliseconds (the gap between the mutation
+-- commit and the publish call reading the clock); only migration-time now() upper-bounds every
+-- version ever emitted for these facts, so the first post-migration fact (seed+1 or greater, once
+-- flushed) can never regress a replica.
+-- Postgres-only syntax is fine here -- tests run with Flyway disabled (ddl-auto: create-drop
+-- against H2), so this migration never runs against H2.
+
+ALTER TABLE person_party ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE person_party
+SET version = CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT);
+
+ALTER TABLE commercial_party ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE commercial_party
+SET version = CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT);

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
@@ -20,6 +20,7 @@ import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
 import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
 import com.positivity.domainevents.customer.CustomerPersonIdentityUpdatedV1;
+import jakarta.persistence.EntityManager;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -48,6 +49,7 @@ class CustomerFactPublisherTest {
     private final PersonDirectoryService personDirectoryService = mock(PersonDirectoryService.class);
     private final PersonPartyRepository personPartyRepository = mock(PersonPartyRepository.class);
     private final PartyRelationshipRepository partyRelationshipRepository = mock(PartyRelationshipRepository.class);
+    private final EntityManager entityManager = mock(EntityManager.class);
 
     private CustomerFactPublisher publisher;
 
@@ -60,7 +62,8 @@ class CustomerFactPublisherTest {
                 personDirectoryService,
                 personPartyRepository,
                 partyRelationshipRepository,
-                "customer.events.v1");
+                "customer.events.v1",
+                entityManager);
     }
 
     private CommercialParty commercialParty(AccountStatus status, Boolean creditHold) {
@@ -69,6 +72,9 @@ class CustomerFactPublisherTest {
         party.setCustomerNumber("CUST-001");
         party.setLegalName("Acme Corp");
         party.setStatus(status);
+        // Deliberately distinct from TEST_CLOCK's epoch millis, so a test asserting on the retired
+        // emission-millis convention would fail loudly rather than passing by coincidence (#1486).
+        party.setVersion(5L);
         if (creditHold != null) {
             BillingRulesEmbeddable rules = new BillingRulesEmbeddable();
             rules.setCreditHold(creditHold);
@@ -95,6 +101,9 @@ class CustomerFactPublisherTest {
         assertThat(fact.requirementsMet()).isFalse();
         assertThat(fact.creditHold()).isTrue();
         assertThat(fact.personId()).isNull();
+        // Flushed before reading the version, so the fact carries the current @Version (#1486).
+        verify(entityManager).flush();
+        assertThat(captor.getValue().aggregateVersion()).isEqualTo(5L);
     }
 
     @Test
@@ -117,6 +126,7 @@ class CustomerFactPublisherTest {
         person.setPersonId(personId);
         person.setCustomerNumber("CUST-PER-1");
         person.setStatus(AccountStatus.ACTIVE);
+        person.setVersion(11L);
         when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(personId)))
                 .thenReturn(Map.of(
                         personId,
@@ -135,6 +145,7 @@ class CustomerFactPublisherTest {
         assertThat(partyFact.personId()).isEqualTo(personId);
         assertThat(partyFact.displayName()).isEqualTo("Jane Smith");
         assertThat(partyFact.requirementsMet()).isTrue();
+        assertThat(captor.getAllValues().get(0).aggregateVersion()).isEqualTo(11L);
 
         CustomerPersonIdentityUpdatedV1 identityFact =
                 (CustomerPersonIdentityUpdatedV1) captor.getAllValues().get(1).payload();
@@ -152,6 +163,7 @@ class CustomerFactPublisherTest {
         person.setPersonPartyId(UUID.randomUUID());
         person.setPersonId(personId);
         person.setStatus(AccountStatus.ACTIVE);
+        person.setVersion(4L);
         when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.empty());
 
         publisher.partyDeleted(person);
@@ -162,6 +174,10 @@ class CustomerFactPublisherTest {
                 (CustomerPartyDeletedV1) captor.getAllValues().get(0).payload();
         assertThat(deleted.partyId()).isEqualTo(person.getPersonPartyId());
         assertThat(deleted.personId()).isEqualTo(personId);
+        // Tombstone: one past every fact this party has ever published (#1486). No flush — the
+        // row is being deleted, not re-saved, so there is no pending @Version increment to apply.
+        assertThat(captor.getAllValues().get(0).aggregateVersion()).isEqualTo(5L);
+        verify(entityManager, never()).flush();
 
         CustomerPersonIdentityUpdatedV1 identityFact =
                 (CustomerPersonIdentityUpdatedV1) captor.getAllValues().get(1).payload();
@@ -191,5 +207,33 @@ class CustomerFactPublisherTest {
         publisher.personReplicaChanged(personId);
 
         verify(writer, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("personReplicaChanged dirties the party row before publishing (#1486)")
+    void personReplicaChangedDirtiesTheRowFirst() {
+        // ext_people_contact_person is a side table the PersonParty row has no mapped relationship
+        // to, so nothing here would otherwise dirty the row: the flush inside publishPartyUpdated
+        // would have no pending @Version increment to apply, and the fact would carry a changed
+        // displayName under an unchanged aggregateVersion. Bumping updatedAt and saving first (the
+        // addParentInternal pattern) is what keeps the version strictly advancing.
+        UUID personId = UUID.randomUUID();
+        PersonParty person = new PersonParty();
+        person.setPersonPartyId(UUID.randomUUID());
+        person.setPersonId(personId);
+        person.setStatus(AccountStatus.ACTIVE);
+        person.setVersion(9L);
+        Instant before = person.getUpdatedAt();
+        when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.of(person));
+        when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(personId))).thenReturn(Map.of());
+
+        publisher.personReplicaChanged(personId);
+
+        assertThat(person.getUpdatedAt()).isNotEqualTo(before);
+        verify(personPartyRepository).save(person);
+        verify(entityManager).flush();
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("customer.events.v1"), captor.capture());
+        assertThat(captor.getValue().aggregateVersion()).isEqualTo(9L);
     }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
@@ -225,7 +225,8 @@ class CustomerFactPublisherTest {
         person.setVersion(9L);
         Instant before = person.getUpdatedAt();
         when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.of(person));
-        when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(personId))).thenReturn(Map.of());
+        when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(personId)))
+                .thenReturn(Map.of());
 
         publisher.personReplicaChanged(personId);
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyServiceImplBillingAndDuplicatesTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyServiceImplBillingAndDuplicatesTest.java
@@ -23,6 +23,7 @@ import com.positivity.customer.service.CustomerInteractionService;
 import com.positivity.customer.service.MarketingConsentService;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -106,6 +107,9 @@ class PartyServiceImplBillingAndDuplicatesTest {
     @Mock
     private CustomerInteractionService customerInteractionService;
 
+    @Mock
+    private EntityManager entityManager;
+
     private PartyServiceImpl service;
 
     @BeforeEach
@@ -121,7 +125,8 @@ class PartyServiceImplBillingAndDuplicatesTest {
                 outboxEventWriter,
                 customerFactPublisher,
                 marketingConsentService,
-                customerInteractionService);
+                customerInteractionService,
+                entityManager);
         when(outboxEventWriter.getIfAvailable()).thenReturn(writer);
         when(customerFactPublisher.eventsTopic()).thenReturn(TOPIC);
     }
@@ -130,6 +135,9 @@ class PartyServiceImplBillingAndDuplicatesTest {
         CommercialParty party = new CommercialParty();
         party.setPartyId(PARTY_ID);
         party.setLegalName(legalName);
+        // Deliberately distinct from NOW's epoch millis, so a test asserting on the retired
+        // emission-millis convention would fail loudly rather than passing by coincidence (#1486).
+        party.setVersion(7L);
         return party;
     }
 
@@ -187,8 +195,10 @@ class PartyServiceImplBillingAndDuplicatesTest {
             assertThat(envelope.eventType()).isEqualTo(BillingRulesUpdatedV1.EVENT_TYPE);
             assertThat(envelope.aggregateId()).isEqualTo(PARTY_ID);
             assertThat(envelope.sourceService()).isEqualTo("pos-customer");
-            // CommercialParty carries no optimistic-lock version, so the update timestamp stands in.
-            assertThat(envelope.aggregateVersion()).isEqualTo(NOW.toEpochMilli());
+            // billingRules is @Embedded on the party row, so the flush below picks up the pending
+            // update and the fact carries CommercialParty's @Version (#1486), not a wall clock.
+            verify(entityManager).flush();
+            assertThat(envelope.aggregateVersion()).isEqualTo(7L);
 
             BillingRulesUpdatedV1 payload = (BillingRulesUpdatedV1) envelope.payload();
             assertThat(payload.partyId()).isEqualTo(PARTY_ID);

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -107,7 +107,8 @@ class PartyServiceImplTest {
                 emptyOutboxWriterProvider(),
                 org.mockito.Mockito.mock(com.positivity.customer.internal.service.CustomerFactPublisher.class),
                 org.mockito.Mockito.mock(com.positivity.customer.service.MarketingConsentService.class),
-                org.mockito.Mockito.mock(com.positivity.customer.service.CustomerInteractionService.class));
+                org.mockito.Mockito.mock(com.positivity.customer.service.CustomerInteractionService.class),
+                org.mockito.Mockito.mock(jakarta.persistence.EntityManager.class));
     }
 
     private CommercialParty party(UUID id) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/AggregateTouch.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/AggregateTouch.java
@@ -1,0 +1,43 @@
+package com.positivity.domainevents;
+
+import java.time.Clock;
+import java.time.Instant;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The publisher-side companion to {@link ReplicaVersionGuard} (#1486): computes the {@code
+ * updatedAt} value a caller stamps to <em>dirty an aggregate row</em> whose fact is about to be
+ * published after a mutation that only touched attribute or child tables.
+ *
+ * <p>The strictly-advancing {@code aggregateVersion} contract relies on Hibernate's {@code
+ * @Version} increment, and Hibernate increments only a <em>dirty</em> row. Stamping {@code
+ * Instant.now(clock)} is almost always enough to dirty it — but not when the clock reading ties
+ * the row's current {@code updatedAt} (a mutation and its child-table follow-up inside one clock
+ * tick, or timestamp truncation): an equal value is no change, the row stays clean, the flush has
+ * no increment to apply, and the fact goes out carrying new content under an unchanged version —
+ * the exact tie #1486 exists to make impossible.
+ *
+ * <p>{@link #monotonicUpdatedAt(Instant, Clock)} therefore returns the clock's reading only when
+ * it is strictly after the current value, and one millisecond past the current value otherwise —
+ * always a change, so the row is always dirtied and the version always advances. One millisecond
+ * stays representable through every timestamp precision in use (Postgres and H2 store
+ * microseconds).
+ */
+public final class AggregateTouch {
+
+    private AggregateTouch() {}
+
+    /**
+     * The next {@code updatedAt} to stamp on an aggregate row being dirtied for publication:
+     * strictly after {@code current}, so the assignment is never a same-value no-op.
+     *
+     * @param current the row's current {@code updatedAt}; {@code null} for a row never stamped
+     * @param clock   the caller's injected clock
+     * @return the clock's reading, or {@code current.plusMillis(1)} when the reading does not
+     *     advance past it
+     */
+    public static Instant monotonicUpdatedAt(@Nullable Instant current, Clock clock) {
+        Instant now = clock.instant();
+        return current != null && !now.isAfter(current) ? current.plusMillis(1) : now;
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/ReplicaVersionGuard.java
@@ -2,9 +2,10 @@ package com.positivity.domainevents;
 
 /**
  * The platform's canonical staleness rule for a replica {@code aggregateVersion} guard (#1486).
- * It applies to every topic whose publisher guarantees a strictly-advancing version — as of
- * #1486 that is catalog, vehicle, invoice, warranty, and location facts; see "Event Replication:
- * aggregateVersion Semantics" in {@code docs/ARCHITECTURE_GUIDE.md} for the per-topic survey.
+ * It applies to every fact whose publisher guarantees a strictly-advancing version — as of the
+ * #1486 follow-ups that is catalog, vehicle, invoice, warranty, location, workorder, and customer
+ * facts; see "Event Replication: aggregateVersion Semantics" in {@code docs/ARCHITECTURE_GUIDE.md}
+ * for the per-fact survey.
  *
  * <p>pos-catalog's {@code aggregateVersion}, for example, is a JPA {@code @Version}-backed
  * counter that strictly advances on every write to the aggregate; it was seeded from the legacy
@@ -22,11 +23,12 @@ package com.positivity.domainevents;
  * equal costs nothing for live traffic (it is an idempotent overwrite with identical content) and
  * is the only thing that makes replay-as-repair actually repair anything.
  *
- * <p>Every consumer stale guard on a strictly-advancing topic must use this class rather than
- * re-deriving the comparison, so the rule stays in exactly one place. Consumers of topics whose
- * publishers still stamp wall-clock millis (workorder, customer facts) are explicitly out of
- * scope until those publishers adopt the {@code @Version}-flush pattern — see the architecture
- * guide section above.
+ * <p>Every consumer stale guard on a strictly-advancing fact must use this class rather than
+ * re-deriving the comparison, so the rule stays in exactly one place. A few facts no consumer
+ * version-guards still carry emission-timestamp versions (see the guide's survey table); before
+ * any consumer starts version-guarding one of those, its publisher must first adopt the
+ * {@code @Version}-flush pattern — guarding first would reintroduce the same-millisecond race
+ * #1486 closed.
  */
 public final class ReplicaVersionGuard {
 

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/AggregateTouchTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/AggregateTouchTest.java
@@ -1,0 +1,40 @@
+package com.positivity.domainevents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class AggregateTouchTest {
+
+    private static final Instant NOW = Instant.parse("2026-01-01T00:00:00.000Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Test
+    void neverStampedRowGetsTheClockReading() {
+        assertThat(AggregateTouch.monotonicUpdatedAt(null, CLOCK)).isEqualTo(NOW);
+    }
+
+    @Test
+    void olderRowGetsTheClockReading() {
+        assertThat(AggregateTouch.monotonicUpdatedAt(NOW.minusSeconds(60), CLOCK))
+                .isEqualTo(NOW);
+    }
+
+    @Test
+    void clockTieAdvancesOneMillisecondPastTheRow() {
+        // Load-bearing (#1486): stamping an updatedAt equal to the row's current value is a
+        // same-value no-op — the row stays clean, Hibernate's @Version never increments, and the
+        // fact goes out carrying new content under an unchanged aggregateVersion. The bump must
+        // always be a change.
+        assertThat(AggregateTouch.monotonicUpdatedAt(NOW, CLOCK)).isEqualTo(NOW.plusMillis(1));
+    }
+
+    @Test
+    void rowAheadOfTheClockAdvancesOneMillisecondPastTheRow() {
+        Instant ahead = NOW.plusSeconds(5);
+        assertThat(AggregateTouch.monotonicUpdatedAt(ahead, CLOCK)).isEqualTo(ahead.plusMillis(1));
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.location.internal.dto.HolidayClosureRequest;
 import com.positivity.location.internal.dto.LocationDescendantResponseDTO;
 import com.positivity.location.internal.dto.LocationParentResponseDTO;
@@ -27,7 +28,6 @@ import com.positivity.location.internal.repository.LocationTypeRepository;
 import com.positivity.location.service.LocationService;
 import java.time.Clock;
 import java.time.DateTimeException;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -427,7 +427,7 @@ public class LocationServiceImpl implements LocationService {
         // @Version increment to apply — the fact would carry changed parentRefs under an unchanged
         // aggregateVersion, breaking the strictly-advancing contract (#1486). Dirty the child
         // first, the same convention catalog's attribute-table mutations follow.
-        child.setUpdatedAt(Instant.now(clock));
+        child.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(child.getUpdatedAt(), clock));
         locationRepository.saveAndFlush(child);
         locationFactPublisher.locationChanged(child);
         return saved;

--- a/pos-order/src/main/java/com/positivity/order/internal/service/CustomerEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/CustomerEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
 import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
 import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
@@ -26,9 +27,15 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Consumes {@code customer.events.v1} into the {@code ext_customer} replica (ADR-0044 §6, parity
  * story I2 replica redesign). Same contract as the pos-customer/pos-invoice replica listeners:
- * idempotent via {@code processed_events} in the upsert transaction, stale envelopes
- * (aggregateVersion at or below the replica's) skipped, transient DB errors rethrown for container
- * retry, malformed payloads logged and skipped.
+ * idempotent via {@code processed_events} in the upsert transaction, stale envelopes skipped,
+ * transient DB errors rethrown for container retry, malformed payloads logged and skipped.
+ *
+ * <p>The stale guard on {@code customer.party.updated} and {@code customer.billing-rules.updated}
+ * is {@link ReplicaVersionGuard} (#1486): pos-customer's party {@code aggregateVersion} strictly
+ * advances, so a held row is stale only when its version is strictly greater than the incoming
+ * fact's — an equal version applies, both because it is an idempotent no-op for live traffic and
+ * because it is what would let a future regenerate-from-state replay repair a replica that holds
+ * the version number but wrong or missing data.
  */
 @Slf4j
 @Component
@@ -105,9 +112,13 @@ public class CustomerEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtCustomer existing = extCustomerRepository.findById(partyId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — the
+        // party's aggregateVersion strictly advances, so equal means identical content, and a
+        // future replay would resend the held version deliberately to repair a replica with
+        // wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug(
-                    "Skipping stale customer event for {} (v{} <= v{})",
+                    "Skipping stale customer event for {} (v{} < v{})",
                     partyId,
                     aggregateVersion,
                     existing.getAggregateVersion());
@@ -131,7 +142,11 @@ public class CustomerEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtBillingRules existing = extBillingRulesRepository.findById(partyId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — the
+        // party's aggregateVersion strictly advances, so equal means identical content, and a
+        // future replay would resend the held version deliberately to repair a replica with
+        // wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug("Skipping stale billing-rules event for {}", partyId);
             return;
         }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/WorkorderEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/WorkorderEventsListener.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.service;
 
+import com.positivity.domainevents.ReplicaVersionGuard;
 import com.positivity.domainevents.workorder.EstimateUpdatedV1;
 import com.positivity.domainevents.workorder.WorkorderUpdatedV1;
 import com.positivity.order.internal.entity.ExtEstimate;
@@ -35,6 +36,14 @@ import tools.jackson.databind.ObjectMapper;
  * approved prices. Same consumer contract as the other replica listeners: idempotent via
  * {@code processed_events}, stale envelopes skipped, transient DB errors rethrown, malformed
  * payloads logged and skipped.
+ *
+ * <p>The stale guard on {@code WorkorderUpdatedV1}'s and {@code EstimateUpdatedV1}'s
+ * {@code aggregateVersion} is {@link ReplicaVersionGuard} (#1486): pos-workorder's {@code Workorder}
+ * and {@code Estimate} each carry a JPA {@code @Version} that strictly advances, so a held row is
+ * stale only when its version is strictly greater than the incoming fact's — an equal version
+ * applies, both because it is an idempotent no-op for live traffic and because it is what would let
+ * a future regenerate-from-state replay repair a replica that holds the version number but wrong or
+ * missing rows.
  */
 @Slf4j
 @Component
@@ -112,7 +121,10 @@ public class WorkorderEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtWorkorder existing = extWorkorderRepository.findById(workorderId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — workorder's
+        // aggregateVersion strictly advances, so equal means identical content, and a future replay
+        // would resend the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug("Skipping stale workorder event for {}", workorderId);
             return;
         }
@@ -164,7 +176,10 @@ public class WorkorderEventsListener {
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
         ExtEstimate existing = extEstimateRepository.findById(estimateId).orElse(null);
-        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+        // Strictly-newer-only skip: equal versions APPLY (#1486, ReplicaVersionGuard) — estimate's
+        // aggregateVersion strictly advances, so equal means identical content, and a future replay
+        // would resend the held version deliberately to repair a replica with wrong or missing rows.
+        if (existing != null && ReplicaVersionGuard.isStale(existing.getAggregateVersion(), aggregateVersion)) {
             log.debug("Skipping stale estimate event for {}", estimateId);
             return;
         }

--- a/pos-order/src/test/java/com/positivity/order/internal/service/CustomerEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/CustomerEventsListenerTest.java
@@ -86,11 +86,16 @@ class CustomerEventsListenerTest {
     }
 
     private static String billingRulesEnvelope(String creditLimit, String creditHold, String poRequired) {
+        return billingRulesEnvelope(creditLimit, creditHold, poRequired, 2);
+    }
+
+    private static String billingRulesEnvelope(
+            String creditLimit, String creditHold, String poRequired, long version) {
         return """
-                {"eventId":"evt-2","eventType":"%s","aggregateVersion":2,
+                {"eventId":"evt-2","eventType":"%s","aggregateVersion":%d,
                  "payload":{"partyId":"%s","paymentTerms":"NET30","creditLimit":%s,
                    "creditHold":%s,"poRequired":%s}}
-                """.formatted(BillingRulesUpdatedV1.EVENT_TYPE, PARTY_ID, creditLimit, creditHold, poRequired);
+                """.formatted(BillingRulesUpdatedV1.EVENT_TYPE, version, PARTY_ID, creditLimit, creditHold, poRequired);
     }
 
     @Test
@@ -123,8 +128,27 @@ class CustomerEventsListenerTest {
     }
 
     @Test
-    @DisplayName("ignores an update no newer than the replica it already holds")
+    @DisplayName("ignores an update strictly older than the replica it already holds")
     void staleUpdateIsIgnored() {
+        ExtCustomer existing = new ExtCustomer();
+        existing.setPartyId(PARTY_ID);
+        existing.setAggregateVersion(7);
+        when(extCustomerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+
+        listener.onCustomerEvent(updateEnvelope(6));
+
+        verify(extCustomerRepository, never()).save(any());
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("applies an update with an equal version stamp (#1486, ReplicaVersionGuard)")
+    void appliesEqualVersion() {
+        // Load-bearing: pos-customer's party aggregateVersion strictly advances (committed JPA
+        // @Version, flushed before emit), so an equal version means identical content, and
+        // POST .../facts/replay deliberately resends a fact at the held version to repair a
+        // replica with wrong or missing rows. Skipping on equal (the old `>=` guard) silently
+        // turned replay into a no-op (#1486).
         ExtCustomer existing = new ExtCustomer();
         existing.setPartyId(PARTY_ID);
         existing.setAggregateVersion(7);
@@ -132,8 +156,9 @@ class CustomerEventsListenerTest {
 
         listener.onCustomerEvent(updateEnvelope(7));
 
-        verify(extCustomerRepository, never()).save(any());
-        verify(processedEventRepository).save(any());
+        ArgumentCaptor<ExtCustomer> captor = ArgumentCaptor.forClass(ExtCustomer.class);
+        verify(extCustomerRepository).save(captor.capture());
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(7);
     }
 
     @Test
@@ -177,15 +202,30 @@ class CustomerEventsListenerTest {
     }
 
     @Test
-    @DisplayName("ignores billing rules no newer than the replica it already holds")
+    @DisplayName("ignores billing rules strictly older than the replica it already holds")
     void staleBillingRulesAreIgnored() {
         ExtBillingRules existing = new ExtBillingRules();
         existing.setPartyId(PARTY_ID);
         existing.setAggregateVersion(4);
         when(extBillingRulesRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
 
-        listener.onCustomerEvent(billingRulesEnvelope("100", "false", "false"));
+        listener.onCustomerEvent(billingRulesEnvelope("100", "false", "false", 3));
 
         verify(extBillingRulesRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applies billing rules with an equal version stamp (#1486, ReplicaVersionGuard)")
+    void appliesEqualBillingRulesVersion() {
+        ExtBillingRules existing = new ExtBillingRules();
+        existing.setPartyId(PARTY_ID);
+        existing.setAggregateVersion(4);
+        when(extBillingRulesRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+
+        listener.onCustomerEvent(billingRulesEnvelope("100", "false", "false", 4));
+
+        ArgumentCaptor<ExtBillingRules> captor = ArgumentCaptor.forClass(ExtBillingRules.class);
+        verify(extBillingRulesRepository).save(captor.capture());
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(4);
     }
 }

--- a/pos-order/src/test/java/com/positivity/order/internal/service/CustomerEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/CustomerEventsListenerTest.java
@@ -89,8 +89,7 @@ class CustomerEventsListenerTest {
         return billingRulesEnvelope(creditLimit, creditHold, poRequired, 2);
     }
 
-    private static String billingRulesEnvelope(
-            String creditLimit, String creditHold, String poRequired, long version) {
+    private static String billingRulesEnvelope(String creditLimit, String creditHold, String poRequired, long version) {
         return """
                 {"eventId":"evt-2","eventType":"%s","aggregateVersion":%d,
                  "payload":{"partyId":"%s","paymentTerms":"NET30","creditLimit":%s,

--- a/pos-order/src/test/java/com/positivity/order/internal/service/WorkorderEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/WorkorderEventsListenerTest.java
@@ -174,8 +174,28 @@ class WorkorderEventsListenerTest {
     }
 
     @Test
-    @DisplayName("ignores a snapshot no newer than the replica it already holds")
-    void staleWorkorderSnapshotIsIgnored() {
+    @DisplayName("ignores a snapshot strictly older than the replica it already holds")
+    void strictlyOlderWorkorderSnapshotIsIgnored() {
+        ExtWorkorder existing = new ExtWorkorder();
+        existing.setWorkorderId(WORKORDER_ID);
+        existing.setAggregateVersion(5);
+        when(extWorkorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(existing));
+
+        listener.onWorkorderEvent(workorderEnvelope(3));
+
+        verify(extWorkorderRepository, never()).save(any());
+        verify(extWorkorderLineRepository, never()).deleteByWorkorderId(any());
+        // Still recorded: the event was consumed and correctly decided against.
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("applies a workorder snapshot at the same version as the replica it already holds (#1486)")
+    void workorderSnapshotAtTheSameVersionIsApplied() {
+        // Load-bearing: pos-workorder's aggregateVersion strictly advances, so an equal version
+        // means identical content, and a future regenerate-from-state replay would deliberately
+        // resend a fact at the held version to repair a replica with wrong or missing rows.
+        // Skipping on equal (the old `>=` guard) would silently turn that into a no-op (#1486).
         ExtWorkorder existing = new ExtWorkorder();
         existing.setWorkorderId(WORKORDER_ID);
         existing.setAggregateVersion(5);
@@ -183,10 +203,8 @@ class WorkorderEventsListenerTest {
 
         listener.onWorkorderEvent(workorderEnvelope(5));
 
-        verify(extWorkorderRepository, never()).save(any());
-        verify(extWorkorderLineRepository, never()).deleteByWorkorderId(any());
-        // Still recorded: the event was consumed and correctly decided against.
-        verify(processedEventRepository).save(any());
+        verify(extWorkorderRepository).save(existing);
+        assertThat(existing.getAggregateVersion()).isEqualTo(5);
     }
 
     @Test
@@ -229,8 +247,8 @@ class WorkorderEventsListenerTest {
     }
 
     @Test
-    @DisplayName("ignores an estimate snapshot no newer than the replica it already holds")
-    void staleEstimateSnapshotIsIgnored() {
+    @DisplayName("ignores an estimate snapshot strictly older than the replica it already holds")
+    void strictlyOlderEstimateSnapshotIsIgnored() {
         ExtEstimate existing = new ExtEstimate();
         existing.setEstimateId(ESTIMATE_ID);
         existing.setAggregateVersion(9);
@@ -240,5 +258,24 @@ class WorkorderEventsListenerTest {
 
         verify(extEstimateRepository, never()).save(any());
         verify(extEstimateLineRepository, never()).deleteByEstimateId(any());
+    }
+
+    @Test
+    @DisplayName("applies an estimate snapshot at the same version as the replica it already holds (#1486)")
+    void estimateSnapshotAtTheSameVersionIsApplied() {
+        // Load-bearing: pos-workorder's aggregateVersion strictly advances, so an equal version
+        // means identical content, and a future regenerate-from-state replay would deliberately
+        // resend a fact at the held version to repair a replica with wrong or missing rows.
+        // Skipping on equal (the old `>=` guard) would silently turn that into a no-op (#1486).
+        ExtEstimate existing = new ExtEstimate();
+        existing.setEstimateId(ESTIMATE_ID);
+        existing.setAggregateVersion(9);
+        when(extEstimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(existing));
+
+        listener.onWorkorderEvent(estimateEnvelope(9));
+
+        ArgumentCaptor<ExtEstimate> header = ArgumentCaptor.forClass(ExtEstimate.class);
+        verify(extEstimateRepository).save(header.capture());
+        assertThat(header.getValue().getAggregateVersion()).isEqualTo(9);
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
@@ -32,6 +32,15 @@ import tools.jackson.databind.ObjectMapper;
  * envelope: the callers are transactional relays that know their payload and aggregate id but not
  * the topic, and building the nine-argument envelope at each of them would duplicate the same
  * source-service and clock wiring thirteen times.
+ *
+ * <p>Two {@code publish} overloads exist for two different {@code aggregateVersion} contracts
+ * (#1486). The four-argument form stamps {@code Instant.now(clock).toEpochMilli()} — an
+ * emission-timestamp LWW hint, fine for facts nothing version-guards, but two mutations landing in
+ * the same millisecond tie under it. The five-argument form takes an explicit
+ * {@code aggregateVersion} and MUST be used for facts about a version-guarded aggregate: as of
+ * #1486 that is {@code WorkorderUpdatedV1} and {@code EstimateUpdatedV1}, fed from
+ * {@code Workorder}/{@code Estimate}'s flushed JPA {@code @Version}, which strictly increments on
+ * every committed mutation and so can never tie.
  */
 @Slf4j
 @Component
@@ -55,21 +64,39 @@ public class OutboxEventWriter {
      * at the call site, so the number moves with the payload it describes (#1279). Payloads that
      * have a {@code pos-domain-events} record pass that record's {@code SCHEMA_VERSION}; the
      * module-internal payload types declare their own.
+     *
+     * <p>Stamps {@code Instant.now(clock).toEpochMilli()} as {@code aggregateVersion} — an
+     * emission-timestamp LWW hint (ADR-0044 §6, #897), fine for a fact nothing version-guards, but
+     * not strictly-advancing: two mutations landing in the same millisecond tie. A fact about a
+     * version-guarded aggregate ({@code WorkorderUpdatedV1}, {@code EstimateUpdatedV1} as of #1486)
+     * must use {@link #publish(String, int, UUID, long, Object)} instead, fed from the entity's
+     * flushed {@code @Version}.
      */
     @Transactional(propagation = Propagation.MANDATORY)
     public void publish(
             @NonNull String eventType, int schemaVersion, @NonNull UUID aggregateId, @NonNull Object payload) {
+        publish(eventType, schemaVersion, aggregateId, Instant.now(clock).toEpochMilli(), payload);
+    }
+
+    /**
+     * Queue a domain event for publication with an explicit {@code aggregateVersion}, as part of
+     * the current transaction. Must be called inside the business transaction ({@code MANDATORY}).
+     *
+     * <p>Use this overload — never the emission-millis four-argument form — for a fact about a
+     * version-guarded aggregate (#1486): {@code aggregateVersion} must come from that aggregate's
+     * flushed JPA {@code @Version}, which strictly increments on every committed mutation, so it
+     * can never tie the way emission-timestamp millis could. The caller is responsible for
+     * flushing the pending mutation before reading the version.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void publish(
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull UUID aggregateId,
+            long aggregateVersion,
+            @NonNull Object payload) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
-                eventType,
-                schemaVersion,
-                aggregateId,
-                // Emission-timestamp LWW hint for replica stale guards (ADR-0044 §6, #897).
-                Instant.now(clock).toEpochMilli(),
-                SOURCE_SERVICE,
-                null,
-                null,
-                payload,
-                clock);
+                eventType, schemaVersion, aggregateId, aggregateVersion, SOURCE_SERVICE, null, null, payload, clock);
         OutboxEvent event = OutboxEvent.builder()
                 .topic(eventsTopic)
                 .recordKey(envelope.recordKey())

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/Estimate.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/Estimate.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -135,6 +136,23 @@ public class Estimate {
     // Version tracking for estimate revisions
     @Builder.Default
     private Integer version = 1;
+
+    /**
+     * The fact-envelope aggregate version (#1486). JPA optimistic-lock counter that strictly
+     * increments on every committed mutation, so it can never tie the way the retired
+     * {@code Instant.now(clock).toEpochMilli()} emission-timestamp convention could when two
+     * mutations landed in the same millisecond. Seeded from wall-clock millis at migration time
+     * by V21 so the published sequence continues above every version consumers already hold.
+     *
+     * <p>Named {@code aggregateVersion} rather than the plain {@code version} the sibling entities
+     * use: this class already has a {@code version} column, an ordinary (non-optimistic-lock)
+     * integer that tracks estimate revisions as a business concept and is unrelated to this fact's
+     * concurrency counter. Reusing that column for {@code @Version} would corrupt the revision
+     * count with Hibernate's own increments.
+     */
+    @Version
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
 
     // CRM reference IDs — immutable point-in-time snapshot (CAP-094 Story #93)
     @Column(length = 36, updatable = false)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/Workorder.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/Workorder.java
@@ -18,6 +18,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -154,6 +155,17 @@ public class Workorder {
         return status == WorkorderStatus.CANCELLED
                 || (status == WorkorderStatus.COMPLETED && !Boolean.TRUE.equals(isReopened));
     }
+
+    /**
+     * The fact-envelope aggregate version (#1486). JPA optimistic-lock counter that strictly
+     * increments on every committed mutation, so it can never tie the way the retired
+     * {@code Instant.now(clock).toEpochMilli()} emission-timestamp convention could when two
+     * mutations landed in the same millisecond. Seeded from wall-clock millis at migration time
+     * by V21 so the published sequence continues above every version consumers already hold.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
 
     public Workorder(UUID id) {
         this.id = id;

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateFactPublisher.java
@@ -6,6 +6,7 @@ import com.positivity.workorder.internal.entity.Estimate;
 import com.positivity.workorder.internal.entity.EstimateItem;
 import com.positivity.workorder.internal.repository.EstimateItemRepository;
 import com.positivity.workorder.internal.repository.EstimateRepository;
+import jakarta.persistence.EntityManager;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,6 +26,18 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * per touched estimate is emitted at {@code beforeCommit} from the final persisted state. First
  * consumer: pos-order's {@code ext_estimate} replica feeding source-document import (spec R7.1).
  * No-op when Kafka publishing is disabled.
+ *
+ * <p>{@code Estimate} carries a JPA {@code @Version} named {@code aggregateVersion} (#1486) — not
+ * the plain {@code version} field, which is an unrelated business revision counter — and the
+ * envelope's {@code aggregateVersion} is that counter: it strictly increments on every committed
+ * mutation, so — unlike the retired {@code Instant.now(clock)}-stamped emission timestamp — two
+ * mutations landing in the same millisecond can never tie. Migration V21 seeded it from wall-clock
+ * millis at migration time, so the published sequence continues above every version consumers
+ * already hold. The persistence context is flushed before reading it, so the increment Hibernate
+ * is about to apply is already reflected in the emitted fact. A mutation that only touches
+ * {@code estimate_item} rows without dirtying the {@code estimate} row itself must dirty it first
+ * (bumping {@code updatedAt}) before calling {@link #markChanged(UUID)}, or the flush here has no
+ * pending {@code @Version} increment to pick up.
  */
 @Slf4j
 @Component
@@ -36,6 +49,7 @@ public class EstimateFactPublisher {
     private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
     private final EstimateRepository estimateRepository;
     private final EstimateItemRepository estimateItemRepository;
+    private final EntityManager entityManager;
 
     /** Mark an estimate as changed in the current transaction; one fact is emitted at commit. */
     public void markChanged(@NonNull UUID estimateId) {
@@ -72,6 +86,11 @@ public class EstimateFactPublisher {
         if (writer == null || pending == null) {
             return;
         }
+        // Flushed before reading aggregateVersion: mutations from this transaction are still
+        // pending in the persistence context, and flushing here forces Hibernate to apply every
+        // pending @Version increment so each emitted fact carries the version its row is about to
+        // commit as, not the one it held before this write (#1486).
+        entityManager.flush();
         for (UUID estimateId : pending) {
             Estimate estimate = estimateRepository.findById(estimateId).orElse(null);
             if (estimate == null) {
@@ -95,7 +114,12 @@ public class EstimateFactPublisher {
                     items,
                     estimate.getCreatedAt(),
                     estimate.getUpdatedAt());
-            writer.publish(EstimateUpdatedV1.EVENT_TYPE, EstimateUpdatedV1.SCHEMA_VERSION, estimateId, payload);
+            writer.publish(
+                    EstimateUpdatedV1.EVENT_TYPE,
+                    EstimateUpdatedV1.SCHEMA_VERSION,
+                    estimateId,
+                    estimate.getAggregateVersion(),
+                    payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -919,6 +919,11 @@ public class EstimateServiceImpl implements EstimateService {
 
         item.validate();
         EstimateItem saved = estimateItemRepository.save(item);
+        // This write only touches the estimate_item row; dirty the estimate row itself so the
+        // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
+        // leaves the emitted fact carrying the new item under an unchanged aggregateVersion.
+        estimate.setUpdatedAt(Instant.now(clock));
+        estimateRepository.save(estimate);
         estimateFactPublisher.markChanged(estimateId);
 
         log.info(
@@ -970,6 +975,11 @@ public class EstimateServiceImpl implements EstimateService {
         item.validate();
 
         EstimateItem saved = estimateItemRepository.save(item);
+        // This write only touches the estimate_item row; dirty the estimate row itself so the
+        // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
+        // leaves the emitted fact carrying the revised item under an unchanged aggregateVersion.
+        estimate.setUpdatedAt(Instant.now(clock));
+        estimateRepository.save(estimate);
         estimateFactPublisher.markChanged(estimateId);
 
         log.info("Updated item {} on estimate {}", itemId, estimateId);
@@ -1067,6 +1077,11 @@ public class EstimateServiceImpl implements EstimateService {
         // Soft delete
         item.setDeleted(true);
         estimateItemRepository.save(item);
+        // This write only touches the estimate_item row; dirty the estimate row itself so the
+        // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
+        // leaves the emitted fact carrying the removed item under an unchanged aggregateVersion.
+        estimate.setUpdatedAt(Instant.now(clock));
+        estimateRepository.save(estimate);
         estimateFactPublisher.markChanged(estimateId);
 
         log.info("Deleted (soft) item {} from estimate {}", itemId, estimateId);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.tax.common.dto.TaxCalculationRequest;
 import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
@@ -922,7 +923,7 @@ public class EstimateServiceImpl implements EstimateService {
         // This write only touches the estimate_item row; dirty the estimate row itself so the
         // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
         // leaves the emitted fact carrying the new item under an unchanged aggregateVersion.
-        estimate.setUpdatedAt(Instant.now(clock));
+        estimate.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(estimate.getUpdatedAt(), clock));
         estimateRepository.save(estimate);
         estimateFactPublisher.markChanged(estimateId);
 
@@ -978,7 +979,7 @@ public class EstimateServiceImpl implements EstimateService {
         // This write only touches the estimate_item row; dirty the estimate row itself so the
         // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
         // leaves the emitted fact carrying the revised item under an unchanged aggregateVersion.
-        estimate.setUpdatedAt(Instant.now(clock));
+        estimate.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(estimate.getUpdatedAt(), clock));
         estimateRepository.save(estimate);
         estimateFactPublisher.markChanged(estimateId);
 
@@ -1080,7 +1081,7 @@ public class EstimateServiceImpl implements EstimateService {
         // This write only touches the estimate_item row; dirty the estimate row itself so the
         // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
         // leaves the emitted fact carrying the removed item under an unchanged aggregateVersion.
-        estimate.setUpdatedAt(Instant.now(clock));
+        estimate.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(estimate.getUpdatedAt(), clock));
         estimateRepository.save(estimate);
         estimateFactPublisher.markChanged(estimateId);
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderFactPublisher.java
@@ -8,6 +8,7 @@ import com.positivity.workorder.internal.entity.WorkorderServiceLine;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import jakarta.persistence.EntityManager;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,6 +30,17 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * built from the final persisted state (workorder row + full part-line set). When Kafka
  * publishing is disabled the outbox writer bean is absent and every call is a no-op, so callers
  * never need their own guard.
+ *
+ * <p>{@code Workorder} carries a JPA {@code @Version}, and the envelope's {@code aggregateVersion}
+ * is that counter (#1486): it strictly increments on every committed mutation, so — unlike the
+ * retired {@code Instant.now(clock)}-stamped emission timestamp — two mutations landing in the same
+ * millisecond can never tie. Migration V21 seeded it from wall-clock millis at migration time, so
+ * the published sequence continues above every version consumers already hold. The persistence
+ * context is flushed before reading it, so the increment Hibernate is about to apply is already
+ * reflected in the emitted fact. A mutation that only touches {@code workorder_part} /
+ * {@code workorder_service_line} rows without dirtying the {@code workorder} row itself must dirty
+ * it first (bumping {@code updatedAt}) before calling {@link #markChanged(UUID)}, or the flush here
+ * has no pending {@code @Version} increment to pick up.
  */
 @Slf4j
 @Component
@@ -41,6 +53,7 @@ public class WorkorderFactPublisher {
     private final WorkorderRepository workorderRepository;
     private final WorkorderPartRepository workorderPartRepository;
     private final WorkorderServiceRepository workorderServiceRepository;
+    private final EntityManager entityManager;
 
     /** Mark a workorder as changed in the current transaction; one fact is emitted at commit. */
     public void markChanged(@NonNull UUID workorderId) {
@@ -77,6 +90,11 @@ public class WorkorderFactPublisher {
         if (writer == null || pending == null) {
             return;
         }
+        // Flushed before reading aggregateVersion: mutations from this transaction are still
+        // pending in the persistence context, and flushing here forces Hibernate to apply every
+        // pending @Version increment so each emitted fact carries the version its row is about to
+        // commit as, not the one it held before this write (#1486).
+        entityManager.flush();
         for (UUID workorderId : pending) {
             Workorder workorder = workorderRepository.findById(workorderId).orElse(null);
             if (workorder == null) {
@@ -102,7 +120,12 @@ public class WorkorderFactPublisher {
                     services,
                     workorder.getCreatedAt(),
                     workorder.getUpdatedAt());
-            writer.publish(WorkorderUpdatedV1.EVENT_TYPE, WorkorderUpdatedV1.SCHEMA_VERSION, workorderId, payload);
+            writer.publish(
+                    WorkorderUpdatedV1.EVENT_TYPE,
+                    WorkorderUpdatedV1.SCHEMA_VERSION,
+                    workorderId,
+                    workorder.getVersion(),
+                    payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
@@ -2,8 +2,10 @@ package com.positivity.workorder.internal.service;
 
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.workorder.internal.dto.WorkorderPartAdjustmentEventResponse;
+import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.entity.WorkorderPartAdjustmentEvent;
+import com.positivity.workorder.internal.exception.WorkorderNotFoundException;
 import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
@@ -90,10 +92,13 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
      * {@code aggregateVersion}.
      */
     private void dirtyWorkorder(UUID workorderId) {
-        workorderRepository.findById(workorderId).ifPresent(workorder -> {
-            workorder.setUpdatedAt(Instant.now(clock));
-            workorderRepository.save(workorder);
-        });
+        // Fail fast on a missing row — silently skipping the bump would emit the fact under an
+        // unchanged aggregateVersion, the exact contract violation this helper exists to prevent.
+        Workorder workorder = workorderRepository
+                .findById(workorderId)
+                .orElseThrow(() -> new WorkorderNotFoundException(workorderId));
+        workorder.setUpdatedAt(Instant.now(clock));
+        workorderRepository.save(workorder);
     }
 
     /**

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
@@ -6,6 +6,7 @@ import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.entity.WorkorderPartAdjustmentEvent;
 import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.IdempotencyService;
 import com.positivity.workorder.service.WorkorderPartAdjustmentService;
 import java.math.BigDecimal;
@@ -62,6 +63,7 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
     private final IdempotencyService idempotencyService;
     private final WorkorderFactPublisher workorderFactPublisher;
     private final PartQuantityDivisibilityService partQuantityDivisibilityService;
+    private final WorkorderRepository workorderRepository;
 
     public WorkorderPartAdjustmentServiceImpl(
             WorkorderPartRepository workorderPartRepository,
@@ -69,6 +71,7 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
             IdempotencyService idempotencyService,
             WorkorderFactPublisher workorderFactPublisher,
             PartQuantityDivisibilityService partQuantityDivisibilityService,
+            WorkorderRepository workorderRepository,
             Clock clock) {
         this.clock = clock;
         this.workorderPartRepository = workorderPartRepository;
@@ -76,6 +79,21 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
         this.idempotencyService = idempotencyService;
         this.workorderFactPublisher = workorderFactPublisher;
         this.partQuantityDivisibilityService = partQuantityDivisibilityService;
+        this.workorderRepository = workorderRepository;
+    }
+
+    /**
+     * Dirties the workorder row itself for a mutation that only touched a
+     * {@code workorder_part} row (#1486): {@link WorkorderFactPublisher} flushes before reading
+     * the aggregate's {@code @Version}, and a clean workorder row gives that flush no pending
+     * increment to pick up, so the emitted fact would carry the new part state under an unchanged
+     * {@code aggregateVersion}.
+     */
+    private void dirtyWorkorder(UUID workorderId) {
+        workorderRepository.findById(workorderId).ifPresent(workorder -> {
+            workorder.setUpdatedAt(Instant.now(clock));
+            workorderRepository.save(workorder);
+        });
     }
 
     /**
@@ -167,6 +185,9 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
                 .build();
 
         substitutePart = workorderPartRepository.save(substitutePart);
+        // This substitution only touches workorder_part rows; dirty the workorder row itself so the
+        // publisher's flush has a pending @Version increment to pick up (#1486).
+        dirtyWorkorder(workorderId);
         workorderFactPublisher.markChanged(substitutePart.getWorkorder().getId());
         if (log.isInfoEnabled()) {
             log.info(
@@ -280,6 +301,9 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
         // Update part.quantityReturned
         part.setQuantityReturned(part.getQuantityReturned().add(quantity));
         workorderPartRepository.save(part);
+        // This write only touches the workorder_part row; dirty the workorder row itself so the
+        // publisher's flush has a pending @Version increment to pick up (#1486).
+        dirtyWorkorder(workorderId);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
         // Create ADDITIONAL_RETURN adjustment event (negative quantity)
@@ -395,6 +419,9 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
             part.setLineTotal(newQuantity.multiply(part.getUnitPrice()));
         }
         workorderPartRepository.save(part);
+        // This correction only touches the workorder_part row; dirty the workorder row itself so
+        // the publisher's flush has a pending @Version increment to pick up (#1486).
+        dirtyWorkorder(workorderId);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
         // Create CORRECTION adjustment event

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.workorder.internal.dto.WorkorderPartAdjustmentEventResponse;
 import com.positivity.workorder.internal.entity.Workorder;
@@ -97,7 +98,7 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
         Workorder workorder = workorderRepository
                 .findById(workorderId)
                 .orElseThrow(() -> new WorkorderNotFoundException(workorderId));
-        workorder.setUpdatedAt(Instant.now(clock));
+        workorder.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(workorder.getUpdatedAt(), clock));
         workorderRepository.save(workorder);
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
@@ -334,8 +334,9 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         }
 
         // Validate workorder and part exist
-        Workorder workorder =
-                workorderRepository.findById(workorderId).orElseThrow(() -> new WorkorderNotFoundException(workorderId));
+        Workorder workorder = workorderRepository
+                .findById(workorderId)
+                .orElseThrow(() -> new WorkorderNotFoundException(workorderId));
 
         WorkorderPart part = workorderPartRepository
                 .findById(partLineId)
@@ -432,8 +433,9 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         }
 
         // Validate workorder and part exist
-        Workorder workorder =
-                workorderRepository.findById(workorderId).orElseThrow(() -> new WorkorderNotFoundException(workorderId));
+        Workorder workorder = workorderRepository
+                .findById(workorderId)
+                .orElseThrow(() -> new WorkorderNotFoundException(workorderId));
 
         WorkorderPart part = workorderPartRepository
                 .findById(partLineId)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.workorder.internal.config.InventoryCommandPublisher;
 import com.positivity.workorder.internal.dto.WorkorderPartUsageEventResponse;
@@ -174,7 +175,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         // This write only touches workorder_part; dirty the workorder row itself so the publisher's
         // flush has a pending @Version increment to pick up (#1486) — a clean row leaves the
         // emitted fact carrying stale part totals under an unchanged aggregateVersion.
-        workorder.setUpdatedAt(Instant.now(clock));
+        workorder.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(workorder.getUpdatedAt(), clock));
         workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
@@ -376,7 +377,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         // This write only touches workorder_part; dirty the workorder row itself so the publisher's
         // flush has a pending @Version increment to pick up (#1486) — a clean row leaves the
         // emitted fact carrying stale part totals under an unchanged aggregateVersion.
-        workorder.setUpdatedAt(Instant.now(clock));
+        workorder.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(workorder.getUpdatedAt(), clock));
         workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
@@ -482,7 +483,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         // This write only touches workorder_part; dirty the workorder row itself so the publisher's
         // flush has a pending @Version increment to pick up (#1486) — a clean row leaves the
         // emitted fact carrying stale part totals under an unchanged aggregateVersion.
-        workorder.setUpdatedAt(Instant.now(clock));
+        workorder.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(workorder.getUpdatedAt(), clock));
         workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
@@ -171,6 +171,11 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         // Update part totals
         part.setQuantityIssued(part.getQuantityIssued().add(quantity));
         workorderPartRepository.save(part);
+        // This write only touches workorder_part; dirty the workorder row itself so the publisher's
+        // flush has a pending @Version increment to pick up (#1486) — a clean row leaves the
+        // emitted fact carrying stale part totals under an unchanged aggregateVersion.
+        workorder.setUpdatedAt(Instant.now(clock));
+        workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
         // Register idempotency key if provided
@@ -329,7 +334,8 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         }
 
         // Validate workorder and part exist
-        workorderRepository.findById(workorderId).orElseThrow(() -> new WorkorderNotFoundException(workorderId));
+        Workorder workorder =
+                workorderRepository.findById(workorderId).orElseThrow(() -> new WorkorderNotFoundException(workorderId));
 
         WorkorderPart part = workorderPartRepository
                 .findById(partLineId)
@@ -366,6 +372,11 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         // Update part totals
         part.setQuantityConsumed(newConsumed);
         workorderPartRepository.save(part);
+        // This write only touches workorder_part; dirty the workorder row itself so the publisher's
+        // flush has a pending @Version increment to pick up (#1486) — a clean row leaves the
+        // emitted fact carrying stale part totals under an unchanged aggregateVersion.
+        workorder.setUpdatedAt(Instant.now(clock));
+        workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
         // Register idempotency key if provided
@@ -421,7 +432,8 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         }
 
         // Validate workorder and part exist
-        workorderRepository.findById(workorderId).orElseThrow(() -> new WorkorderNotFoundException(workorderId));
+        Workorder workorder =
+                workorderRepository.findById(workorderId).orElseThrow(() -> new WorkorderNotFoundException(workorderId));
 
         WorkorderPart part = workorderPartRepository
                 .findById(partLineId)
@@ -465,6 +477,11 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         // Update part totals
         part.setQuantityReturned(part.getQuantityReturned().add(quantity));
         workorderPartRepository.save(part);
+        // This write only touches workorder_part; dirty the workorder row itself so the publisher's
+        // flush has a pending @Version increment to pick up (#1486) — a clean row leaves the
+        // emitted fact carrying stale part totals under an unchanged aggregateVersion.
+        workorder.setUpdatedAt(Instant.now(clock));
+        workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(part.getWorkorder().getId());
 
         // Register idempotency key if provided

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.workorder.internal.dto.AssignmentUpdatePayload;
@@ -649,7 +650,7 @@ public class WorkorderServiceImpl implements WorkorderService {
             Workorder workorder = workorderRepository
                     .findById(workorderId)
                     .orElseThrow(() -> new WorkorderNotFoundException(workorderId));
-            workorder.setUpdatedAt(Instant.now(clock));
+            workorder.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(workorder.getUpdatedAt(), clock));
             workorderRepository.save(workorder);
             workorderFactPublisher.markChanged(workorderId);
             log.info("Part {} on workorder {} marked COMPLETED by {}", partId, workorderId, actorId);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -644,11 +644,13 @@ public class WorkorderServiceImpl implements WorkorderService {
             part.setStatus(status);
             workorderPartRepository.save(part);
             // This write only touches the workorder_part row; dirty the workorder row itself so the
-            // publisher's flush has a pending @Version increment to pick up (#1486).
-            workorderRepository.findById(workorderId).ifPresent(workorder -> {
-                workorder.setUpdatedAt(Instant.now(clock));
-                workorderRepository.save(workorder);
-            });
+            // publisher's flush has a pending @Version increment to pick up (#1486). Fail fast on a
+            // missing row — silently skipping would emit the fact under an unchanged version.
+            Workorder workorder = workorderRepository
+                    .findById(workorderId)
+                    .orElseThrow(() -> new WorkorderNotFoundException(workorderId));
+            workorder.setUpdatedAt(Instant.now(clock));
+            workorderRepository.save(workorder);
             workorderFactPublisher.markChanged(workorderId);
             log.info("Part {} on workorder {} marked COMPLETED by {}", partId, workorderId, actorId);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -643,6 +643,12 @@ public class WorkorderServiceImpl implements WorkorderService {
         if (status != part.getStatus()) {
             part.setStatus(status);
             workorderPartRepository.save(part);
+            // This write only touches the workorder_part row; dirty the workorder row itself so the
+            // publisher's flush has a pending @Version increment to pick up (#1486).
+            workorderRepository.findById(workorderId).ifPresent(workorder -> {
+                workorder.setUpdatedAt(Instant.now(clock));
+                workorderRepository.save(workorder);
+            });
             workorderFactPublisher.markChanged(workorderId);
             log.info("Part {} on workorder {} marked COMPLETED by {}", partId, workorderId, actorId);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImpl.java
@@ -132,8 +132,9 @@ public class WorkorderSubstitutionServiceImpl implements WorkorderSubstitutionSe
         // This substitution only touches workorder_part rows; dirty the workorder row itself so the
         // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
         // leaves the emitted fact carrying the new substitution under an unchanged aggregateVersion.
-        Workorder workorder = workorderRepository.findById(workorderId).orElseThrow(() -> new NoSuchElementException(
-                "Workorder not found: " + workorderId));
+        Workorder workorder = workorderRepository
+                .findById(workorderId)
+                .orElseThrow(() -> new NoSuchElementException("Workorder not found: " + workorderId));
         workorder.setUpdatedAt(Instant.now(clock));
         workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(workorderId);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.domainevents.AggregateTouch;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.workorder.internal.dto.WorkorderPartAdjustmentEventResponse;
 import com.positivity.workorder.internal.entity.WorkOrderPartSubstitution;
@@ -135,7 +136,7 @@ public class WorkorderSubstitutionServiceImpl implements WorkorderSubstitutionSe
         Workorder workorder = workorderRepository
                 .findById(workorderId)
                 .orElseThrow(() -> new NoSuchElementException("Workorder not found: " + workorderId));
-        workorder.setUpdatedAt(Instant.now(clock));
+        workorder.setUpdatedAt(AggregateTouch.monotonicUpdatedAt(workorder.getUpdatedAt(), clock));
         workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(workorderId);
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImpl.java
@@ -11,6 +11,7 @@ import com.positivity.workorder.internal.enums.SubstitutionStatus;
 import com.positivity.workorder.internal.repository.WorkOrderPartSubstitutionRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.IdempotencyService;
 import com.positivity.workorder.service.WorkorderSubstitutionService;
 import java.math.BigDecimal;
@@ -48,6 +49,7 @@ public class WorkorderSubstitutionServiceImpl implements WorkorderSubstitutionSe
     private final IdempotencyService idempotencyService;
     private final WorkorderFactPublisher workorderFactPublisher;
     private final ObjectMapper objectMapper;
+    private final WorkorderRepository workorderRepository;
 
     public WorkorderSubstitutionServiceImpl(
             WorkorderPartRepository workorderPartRepository,
@@ -56,6 +58,7 @@ public class WorkorderSubstitutionServiceImpl implements WorkorderSubstitutionSe
             IdempotencyService idempotencyService,
             ObjectMapper objectMapper,
             WorkorderFactPublisher workorderFactPublisher,
+            WorkorderRepository workorderRepository,
             Clock clock) {
         this.clock = clock;
         this.workorderPartRepository = workorderPartRepository;
@@ -64,6 +67,7 @@ public class WorkorderSubstitutionServiceImpl implements WorkorderSubstitutionSe
         this.idempotencyService = idempotencyService;
         this.objectMapper = objectMapper;
         this.workorderFactPublisher = workorderFactPublisher;
+        this.workorderRepository = workorderRepository;
     }
 
     @Override
@@ -125,6 +129,13 @@ public class WorkorderSubstitutionServiceImpl implements WorkorderSubstitutionSe
             originalPart.setOriginalProductId(originalProductReference);
         }
         workorderPartRepository.save(originalPart);
+        // This substitution only touches workorder_part rows; dirty the workorder row itself so the
+        // publisher's flush has a pending @Version increment to pick up (#1486) — a clean row
+        // leaves the emitted fact carrying the new substitution under an unchanged aggregateVersion.
+        Workorder workorder = workorderRepository.findById(workorderId).orElseThrow(() -> new NoSuchElementException(
+                "Workorder not found: " + workorderId));
+        workorder.setUpdatedAt(Instant.now(clock));
+        workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(workorderId);
 
         WorkorderPart substitutePart = WorkorderPart.builder()

--- a/pos-workorder/src/main/resources/db/migration/V21__workorder_estimate_aggregate_version_columns.sql
+++ b/pos-workorder/src/main/resources/db/migration/V21__workorder_estimate_aggregate_version_columns.sql
@@ -1,0 +1,33 @@
+-- #1486 follow-up: pos-workorder's workorder.events.v1 envelope stamped
+-- Instant.now(clock).toEpochMilli() as aggregateVersion for every WorkorderUpdatedV1 and
+-- EstimateUpdatedV1 fact -- an emission-time value, not the aggregate's own state version, so two
+-- mutations landing in the same millisecond tied. Replaced with JPA optimistic-lock @Version
+-- counters on Workorder and Estimate, so the published sequence strictly advances per committed
+-- mutation and the platform's equal-applies consumer rule (ReplicaVersionGuard) is safe to adopt
+-- for these two facts.
+--
+-- workorder has no existing version column, so it gets a plain `version` BIGINT like the
+-- catalog/location precedent. estimate already has a `version` column, but it is an ordinary
+-- (non-optimistic-lock) integer that tracks estimate revisions as a business concept -- unrelated
+-- to this fact's concurrency counter -- so the new column is named `aggregate_version` instead of
+-- colliding with it (see Estimate.aggregateVersion javadoc).
+--
+-- Both are seeded here, unconditionally, from wall-clock millis at MIGRATION time -- deliberately
+-- NOT from updated_at, mirroring pos-location's V6. The versions consumers currently hold are
+-- EMISSION-time clock millis, which can exceed a row's updated_at by a few milliseconds (the gap
+-- between the mutation commit and the publish call reading the clock); only migration-time now()
+-- upper-bounds every version ever emitted for these facts, so the first post-migration fact
+-- (seed+1 or greater, once flushed) can never regress a replica.
+--
+-- Postgres-only syntax is fine here -- the default test suite runs with Flyway disabled
+-- (ddl-auto: create-drop against H2); only FlywayMigrationIT (Testcontainers Postgres, `verify`
+-- phase, profile `pg`) exercises this migration for real, with Hibernate then validating the
+-- resulting schema against these same entities.
+
+ALTER TABLE workorder ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+UPDATE workorder
+SET version = CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT);
+
+ALTER TABLE estimate ADD COLUMN aggregate_version BIGINT NOT NULL DEFAULT 0;
+UPDATE estimate
+SET aggregate_version = CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT);

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
@@ -94,6 +94,28 @@ class OutboxEventWriterIntegrationTest {
     }
 
     @Test
+    @DisplayName("The explicit-version overload stamps the given aggregateVersion, not emission millis")
+    void explicitVersionOverloadStampsGivenVersion() {
+        // #1486: WorkorderUpdatedV1/EstimateUpdatedV1 are version-guarded and must carry the
+        // entity's flushed @Version rather than the emission-timestamp millis the four-argument
+        // overload stamps.
+        writer.publish(
+                "workorder.work-session.started.v1",
+                WorkSessionStartedEvent.SCHEMA_VERSION,
+                SAMPLE_ID,
+                7L,
+                workSessionStarted());
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        List<OutboxEvent> rows = repository.findTop100ByPublishedAtIsNullOrderByIdAsc();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.getFirst().getPayload()).contains("\"aggregateVersion\":7");
+
+        repository.deleteAll();
+    }
+
+    @Test
     @DisplayName("No outbox row survives when the business transaction rolls back")
     void discardsRowOnRollback() {
         writer.publish(

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImplTest.java
@@ -16,6 +16,7 @@ import com.positivity.workorder.internal.entity.WorkorderPartAdjustmentEvent;
 import com.positivity.workorder.internal.enums.WorkorderItemStatus;
 import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.IdempotencyService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -77,6 +78,9 @@ class WorkorderPartAdjustmentServiceImplTest {
     @Mock
     private PartQuantityDivisibilityService partQuantityDivisibilityService;
 
+    @Mock
+    private WorkorderRepository workorderRepository;
+
     private WorkorderPartAdjustmentServiceImpl service;
 
     @BeforeEach
@@ -87,6 +91,7 @@ class WorkorderPartAdjustmentServiceImplTest {
                 idempotencyService,
                 workorderFactPublisher,
                 partQuantityDivisibilityService,
+                workorderRepository,
                 Clock.fixed(NOW, ZoneOffset.UTC));
 
         UsernamePasswordAuthenticationToken token =
@@ -110,6 +115,7 @@ class WorkorderPartAdjustmentServiceImplTest {
             }
             return event;
         });
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder(WORKORDER_ID)));
     }
 
     @AfterEach

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImplTest.java
@@ -20,6 +20,7 @@ import com.positivity.workorder.internal.enums.SubstitutionStatus;
 import com.positivity.workorder.internal.repository.WorkOrderPartSubstitutionRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.IdempotencyService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -77,6 +78,9 @@ class WorkorderSubstitutionServiceImplTest {
     @Mock
     private WorkorderFactPublisher workorderFactPublisher;
 
+    @Mock
+    private WorkorderRepository workorderRepository;
+
     private WorkorderSubstitutionServiceImpl service;
 
     @BeforeEach
@@ -88,6 +92,7 @@ class WorkorderSubstitutionServiceImplTest {
                 idempotencyService,
                 new ObjectMapper(),
                 workorderFactPublisher,
+                workorderRepository,
                 Clock.fixed(NOW, ZoneOffset.UTC));
 
         UsernamePasswordAuthenticationToken token =
@@ -111,6 +116,9 @@ class WorkorderSubstitutionServiceImplTest {
         });
         when(idempotencyService.getExistingPartAdjustmentEventId(anyString(), anyString()))
                 .thenReturn(Optional.empty());
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
     }
 
     @AfterEach

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
@@ -55,7 +55,11 @@ class WorkorderFactPublisherTest {
     void setUp() {
         when(writerProvider.getIfAvailable()).thenReturn(writer);
         publisher = new WorkorderFactPublisher(
-                writerProvider, workorderRepository, workorderPartRepository, workorderServiceRepository, entityManager);
+                writerProvider,
+                workorderRepository,
+                workorderPartRepository,
+                workorderServiceRepository,
+                entityManager);
         TransactionSynchronizationManager.initSynchronization();
     }
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,6 +20,7 @@ import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
 import com.positivity.workorder.internal.service.WorkorderFactPublisher;
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +47,7 @@ class WorkorderFactPublisherTest {
     private final WorkorderRepository workorderRepository = mock(WorkorderRepository.class);
     private final WorkorderPartRepository workorderPartRepository = mock(WorkorderPartRepository.class);
     private final WorkorderServiceRepository workorderServiceRepository = mock(WorkorderServiceRepository.class);
+    private final EntityManager entityManager = mock(EntityManager.class);
 
     private WorkorderFactPublisher publisher;
 
@@ -52,7 +55,7 @@ class WorkorderFactPublisherTest {
     void setUp() {
         when(writerProvider.getIfAvailable()).thenReturn(writer);
         publisher = new WorkorderFactPublisher(
-                writerProvider, workorderRepository, workorderPartRepository, workorderServiceRepository);
+                writerProvider, workorderRepository, workorderPartRepository, workorderServiceRepository, entityManager);
         TransactionSynchronizationManager.initSynchronization();
     }
 
@@ -78,6 +81,7 @@ class WorkorderFactPublisherTest {
                 .id(workorderId)
                 .workorderNumber("WO-2026-1001")
                 .status(WorkorderStatus.WORK_IN_PROGRESS)
+                .version(3L)
                 .build();
         WorkorderPart part = WorkorderPart.builder()
                 .id(UUID.randomUUID())
@@ -91,12 +95,17 @@ class WorkorderFactPublisherTest {
         publisher.markChanged(workorderId);
         fireBeforeCommit();
 
+        // Flushed once before assembling any payload, so the pending @Version increment from this
+        // transaction's mutations is already reflected in the emitted fact (#1486).
+        verify(entityManager, times(1)).flush();
+
         ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
         verify(writer, times(1))
                 .publish(
                         eq(WorkorderUpdatedV1.EVENT_TYPE),
                         eq(WorkorderUpdatedV1.SCHEMA_VERSION),
                         eq(workorderId),
+                        eq(3L),
                         payloadCaptor.capture());
         WorkorderUpdatedV1 fact = (WorkorderUpdatedV1) payloadCaptor.getValue();
         assertThat(fact.workorderNumber()).isEqualTo("WO-2026-1001");
@@ -114,5 +123,6 @@ class WorkorderFactPublisherTest {
         fireBeforeCommit();
 
         verify(writer, never()).publish(any(), anyInt(), any(), any());
+        verify(writer, never()).publish(any(), anyInt(), any(), anyLong(), any());
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderItemCompletionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderItemCompletionTest.java
@@ -13,14 +13,19 @@ import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.entity.WorkorderServiceLine;
 import com.positivity.workorder.internal.enums.WorkorderItemStatus;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
 import com.positivity.workorder.internal.service.WorkorderServiceImpl;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -38,8 +43,14 @@ class WorkorderItemCompletionTest {
     @Mock
     private WorkorderPartRepository workorderPartRepository;
 
+    @Mock
+    private WorkorderRepository workorderRepository;
+
     @org.mockito.Mock
     private com.positivity.workorder.internal.service.WorkorderFactPublisher workorderFactPublisher;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-08-25T12:00:00Z"), ZoneOffset.UTC);
 
     @InjectMocks
     private WorkorderServiceImpl service;
@@ -110,12 +121,17 @@ class WorkorderItemCompletionTest {
     @Test
     void completePartItem_marksOpenPartCompleted() {
         when(workorderPartRepository.findById(ITEM)).thenReturn(Optional.of(part(WorkorderItemStatus.OPEN, WORKORDER)));
+        when(workorderRepository.findById(WORKORDER))
+                .thenReturn(Optional.of(Workorder.builder().id(WORKORDER).build()));
 
         WorkorderItemCompletionResponse res = service.completePartItem(WORKORDER, ITEM, "tech");
 
         assertThat(res.getStatus()).isEqualTo(WorkorderItemStatus.COMPLETED);
         assertThat(res.getItemType()).isEqualTo(WorkorderItemCompletionResponse.ItemType.PART);
         verify(workorderPartRepository).save(any());
+        // Dirties the workorder row itself (#1486) so the publisher's flush has a pending @Version
+        // increment to pick up — this write only touches workorder_part.
+        verify(workorderRepository).save(any());
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (event-semantics remediation, no cap id)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1486 (follow-up to merged #1511)
- Domain: `domain:workorder` + `domain:customer` (plus consumer guards in pos-order and pos-accounting)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/workorder/.business-rules/BACKEND_CONTRACT_GUIDE.md` / `domains/customer/.business-rules/BACKEND_CONTRACT_GUIDE.md` — the `aggregateVersion` envelope semantics changed here are documented in `docs/ARCHITECTURE_GUIDE.md` § "Event Replication: `aggregateVersion` Semantics"; no request/response DTO shape changed.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed:
  - **pos-workorder**: JPA `@Version` on `Workorder` (`version`) and `Estimate` (`aggregate_version` — `Estimate` already had an unrelated manual `version` revision counter, so the optimistic-lock column gets its own name). Migration `V21` adds and seeds both from migration-time wall-clock millis (old versions were emission-time, so `updated_at` would not upper-bound them). `OutboxEventWriter` gains an explicit-version `publish` overload; `WorkorderFactPublisher`/`EstimateFactPublisher` flush and publish the entity version. Ten call sites that mutated only child tables (part usage, substitutions, adjustments, estimate items, item completion) now dirty the aggregate row before publishing, so the version actually advances with the content. Facts nothing version-guards (service-completion, fleet-auth, time/work-session) stay on the emission-timestamp hint, documented.
  - **pos-customer**: `@Version` on `AbstractParty` (TABLE_PER_CLASS root — `person_party` and `commercial_party` each get the seeded column via `V30`). `CustomerFactPublisher` flushes and publishes `party.getVersion()`; party deletes tombstone `version + 1`; billing-rules facts (embedded on the party row, so mutations dirty it for free) publish the same version stream. Fixed a dirty-row hazard in `personReplicaChanged`, which re-emitted the party fact after a side-table change without advancing the version. Tag/segment/suppression/consent/redemption facts stay on emission millis — no consumer version-guards them.
  - **Consumers**: pos-order's `WorkorderEventsListener` (workorder + estimate) and `CustomerEventsListener` (party + billing rules) flip `>=` to `ReplicaVersionGuard` (equal applies); pos-accounting's `CustomerEventsListener` does the same and retires the legacy `aggregateVersion > 0` carve-out for versionless envelopes — under the new contract a v0 fact is unambiguously legacy/malformed, pinned by a test.
  - **Docs**: the survey table in `docs/ARCHITECTURE_GUIDE.md` now shows every version-guarded fact on the strictly-advancing contract; nothing is scoped out; `ReplicaVersionGuard`'s javadoc lists all seven fact families.
- Why: completes #1486. Merged #1511 fixed catalog and location; workorder and customer facts still stamped wall-clock millis, which can tie inside a millisecond, so their consumers had to keep skip-on-equal guards — leaving the last of the `>` / `>=` split and blocking replay-as-repair from ever working on those topics.

## Tests
- [x] Unit tests added/updated — publisher tests assert flush + version emission and the party tombstone; dirty-row fixes covered (workorder part flows, `personReplicaChangedDirtiesTheRowFirst`); listener tests flip to strictly-older naming and add equal-version-applies cases for workorder, estimate, party, and billing rules; a test pins that v0 legacy envelopes are now stale against any real held version.
- [ ] Integration tests added/updated — none; note `pos-workorder`/`pos-customer` have Testcontainers-based `FlywayMigrationIT`s (Failsafe `verify` phase, Docker) that will validate `V21`/`V30` against real Postgres in CI/environments that run them; not runnable in this session.
- [ ] Provider behavioral contract tests added/updated — n/a; envelope schema unchanged, only the version source.
- How to run: `./mvnw -pl pos-workorder,pos-customer,pos-accounting,pos-order,pos-domain-events test` and `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` (all green locally: 954 + 705 + 1320 + 544 tests, ArchUnit 16/16).

## Risk & Rollback
- Risk level: Medium — adds optimistic locking to three aggregate roots (including the party hierarchy) and changes stale-guard behavior in three consuming services. Mitigations: migration-time `now()` seeding guarantees no published version regresses below what replicas hold; detached-save audits found no hazardous save paths (all root-aggregate writes are load-and-mutate or genuinely new); the dirty-row audit covered every publisher call site; equal-applies is an idempotent overwrite for live traffic.
- Rollback plan: revert the PR. `V21`/`V30` only add/update bigint columns the reverted code ignores; consumers revert to their previous guards.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, no capability; #1486 follow-up branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present (#1486)
- [x] Contract guide updated (when contract semantics changed) — `docs/ARCHITECTURE_GUIDE.md` survey + rule updated
- [ ] Required CI checks passing — pending first run on this PR

Refs #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCEqZW4MVbUgxXpWuVk31Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCEqZW4MVbUgxXpWuVk31Q)_