### PR TITLE
Give role_permissions a provenance trail (granted_at / granted_by)

### DIFF
--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/RoleRepository.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/RoleRepository.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -66,8 +67,8 @@ public interface RoleRepository extends JpaRepository<Role, UUID> {
                     + " WHERE role_id = :roleId AND permission_id IN (:permissionIds)",
             nativeQuery = true)
     int recordGrantProvenance(
-            @Param("roleId") UUID roleId,
-            @Param("permissionIds") Collection<UUID> permissionIds,
-            @Param("grantedBy") String grantedBy,
-            @Param("grantedAt") Instant grantedAt);
+            @Param("roleId") @NonNull UUID roleId,
+            @Param("permissionIds") @NonNull Collection<UUID> permissionIds,
+            @Param("grantedBy") @NonNull String grantedBy,
+            @Param("grantedAt") @NonNull Instant grantedAt);
 }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/RoleRepository.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/RoleRepository.java
@@ -1,11 +1,13 @@
 package com.positivity.securityservice.internal.repository;
 
 import com.positivity.securityservice.internal.entity.Role;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,4 +40,34 @@ public interface RoleRepository extends JpaRepository<Role, UUID> {
      */
     @Query("SELECT DISTINCT p.name FROM Role r JOIN r.permissions p WHERE UPPER(r.name) IN :names")
     Set<String> findPermissionNamesByRoleNames(@Param("names") Collection<String> names);
+
+    /**
+     * Records who granted a role-permission row and when (#1512).
+     *
+     * <p>Native because {@code role_permissions} is mapped as a plain {@code @ManyToMany} join
+     * table on {@link Role#getPermissions()}; Hibernate writes only the two key columns, so the
+     * provenance columns V30 added are unreachable through the entity model. Restructuring the
+     * association into an entity would change how every caller reads grants, for two columns
+     * nothing in the resolution path consults.
+     *
+     * <p>{@code flushAutomatically} matters: the join-table INSERT is still pending in the
+     * persistence context when this runs, and without the flush the UPDATE would match no row.
+     *
+     * <p>Callers must pass only permissions the call actually added. Re-stamping a grant that
+     * was already there would rewrite history: the actor who re-asserted an existing permission
+     * is not the actor who granted it.
+     *
+     * @param permissionIds permissions newly granted to the role in this transaction
+     * @return the number of grant rows stamped
+     */
+    @Modifying(flushAutomatically = true)
+    @Query(
+            value = "UPDATE role_permissions SET granted_at = :grantedAt, granted_by = :grantedBy"
+                    + " WHERE role_id = :roleId AND permission_id IN (:permissionIds)",
+            nativeQuery = true)
+    int recordGrantProvenance(
+            @Param("roleId") UUID roleId,
+            @Param("permissionIds") Collection<UUID> permissionIds,
+            @Param("grantedBy") String grantedBy,
+            @Param("grantedAt") Instant grantedAt);
 }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleManagementServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleManagementServiceImpl.java
@@ -97,13 +97,26 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             permissions.add(permission);
         }
 
+        // #1512: only the permissions this call adds get stamped. Ones the role already held
+        // keep their original grantor — re-submitting a list is not re-granting what was in it.
+        Set<UUID> alreadyHeld =
+                role.getPermissions().stream().map(Permission::getId).collect(Collectors.toSet());
+        Set<UUID> newlyGranted = permissions.stream()
+                .map(Permission::getId)
+                .filter(id -> !alreadyHeld.contains(id))
+                .collect(Collectors.toSet());
+
         role.setPermissions(permissions);
         role.setLastModifiedBy(getCurrentUsername());
         role.setLastModifiedAt(Instant.now(clock));
 
         log.info("Updated permissions for role {}: {} permissions assigned", role.getName(), permissions.size());
 
-        return toRoleDto(roleRepository.save(role));
+        RoleDto dto = toRoleDto(roleRepository.save(role));
+        if (!newlyGranted.isEmpty()) {
+            roleRepository.recordGrantProvenance(role.getId(), newlyGranted, getCurrentUsername(), Instant.now(clock));
+        }
+        return dto;
     }
 
     /**
@@ -331,10 +344,14 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                 .findByName(permissionKey)
                 .orElseThrow(() -> new PermissionNotFoundException(
                         "Permission not found: " + permissionKey + ". It must be registered first."));
-        role.getPermissions().add(permission);
+        boolean newGrant = role.getPermissions().add(permission);
         role.setLastModifiedBy(getCurrentUsername());
         role.setLastModifiedAt(Instant.now(clock));
         roleRepository.save(role);
+        if (newGrant) {
+            roleRepository.recordGrantProvenance(
+                    roleId, List.of(permission.getId()), getCurrentUsername(), Instant.now(clock));
+        }
     }
 
     @Override

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RolePermissionServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RolePermissionServiceImpl.java
@@ -13,6 +13,7 @@ import com.positivity.securityservice.internal.repository.RoleRepository;
 import com.positivity.securityservice.service.RolePermissionService;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -70,11 +71,21 @@ public class RolePermissionServiceImpl implements RolePermissionService {
             return permissionRepository.save(created);
         });
 
-        role.getPermissions().add(permission);
+        boolean newGrant = role.getPermissions().add(permission);
         Role savedRole = roleRepository.save(role);
 
+        String actor = getCurrentActor();
+        Instant grantedAt = Instant.now(clock);
+
+        // #1512: stamp provenance onto the join-table row itself. The audit event below is
+        // fire-and-forget; the row is what a later investigator queries. Only for a genuinely
+        // new grant — re-granting an existing permission must not overwrite who first made it.
+        if (newGrant) {
+            roleRepository.recordGrantProvenance(roleId, List.of(permission.getId()), actor, grantedAt);
+        }
+
         applicationEventPublisher.publishEvent(
-                new RolePermissionGrantAuditEvent(this, getCurrentActor(), roleId, permissionKey, Instant.now(clock)));
+                new RolePermissionGrantAuditEvent(this, actor, roleId, permissionKey, grantedAt));
 
         return toRoleDto(savedRole);
     }

--- a/pos-security-service/src/main/resources/db/migration/V30__add_role_permission_audit_columns.sql
+++ b/pos-security-service/src/main/resources/db/migration/V30__add_role_permission_audit_columns.sql
@@ -1,0 +1,55 @@
+-- #1512: give role_permissions a provenance trail.
+--
+-- The table was created by V1 as a bare join table -- (role_id, permission_id)
+-- as the primary key and two foreign keys, nothing else. Every other RBAC table
+-- carries audit columns: roles and role_assignments have created_at/created_by,
+-- permissions has registered_at/registered_by_service. The one table that
+-- records actual authority had no record of who granted it or when.
+--
+-- That gap is what made the alpha investigation in #1512 expensive. An
+-- out-of-band grant gave SYSTEM_ADMINISTRATOR 398 permissions -- every row then
+-- in the permissions table, against a seed that grants it 40. Establishing that
+-- much took cross-referencing the Flyway history, per-service registration
+-- timestamps and the catalog bit indexes, and even then the actor is still
+-- unknown, because the database never recorded one. With these columns the same
+-- question is a single SELECT.
+--
+-- Column semantics:
+--
+--   granted_at  NULL means the row predates this migration. Existing rows are
+--               deliberately left NULL rather than stamped with NOW(): their
+--               real grant time is unknown and inventing one would defeat the
+--               purpose of an audit column. The DEFAULT is attached after the
+--               backfill precisely so that ADD COLUMN does not apply it to
+--               existing rows.
+--
+--   granted_by  NULL means the row was written by something other than the
+--               role-permission admin API -- the Flyway seeds, a psql session,
+--               or an out-of-band script. That is a signal, not a defect: a
+--               grant nobody can be named for is exactly the case #1512 is
+--               about. Rows that existed before this migration are marked
+--               'pre-v30-unattributed' to keep them distinguishable from
+--               unattributed rows written after it.
+--
+-- Both columns are nullable and neither is written by Hibernate's @ManyToMany
+-- mapping of Role.permissions, so an insert through the entity model continues
+-- to work unchanged and picks up the granted_at default.
+
+ALTER TABLE role_permissions
+    ADD COLUMN IF NOT EXISTS granted_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS granted_by VARCHAR(255);
+
+-- Mark pre-existing grants as unattributed. Runs before the DEFAULT is set, so
+-- granted_at stays NULL for them.
+UPDATE role_permissions
+SET granted_by = 'pre-v30-unattributed'
+WHERE granted_by IS NULL;
+
+ALTER TABLE role_permissions
+    ALTER COLUMN granted_at SET DEFAULT NOW();
+
+COMMENT ON COLUMN role_permissions.granted_at IS
+    'When the grant was written. NULL for rows predating V30.';
+
+COMMENT ON COLUMN role_permissions.granted_by IS
+    'Actor that granted the permission via the admin API. NULL when written by a seed, direct SQL, or an out-of-band script; ''pre-v30-unattributed'' for rows predating V30.';

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/RoleManagementServiceTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/RoleManagementServiceTest.java
@@ -3,6 +3,7 @@ package com.positivity.securityservice.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -302,7 +303,9 @@ class RoleManagementServiceTest {
             Role role = new Role();
             role.setId(ROLE_ID);
             role.setPermissions(new HashSet<>());
+            UUID permissionId = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
             Permission perm = new Permission();
+            perm.setId(permissionId);
             perm.setName(permissionKey);
             when(roleRepository.findById(ROLE_ID)).thenReturn(Optional.of(role));
             when(permissionRepository.findByName(permissionKey)).thenReturn(Optional.of(perm));
@@ -314,6 +317,9 @@ class RoleManagementServiceTest {
             assertThat(role.getLastModifiedBy()).isEqualTo("rbac-admin");
             assertThat(role.getLastModifiedAt()).isEqualTo(Instant.now(TEST_CLOCK));
             verify(roleRepository).save(role);
+            // #1512: the grant row records the actor, not only the role's lastModifiedBy.
+            verify(roleRepository)
+                    .recordGrantProvenance(eq(ROLE_ID), eq(List.of(permissionId)), eq("rbac-admin"), any());
         }
 
         /**

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/RolePermissionServiceImplTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/RolePermissionServiceImplTest.java
@@ -2,6 +2,7 @@ package com.positivity.securityservice.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,6 +17,7 @@ import com.positivity.securityservice.internal.repository.RoleRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -115,7 +117,9 @@ class RolePermissionServiceImplTest {
             role.setId(roleId);
             role.setPermissions(new java.util.HashSet<>());
 
+            UUID permissionId = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
             Permission permission = new Permission();
+            permission.setId(permissionId);
             permission.setName(permissionKey);
 
             when(roleRepository.findById(roleId)).thenReturn(Optional.of(role));
@@ -126,6 +130,8 @@ class RolePermissionServiceImplTest {
 
             assertThat(result.getPermissions()).extracting("name").contains(permissionKey);
             verify(applicationEventPublisher).publishEvent(any());
+            // #1512: the grant row itself records who made it, not just the audit event.
+            verify(roleRepository).recordGrantProvenance(eq(roleId), eq(List.of(permissionId)), any(), any());
         }
 
         @Test
@@ -140,7 +146,12 @@ class RolePermissionServiceImplTest {
 
             when(roleRepository.findById(roleId)).thenReturn(Optional.of(role));
             when(permissionRepository.findByName(permissionKey)).thenReturn(Optional.empty());
-            when(permissionRepository.save(any(Permission.class))).thenAnswer(invocation -> invocation.getArgument(0));
+            // Mirrors JPA: a persisted permission comes back with a generated identifier.
+            when(permissionRepository.save(any(Permission.class))).thenAnswer(invocation -> {
+                Permission saved = invocation.getArgument(0);
+                saved.setId(UUID.fromString("00000000-0000-0000-0000-0000000000a2"));
+                return saved;
+            });
             when(roleRepository.save(any(Role.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
             RoleDto result = sut.grantPermission(roleId, permissionKey);

--- a/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionAuditColumnsIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionAuditColumnsIT.java
@@ -1,0 +1,234 @@
+package com.positivity.securityservice.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.securityservice.internal.dto.RolePermissionsRequest;
+import com.positivity.securityservice.internal.repository.PermissionRepository;
+import com.positivity.securityservice.service.RoleManagementService;
+import com.positivity.securityservice.service.RolePermissionService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Covers the {@code role_permissions} provenance columns added by V30 (#1512).
+ *
+ * <p>Only observable against a real Postgres: the default test profile runs on H2 with Flyway
+ * disabled, so neither the migration nor the {@code granted_at} column default exists there.
+ *
+ * <p>The properties worth pinning are the ones that made the alpha investigation expensive.
+ * A grant written outside the admin API must still be dated, or an out-of-band grant leaves no
+ * trace at all; and it must be distinguishable from an attributed one, or "nobody knows who did
+ * this" reads the same as "the API did it".
+ *
+ * <p>Requires Docker.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("pg")
+@Testcontainers
+@DisplayName("role_permissions provenance columns (Postgres)")
+class RolePermissionAuditColumnsIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private static final String PROVENANCE_QUERY =
+            "SELECT granted_at, granted_by FROM role_permissions WHERE role_id = ? AND permission_id = ?";
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private RolePermissionService rolePermissionService;
+
+    @Autowired
+    private RoleManagementService roleManagementService;
+
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    private UUID roleId;
+
+    @DynamicPropertySource
+    static void seedPlaceholders(DynamicPropertyRegistry registry) {
+        registry.add("SECURITY_SEED_ADMIN_PASSWORD_HASH", () -> "not-a-real-hash-pg-test-only");
+    }
+
+    @AfterEach
+    void cleanUp() {
+        SecurityContextHolder.clearContext();
+        if (roleId != null) {
+            JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+            jdbc.update("DELETE FROM role_permissions WHERE role_id = ?", roleId);
+            jdbc.update("DELETE FROM roles WHERE id = ?", roleId);
+            roleId = null;
+        }
+    }
+
+    @Test
+    @DisplayName("both columns exist and are nullable, and granted_at defaults to now()")
+    void columnsExistWithExpectedShape() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        Map<String, Object> grantedAt =
+                jdbc.queryForMap("SELECT data_type, is_nullable, column_default FROM information_schema.columns"
+                        + " WHERE table_name = 'role_permissions' AND column_name = 'granted_at'");
+        assertThat(grantedAt.get("data_type")).isEqualTo("timestamp with time zone");
+        assertThat(grantedAt.get("is_nullable")).isEqualTo("YES");
+        assertThat((String) grantedAt.get("column_default")).containsIgnoringCase("now()");
+
+        Map<String, Object> grantedBy =
+                jdbc.queryForMap("SELECT data_type, is_nullable, column_default FROM information_schema.columns"
+                        + " WHERE table_name = 'role_permissions' AND column_name = 'granted_by'");
+        assertThat(grantedBy.get("data_type")).isEqualTo("character varying");
+        assertThat(grantedBy.get("is_nullable")).isEqualTo("YES");
+        assertThat(grantedBy.get("column_default"))
+                .as("a default would attribute unattributed writes")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("a grant written outside the admin API is dated but not attributed")
+    void rawInsertIsDatedAndUnattributed() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        roleId = insertRole(jdbc, "IT_PROVENANCE_RAW");
+        UUID permissionId = anyPermissionId(jdbc);
+
+        // Exactly the shape of an out-of-band grant: the two key columns and nothing else.
+        jdbc.update("INSERT INTO role_permissions (role_id, permission_id) VALUES (?, ?)", roleId, permissionId);
+
+        Map<String, Object> row = jdbc.queryForMap(PROVENANCE_QUERY, roleId, permissionId);
+        assertThat(row.get("granted_at"))
+                .as("the column default must date a write that names no actor")
+                .isNotNull();
+        assertThat(row.get("granted_by"))
+                .as("nothing may attribute a grant the API did not make")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("a grant through the admin API records the authenticated actor")
+    void adminApiGrantRecordsActor() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        roleId = insertRole(jdbc, "IT_PROVENANCE_API");
+        String permissionName = anyPermissionName(jdbc);
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(
+                        "grant.auditor", "n/a", AuthorityUtils.createAuthorityList("security:role:edit")));
+
+        Instant before = Instant.now();
+        rolePermissionService.grantPermission(roleId, permissionName);
+
+        UUID permissionId =
+                permissionRepository.findByName(permissionName).orElseThrow().getId();
+        Map<String, Object> row = jdbc.queryForMap(PROVENANCE_QUERY, roleId, permissionId);
+
+        assertThat(row.get("granted_by")).isEqualTo("grant.auditor");
+        assertThat(((java.sql.Timestamp) row.get("granted_at")).toInstant()).isAfterOrEqualTo(before.minusSeconds(5));
+    }
+
+    @Test
+    @DisplayName("re-granting an existing permission keeps the original grantor")
+    void regrantDoesNotOverwriteOriginalGrantor() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        roleId = insertRole(jdbc, "IT_PROVENANCE_REGRANT");
+        String permissionName = anyPermissionName(jdbc);
+        UUID permissionId =
+                permissionRepository.findByName(permissionName).orElseThrow().getId();
+
+        authenticateAs("first.grantor");
+        rolePermissionService.grantPermission(roleId, permissionName);
+
+        authenticateAs("second.grantor");
+        rolePermissionService.grantPermission(roleId, permissionName);
+
+        Map<String, Object> row = jdbc.queryForMap(PROVENANCE_QUERY, roleId, permissionId);
+        assertThat(row.get("granted_by"))
+                .as("the first grant is the one that changed the role's authority")
+                .isEqualTo("first.grantor");
+    }
+
+    @Test
+    @DisplayName("a bulk permission update stamps only the permissions it adds")
+    void bulkUpdateStampsOnlyNewGrants() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        roleId = insertRole(jdbc, "IT_PROVENANCE_BULK");
+        List<String> names = twoPermissionNames(jdbc);
+        String held = names.get(0);
+        String added = names.get(1);
+
+        authenticateAs("first.grantor");
+        rolePermissionService.grantPermission(roleId, held);
+
+        // The bulk endpoint re-submits the full list, so the already-held permission appears in
+        // the request. Re-asserting it is not re-granting it.
+        authenticateAs("bulk.editor");
+        RolePermissionsRequest request = new RolePermissionsRequest();
+        request.setRoleId(roleId);
+        request.setPermissionNames(Set.of(held, added));
+        roleManagementService.updateRolePermissions(request);
+
+        assertThat(grantorOf(jdbc, held))
+                .as("a permission the role already held keeps its original grantor")
+                .isEqualTo("first.grantor");
+        assertThat(grantorOf(jdbc, added))
+                .as("the permission this call actually added is attributed to its caller")
+                .isEqualTo("bulk.editor");
+    }
+
+    private String grantorOf(JdbcTemplate jdbc, String permissionName) {
+        UUID permissionId =
+                permissionRepository.findByName(permissionName).orElseThrow().getId();
+        return (String) jdbc.queryForMap(PROVENANCE_QUERY, roleId, permissionId).get("granted_by");
+    }
+
+    private List<String> twoPermissionNames(JdbcTemplate jdbc) {
+        return jdbc.queryForList("SELECT name FROM permissions ORDER BY name LIMIT 2", String.class);
+    }
+
+    private void authenticateAs(String username) {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(
+                        username, "n/a", AuthorityUtils.createAuthorityList("security:role:edit")));
+    }
+
+    private UUID insertRole(JdbcTemplate jdbc, String name) {
+        UUID id = UUID.randomUUID();
+        jdbc.update(
+                "INSERT INTO roles (id, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), ?)",
+                id,
+                name,
+                "provenance integration test",
+                "RolePermissionAuditColumnsIT");
+        return id;
+    }
+
+    private UUID anyPermissionId(JdbcTemplate jdbc) {
+        return jdbc.queryForObject("SELECT id FROM permissions ORDER BY name LIMIT 1", UUID.class);
+    }
+
+    private String anyPermissionName(JdbcTemplate jdbc) {
+        return jdbc.queryForObject("SELECT name FROM permissions ORDER BY name LIMIT 1", String.class);
+    }
+}


### PR DESCRIPTION
> ⚠️ **Version-number collision risk.** A separate session is reworking seed data. This adds **V30**. If that work also lands a V30, Flyway fails loudly at build rather than silently — but it is worth coordinating before merge. Nothing seed-related is touched here: no `R__seed_*.sql`, no `permissions.yaml`, no `PermissionCode`.

## Capability & Traceability
- Capability: n/a (RBAC audit remediation; follows #1515, #1516, #1517, #1518, #1520)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1512
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/security/.business-rules/BACKEND_CONTRACT_GUIDE.md` — **no contract change.** No controller, DTO, `*Request`/`*Response`, event payload, validation model or `openapi.yaml` is touched. The two new columns are internal persistence detail; they are not exposed on any response and nothing in the authority-resolution path reads them.
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

**What changed:** `role_permissions` gets `granted_at` and `granted_by`, and all three admin write paths populate them.

**Why:** `V1__baseline_rbac_schema.sql:31-39` created the table as a bare join table — `(role_id, permission_id)` as the primary key, two foreign keys, nothing else. Every other RBAC table carries provenance: `roles` and `role_assignments` have `created_at`/`created_by`, `permissions` has `registered_at`/`registered_by_service`. The one table that records actual authority recorded nothing about how it got there.

That gap is what made the alpha investigation in #1512 expensive. An out-of-band grant gave `SYSTEM_ADMINISTRATOR` **398** permissions against a seed that grants it **40**, and pinning that down took cross-referencing the Flyway history, per-service registration timestamps and the `PermissionCode` bit indexes. The actor is *still* unknown, because nothing ever recorded one. With `granted_at` alone the grant would have been dated to the minute instead of narrowed to a 1.5-day window by inference.

### The NULL semantics are the design, not an oversight

| Column | NULL means |
|---|---|
| `granted_at` | The row predates this migration. |
| `granted_by` | The row was written by something other than the admin API — a seed, a `psql` session, an out-of-band script. |

Two deliberate calls follow from that:

**Existing rows keep `granted_at` NULL rather than being stamped with `NOW()`.** Their real grant time is unknown and inventing one defeats the purpose of an audit column. The `DEFAULT` is attached *after* the backfill precisely so `ADD COLUMN` does not apply it retroactively. Every future write is dated regardless of who makes it.

**`granted_by` gets no default.** A default would attribute unattributed writes, which is the failure mode this is meant to expose. An unattributed grant is a signal, not a defect. Rows predating the migration are marked `'pre-v30-unattributed'` so they stay distinguishable from unattributed rows written *after* it — on alpha that separates the 398 mystery rows from anything new.

### Three write paths, not one

The obvious one is `RolePermissionServiceImpl.grantPermission`. `RoleManagementServiceImpl` has two more — `assignPermissionToRole` and `updateRolePermissions`. **Stamping only the first would have been worse than adding no column at all**, because real API grants would then look identical to out-of-band ones and the NULL signal above would be noise.

Each path stamps **only the permissions the call actually adds**. Re-granting a permission the role already holds, or re-submitting it inside a bulk `updateRolePermissions` list, must not rewrite who granted it first — the actor who re-asserts an existing grant is not the actor who made it.

### Why the write is a native UPDATE

`role_permissions` is mapped as a plain `@ManyToMany` join table on `Role.permissions` (`Role.java:36-41`), so Hibernate writes only the two key columns and the new ones are unreachable through the entity model. Promoting the association to an entity would change how every caller reads grants, for two columns nothing in the authority-resolution path consults. `flushAutomatically = true` is load-bearing: the join-table INSERT is still pending in the persistence context when the UPDATE runs, and without the flush it would match no row.

## Tests
- [x] Unit tests added/updated — two fixtures (`RolePermissionServiceImplTest`, `RoleManagementServiceTest`) built a `Permission` with no identifier to stand in for a persisted row; both now set one, matching what the repository actually returns. Each gains a `verify` that the grant row is stamped, not just that the audit event fires.
- [x] Integration tests added/updated — new `RolePermissionAuditColumnsIT` (Testcontainers Postgres, `pg` profile): column shape and the `now()` default; a raw INSERT is dated but unattributed; an admin-API grant records the authenticated actor; a re-grant keeps the original grantor; a bulk update stamps only what it adds.
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run:
  - `./mvnw -pl pos-security-service -am -DskipTests=false test` → **492 pass**
  - `python3 scripts/audit-rbac.py --check` → exit 0
  - `./mvnw -pl pos-security-service -am verify -Dit.test=RolePermissionAuditColumnsIT` (requires Docker)

⚠️ **The new IT has not been executed.** No Docker daemon was available in the authoring environment, so `RolePermissionAuditColumnsIT` — like the existing `RolePermissionSeedIT` — is unverified locally. CI is the first place it runs. The migration SQL is likewise unexecuted; it is Postgres-only syntax (`COMMENT ON COLUMN`, `ADD COLUMN IF NOT EXISTS`) and the H2 profile disables Flyway, so CI's Testcontainers run is the first real application.

## Risk & Rollback
- Risk level: **Low**. Both columns are nullable with no NOT NULL constraint, so no existing insert path can fail on them. Hibernate's `@ManyToMany` mapping writes neither column, so entity-model inserts are unchanged and simply pick up the `granted_at` default. `ddl-auto: validate` on the `pg` profile does not object to columns absent from the entity. No permission, grant, role or bit index changes — `audit-rbac.py --check` reports no drift.
- Rollback plan: revert the PR, then `ALTER TABLE role_permissions DROP COLUMN granted_at, DROP COLUMN granted_by;` if the columns need to go. Reverting the code alone is safe on its own — the columns simply stop being populated and no read path depends on them.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — audit remediation, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id for this sweep
- [x] Links to parent + child issues are present (#1512)
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending first run

### What this does not do

It does not answer **who** made the alpha grant — that mechanism is external to this repository and remains open on #1512. This closes the gap that made the question hard to answer, so the next occurrence names itself. The policy question is also still open: `SYSTEM_ADMINISTRATOR` is documented as deliberately *not* a superuser, and alpha's 358 extra rows either need a versioned revoke or the decision needs revising in `R__seed_role_permissions.sql` where the audit and the CI gate can see it.

Worth noting for a reviewer: the #1518 CI gate reads the **seed**, so it cannot see runtime grants at all. Proving a *running environment* matches the seed is a different check than the one that exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQLHEJnxCa3LaXsxUco1fM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQLHEJnxCa3LaXsxUco1fM)_