### PR TITLE
Fix the two provenance defects that broke main (#1526 follow-up)

### DIFF
--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleManagementServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleManagementServiceImpl.java
@@ -106,7 +106,13 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                 .filter(id -> !alreadyHeld.contains(id))
                 .collect(Collectors.toSet());
 
-        role.setPermissions(permissions);
+        // Mutate the managed collection rather than replacing it. Assigning a new Set
+        // dereferences the persistent collection, and Hibernate answers that by deleting every
+        // join row and re-inserting the survivors — which silently resets granted_at/granted_by
+        // on permissions the role already held. Mutating in place issues targeted inserts and
+        // deletes, so untouched rows keep their provenance.
+        role.getPermissions().retainAll(permissions);
+        role.getPermissions().addAll(permissions);
         role.setLastModifiedBy(getCurrentUsername());
         role.setLastModifiedAt(Instant.now(clock));
 

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/RolePermissionProvenanceTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/RolePermissionProvenanceTest.java
@@ -1,0 +1,183 @@
+package com.positivity.securityservice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.securityservice.PosSecurityServiceApplication;
+import com.positivity.securityservice.internal.dto.RolePermissionsRequest;
+import com.positivity.securityservice.internal.entity.Permission;
+import com.positivity.securityservice.internal.repository.PermissionRepository;
+import com.positivity.securityservice.service.RoleManagementService;
+import com.positivity.securityservice.service.RolePermissionService;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Pins who a role-permission grant is attributed to (#1512).
+ *
+ * <p>Deliberately a surefire test on H2 rather than only a Postgres IT. The failsafe ITs run on
+ * main but are skipped on pull requests, and the bug this class exists to prevent — a bulk update
+ * silently resetting the provenance of permissions the role already held — reached main precisely
+ * because nothing exercised it earlier. The columns are present here because
+ * {@code src/test/resources/schema.sql} mirrors V30 into the generated H2 schema.
+ *
+ * <p>{@code RolePermissionAuditColumnsIT} still covers what only a real Postgres can show: the
+ * migration's own DDL, column types and the {@code granted_at} default.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        classes = PosSecurityServiceApplication.class,
+        properties = {"security.jwt.secret=test-jwt-secret-key-01234567890123456789"})
+@ActiveProfiles("test")
+@DisplayName("role-permission grant provenance")
+class RolePermissionProvenanceTest {
+
+    private static final String PROVENANCE_QUERY =
+            "SELECT granted_by FROM role_permissions WHERE role_id = ? AND permission_id = ?";
+
+    @MockitoBean
+    private TokenRevocationManager tokenRevocationManager;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private RolePermissionService rolePermissionService;
+
+    @Autowired
+    private RoleManagementService roleManagementService;
+
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    private JdbcTemplate jdbc;
+    private UUID roleId;
+
+    @BeforeEach
+    void setUp() {
+        jdbc = new JdbcTemplate(dataSource);
+        roleId = UUID.randomUUID();
+        jdbc.update(
+                "INSERT INTO roles (id, name, description, created_at, created_by) VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)",
+                roleId,
+                "TEST_PROVENANCE_" + roleId.toString().substring(0, 8),
+                "provenance test",
+                "RolePermissionProvenanceTest");
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        jdbc.update("DELETE FROM role_permissions WHERE role_id = ?", roleId);
+        jdbc.update("DELETE FROM roles WHERE id = ?", roleId);
+    }
+
+    @Test
+    @DisplayName("a grant through the admin API records the authenticated actor")
+    void grantRecordsActor() {
+        authenticateAs("grant.auditor");
+        String permission = registerPermission("provenance:single:grant");
+
+        rolePermissionService.grantPermission(roleId, permission);
+
+        assertThat(grantorOf(permission)).isEqualTo("grant.auditor");
+    }
+
+    @Test
+    @DisplayName("re-granting an existing permission keeps the original grantor")
+    void regrantKeepsOriginalGrantor() {
+        String permission = registerPermission("provenance:regrant:grant");
+
+        authenticateAs("first.grantor");
+        rolePermissionService.grantPermission(roleId, permission);
+
+        authenticateAs("second.grantor");
+        rolePermissionService.grantPermission(roleId, permission);
+
+        assertThat(grantorOf(permission))
+                .as("the first grant is the one that changed the role's authority")
+                .isEqualTo("first.grantor");
+    }
+
+    @Test
+    @DisplayName("a bulk update stamps only the permissions it adds")
+    void bulkUpdateStampsOnlyNewGrants() {
+        String held = registerPermission("provenance:bulk:held");
+        String added = registerPermission("provenance:bulk:added");
+
+        authenticateAs("first.grantor");
+        rolePermissionService.grantPermission(roleId, held);
+
+        // The bulk endpoint re-submits the full list, so the already-held permission is in the
+        // request. Re-asserting it is not re-granting it — and must not reset its provenance.
+        authenticateAs("bulk.editor");
+        RolePermissionsRequest request = new RolePermissionsRequest();
+        request.setRoleId(roleId);
+        request.setPermissionNames(Set.of(held, added));
+        roleManagementService.updateRolePermissions(request);
+
+        assertThat(grantorOf(held))
+                .as("a permission the role already held keeps its original grantor")
+                .isEqualTo("first.grantor");
+        assertThat(grantorOf(added))
+                .as("the permission this call actually added is attributed to its caller")
+                .isEqualTo("bulk.editor");
+    }
+
+    @Test
+    @DisplayName("a grant written outside the admin API is left unattributed")
+    void rawInsertIsUnattributed() {
+        String permission = registerPermission("provenance:raw:insert");
+        UUID permissionId = permissionIdOf(permission);
+
+        // Exactly the shape of an out-of-band grant: the two key columns and nothing else.
+        jdbc.update("INSERT INTO role_permissions (role_id, permission_id) VALUES (?, ?)", roleId, permissionId);
+
+        assertThat(grantorOf(permission))
+                .as("nothing may attribute a grant the API did not make")
+                .isNull();
+    }
+
+    private String registerPermission(String name) {
+        return permissionRepository.findByName(name).map(Permission::getName).orElseGet(() -> {
+            Permission permission = new Permission();
+            permission.setName(name);
+            permission.setDescription("provenance test");
+            permission.setRegisteredByService("pos-security-service");
+            permission.setDeprecated(false);
+            permission.parsePermissionName();
+            return permissionRepository.save(permission).getName();
+        });
+    }
+
+    private UUID permissionIdOf(String name) {
+        return permissionRepository.findByName(name).orElseThrow().getId();
+    }
+
+    private String grantorOf(String permissionName) {
+        List<String> rows = jdbc.queryForList(PROVENANCE_QUERY, String.class, roleId, permissionIdOf(permissionName));
+        assertThat(rows)
+                .as("expected exactly one grant row for %s", permissionName)
+                .hasSize(1);
+        return rows.get(0);
+    }
+
+    private void authenticateAs(String username) {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(
+                        username, "n/a", AuthorityUtils.createAuthorityList("security:role:edit")));
+    }
+}

--- a/pos-security-service/src/test/resources/application-test.yml
+++ b/pos-security-service/src/test/resources/application-test.yml
@@ -10,6 +10,9 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
+    # Runs src/test/resources/schema.sql after Hibernate builds the schema, so
+    # migration-only columns can be patched in (#1512). See schema.sql.
+    defer-datasource-initialization: true
     show-sql: false
     properties:
       hibernate:

--- a/pos-security-service/src/test/resources/schema.sql
+++ b/pos-security-service/src/test/resources/schema.sql
@@ -1,0 +1,22 @@
+-- H2-only test schema patch.
+--
+-- The default test profile builds its schema from the JPA entities
+-- (ddl-auto: create-drop) with Flyway disabled, so any column that exists only
+-- in a migration is invisible here. role_permissions is mapped as a plain
+-- @ManyToMany join table on Role.permissions, which means Hibernate generates
+-- exactly (role_id, permission_id) and nothing else.
+--
+-- V30 adds granted_at/granted_by and RoleRepository.recordGrantProvenance
+-- writes them natively (#1512). Without this patch every grant through the
+-- admin API fails on H2 with "Column GRANTED_AT not found" — a schema gap in
+-- the test profile, not a defect in the query.
+--
+-- Runs after Hibernate's DDL because application-test.yml sets
+-- defer-datasource-initialization: true. It does not run under the `pg`
+-- profile: spring.sql.init.mode defaults to `embedded`, and the Testcontainers
+-- Postgres there gets these columns from V30 itself.
+--
+-- Keep in sync with V30__add_role_permission_audit_columns.sql.
+
+ALTER TABLE role_permissions ADD COLUMN IF NOT EXISTS granted_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE role_permissions ADD COLUMN IF NOT EXISTS granted_by VARCHAR(255);


### PR DESCRIPTION
> 🔴 **main is currently red.** [Run 33004185232](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/33004185232) failed on the merge of #1526 with three test failures. This fixes all three.

## Capability & Traceability
- Capability: n/a (defect fix for #1526)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1512
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/security/.business-rules/BACKEND_CONTRACT_GUIDE.md` — **no contract change.** No controller, DTO, `*Request`/`*Response`, event payload, validation model or `openapi.yaml` is touched. One service method's internal collection handling, one test-profile schema patch, one new test.
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Why this escaped the #1526 pull request

`Backend CI/CD` step 14 is *"Test changed modules and dependents (PR)"*; step 15 is *"Test changed modules and dependents incl. ITs (main)"*. **Failsafe ITs are skipped on pull requests.** #1526 was genuinely green on its branch and failed on the merge commit, where the ITs ran for the first time.

That is the more important finding than either defect below, and it is why the regression coverage here lands in **surefire**, not failsafe.

## Defect 1 — every admin-API grant returned 500 on H2

Took down `RolePermissionContractBehaviorIT.ac3_authorizationDecision_returnsAllow` and `ac5_grantPermission_emitsAuditEvent`.

The default `test` profile builds its schema from the JPA entities (`ddl-auto: create-drop`) with Flyway disabled, so a column that exists only in a migration is invisible there. `role_permissions` is mapped as a plain `@ManyToMany` join table on `Role.permissions` (`Role.java:36-41`), which means Hibernate generates exactly `(role_id, permission_id)` — V30's columns are not in that schema, and `recordGrantProvenance` failed:

```
Column "GRANTED_AT" not found; SQL statement:
UPDATE role_permissions SET granted_at = ?, granted_by = ? WHERE role_id = ? AND permission_id IN (?)
```

**Fix:** `pos-security-service/src/test/resources/schema.sql` mirrors the two columns into the generated H2 schema, with `defer-datasource-initialization: true` so it runs *after* Hibernate's DDL. It does **not** run under the `pg` profile — `spring.sql.init.mode` defaults to `embedded`, and the Testcontainers Postgres there gets the columns from V30 itself. `pos-accounting` already uses this pattern.

## Defect 2 — a bulk update reset the provenance it was supposed to preserve

Caught by `RolePermissionAuditColumnsIT.bulkUpdateStampsOnlyNewGrants`, the test added in #1526 for exactly this property.

`updateRolePermissions` called `role.setPermissions(newSet)`. **Assigning a new `Set` dereferences the persistent collection, and Hibernate answers that by deleting every join row and re-inserting the survivors** — so a permission the role already held came back with `granted_at` defaulted and `granted_by` null. The stamping logic then correctly skipped it, because by then it genuinely was not newly granted.

**Fix:** mutate the managed collection in place (`retainAll` + `addAll`), which issues targeted inserts and deletes and leaves untouched rows alone.

## Tests
- [x] Unit tests added/updated — new `RolePermissionProvenanceTest`: a surefire test running the attribution semantics on H2 (actor recorded, re-grant keeps the original grantor, bulk update stamps only what it adds, raw INSERT stays unattributed).
- [x] Integration tests added/updated — `RolePermissionAuditColumnsIT` unchanged; it keeps what only real Postgres can show (the migration's DDL, column types, the `granted_at` default).
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run:
  - `./mvnw -pl pos-security-service -am -DskipTests=false test` → **496 pass** (492 + 4 new)
  - `./mvnw -pl pos-security-service -am verify -Dit.test=RolePermissionContractBehaviorIT` → **6/6 pass** (was 4/6)

**Both fixes were reproduced before being applied**, per the repo's CI-fix discipline:
- Defect 1 reproduced locally — the `Column "GRANTED_AT" not found` trace above is from a local run of the contract IT, not from CI.
- Defect 2: reverting the collection fix with the new test in place reproduces CI's exact assertion, `expected: "first.grantor" but was: null`. Restoring it goes green.

`RolePermissionAuditColumnsIT` itself still has not run anywhere but CI — no Docker daemon in the authoring environment. Its one failing assertion is now also covered on H2, so a repeat would be caught on the pull request rather than on main.

## Risk & Rollback
- Risk level: **Low**. One behavioural change (`retainAll`/`addAll` in place of `setPermissions`) with identical end state for the role's permission set — only the join-table write pattern differs. Everything else is test-scoped: a new test, a test-profile schema patch, and one config line. `schema.sql` cannot affect production or the `pg` profile.
- Rollback plan: revert the PR. main returns to its current red state, so a revert is only sensible alongside reverting #1526.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — defect fix, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id
- [x] Links to parent + child issues are present (#1512, #1526)
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending first run

### Worth considering separately

The PR/main asymmetry will do this again. Options, roughly in order of cost: run failsafe ITs on pull requests for changed modules; or keep the split but treat "this behaviour is only covered by an IT" as a review smell. Not proposed here — it is a CI policy decision, and main should go green first.

No conflict with `claude/data-seed-strategy-dafw3p`: its 78 changed files and these 4 are disjoint, and nothing in its `pos-security-service` diff touches `role_permissions`, `RoleRepository`, or the `Role` entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQLHEJnxCa3LaXsxUco1fM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQLHEJnxCa3LaXsxUco1fM)_