### PR TITLE
pos-mcp-server: align RAG required-permissions with the post-#1519/#1499 permission model

### DIFF
--- a/pos-mcp-server/src/main/resources/application-alpha.yml
+++ b/pos-mcp-server/src/main/resources/application-alpha.yml
@@ -60,7 +60,8 @@ mcp:
         - id: "accounting.journal-entries"
           source-path: "classpath:rag/accounting-journal-entries-rag.md"
           rag-scope: "accounting"
-          required-permissions: ["accounting:je:view"]
+          # #1525: dual-listed for the reshaped facade JE surface — rationale in application.yml.
+          required-permissions: ["accounting:je:view", "reporting:view:financial-statements"]
         - id: "accounting.financial-statements"
           source-path: "classpath:rag/accounting-financial-statements-rag.md"
           rag-scope: "accounting"
@@ -72,14 +73,16 @@ mcp:
         - id: "accounting.codes"
           source-path: "classpath:rag/accounting-codes-rag.md"
           rag-scope: "accounting"
-          required-permissions: ["accounting:je:view"]
+          # #1525: dual-listed for the reshaped facade JE surface — rationale in application.yml.
+          required-permissions: ["accounting:je:view", "reporting:view:financial-statements"]
         - id: "inventory.inv-cntrl"
           source-path: "classpath:rag/inv-cntrl-rag.md"
           rag-scope: "inventory"
         - id: "inventory.purchase-orders"
           source-path: "classpath:rag/inventory-purchase-orders-rag.md"
           rag-scope: "inventory"
-          required-permissions: ["inventory:purchase_order:view"]
+          # #1525: retargeted to the live pos-order code — rationale in application.yml.
+          required-permissions: ["order:purchase_order:view"]
         - id: "inventory.receiving"
           source-path: "classpath:rag/inventory-receiving-rag.md"
           rag-scope: "inventory"
@@ -91,7 +94,8 @@ mcp:
         - id: "inventory.codes"
           source-path: "classpath:rag/inventory-codes-rag.md"
           rag-scope: "inventory"
-          required-permissions: ["inventory:purchase_order:view"]
+          # #1525: retargeted to the live pos-order code — rationale in application.yml.
+          required-permissions: ["order:purchase_order:view"]
         - id: "people.human-resources"
           source-path: "classpath:rag/hr-functions-guide.md"
           rag-scope: "hr"
@@ -144,7 +148,8 @@ mcp:
         - id: "pricing.guide"
           source-path: "classpath:rag/pricing-guide.md"
           rag-scope: "pricing"
-          required-permissions: ["pricing:price_book:view", "pricing:rule:view"]
+          # #1525: dead pricing:price_book:view dropped, ADR-0054 successor added — see application.yml.
+          required-permissions: ["pricing:rule:view", "catalog:price_book:read"]
         - id: "pricing.promotions"
           source-path: "classpath:rag/pricing-promotions-rag.md"
           rag-scope: "pricing"
@@ -168,7 +173,8 @@ mcp:
         - id: "crm.customer-vehicle"
           source-path: "classpath:rag/customer-vehicle-guide.md"
           rag-scope: "customer"
-          required-permissions: ["crm:party:view", "crm:party:search", "crm:vehicle:view", "crm:vehicle:search", "crm:contact:view"]
+          # #1525: crm:vehicle:search → vehicle-inventory:search:view — see application.yml.
+          required-permissions: ["crm:party:view", "crm:party:search", "crm:vehicle:view", "vehicle-inventory:search:view", "crm:contact:view"]
         - id: "crm.party-account-model"
           source-path: "classpath:rag/crm-party-account-model-rag.md"
           rag-scope: "customer"

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -81,7 +81,7 @@ mcp:
           rag-scope: "accounting"
           # #1525: dual-listed — accounting:je:view keeps the ACCOUNTING_ASSOCIATE audience on the
           # direct JE endpoints; reporting:view:financial-statements covers facade callers, whose JE
-          # surface was RESHAPEd to the general-ledger report (#1519 Wave 4, V37).
+          # surface was reshaped to the general-ledger report (#1519 Wave 4, V37).
           required-permissions: ["accounting:je:view", "reporting:view:financial-statements"]
         - id: "accounting.financial-statements"
           source-path: "classpath:rag/accounting-financial-statements-rag.md"
@@ -96,7 +96,7 @@ mcp:
           rag-scope: "accounting"
           # #1525: dual-listed — accounting:je:view keeps the ACCOUNTING_ASSOCIATE audience on the
           # direct JE endpoints; reporting:view:financial-statements covers facade callers, whose JE
-          # surface was RESHAPEd to the general-ledger report (#1519 Wave 4, V37).
+          # surface was reshaped to the general-ledger report (#1519 Wave 4, V37).
           required-permissions: ["accounting:je:view", "reporting:view:financial-statements"]
         - id: "inventory.inv-cntrl"
           source-path: "classpath:rag/inv-cntrl-rag.md"

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -79,7 +79,10 @@ mcp:
         - id: "accounting.journal-entries"
           source-path: "classpath:rag/accounting-journal-entries-rag.md"
           rag-scope: "accounting"
-          required-permissions: ["accounting:je:view"]
+          # #1525: dual-listed — accounting:je:view keeps the ACCOUNTING_ASSOCIATE audience on the
+          # direct JE endpoints; reporting:view:financial-statements covers facade callers, whose JE
+          # surface was RESHAPEd to the general-ledger report (#1519 Wave 4, V37).
+          required-permissions: ["accounting:je:view", "reporting:view:financial-statements"]
         - id: "accounting.financial-statements"
           source-path: "classpath:rag/accounting-financial-statements-rag.md"
           rag-scope: "accounting"
@@ -91,14 +94,19 @@ mcp:
         - id: "accounting.codes"
           source-path: "classpath:rag/accounting-codes-rag.md"
           rag-scope: "accounting"
-          required-permissions: ["accounting:je:view"]
+          # #1525: dual-listed — accounting:je:view keeps the ACCOUNTING_ASSOCIATE audience on the
+          # direct JE endpoints; reporting:view:financial-statements covers facade callers, whose JE
+          # surface was RESHAPEd to the general-ledger report (#1519 Wave 4, V37).
+          required-permissions: ["accounting:je:view", "reporting:view:financial-statements"]
         - id: "inventory.inv-cntrl"
           source-path: "classpath:rag/inv-cntrl-rag.md"
           rag-scope: "inventory"
         - id: "inventory.purchase-orders"
           source-path: "classpath:rag/inventory-purchase-orders-rag.md"
           rag-scope: "inventory"
-          required-permissions: ["inventory:purchase_order:view"]
+          # #1525: retargeted from inventory:purchase_order:view, whose grants were retired by the
+          # #1499 sweep (pos-security-service V28) — purchase orders live in pos-order now.
+          required-permissions: ["order:purchase_order:view"]
         - id: "inventory.receiving"
           source-path: "classpath:rag/inventory-receiving-rag.md"
           rag-scope: "inventory"
@@ -110,7 +118,9 @@ mcp:
         - id: "inventory.codes"
           source-path: "classpath:rag/inventory-codes-rag.md"
           rag-scope: "inventory"
-          required-permissions: ["inventory:purchase_order:view"]
+          # #1525: retargeted from inventory:purchase_order:view, whose grants were retired by the
+          # #1499 sweep (pos-security-service V28) — purchase orders live in pos-order now.
+          required-permissions: ["order:purchase_order:view"]
         - id: "people.human-resources"
           source-path: "classpath:rag/hr-functions-guide.md"
           rag-scope: "hr"
@@ -124,10 +134,9 @@ mcp:
           source-path: "classpath:rag/security-service-guide.md"
           rag-scope: "master"
           required-permissions: ["security:permission:view", "security:role:view"]
-        # Gate 5 documents. `required-permissions` is the G5.2 metadata field (not yet bound by
-        # StaticDocEntry — ignored until G5.2 adds the field + permission-aware filter G5.1);
-        # carried here so it is ready and records intent. Permission codes verified against the
-        # service permissions.yaml files.
+        # Gate 5 documents. `required-permissions` is bound by StaticDocEntry (G5.2) and enforced by
+        # the permission-aware RAG filter (G5.1). Permission codes verified against the service
+        # permissions.yaml files and guarded by RagRequiredPermissionSeedTest (#1525).
         - id: "platform.capability-catalog"
           source-path: "classpath:rag/capability-catalog.md"
           rag-scope: "master"
@@ -163,7 +172,10 @@ mcp:
         - id: "pricing.guide"
           source-path: "classpath:rag/pricing-guide.md"
           rag-scope: "pricing"
-          required-permissions: ["pricing:price_book:view", "pricing:rule:view"]
+          # #1525: pricing:price_book:view dropped (grants retired by #1499/V28; no PriceBook
+          # resource exists in pos-price). Price books moved to catalog per ADR-0054, so the doc's
+          # price-book half is covered by catalog:price_book:read.
+          required-permissions: ["pricing:rule:view", "catalog:price_book:read"]
         - id: "pricing.promotions"
           source-path: "classpath:rag/pricing-promotions-rag.md"
           rag-scope: "pricing"
@@ -187,7 +199,10 @@ mcp:
         - id: "crm.customer-vehicle"
           source-path: "classpath:rag/customer-vehicle-guide.md"
           rag-scope: "customer"
-          required-permissions: ["crm:party:view", "crm:party:search", "crm:vehicle:view", "crm:vehicle:search", "crm:contact:view"]
+          # #1525: crm:vehicle:search replaced with vehicle-inventory:search:view — the vehicle
+          # search surface moved to pos-vehicle-inventory and the crm code's grants were retired by
+          # the #1499 sweep (V28); the successor keeps the doc visible to SERVICE_ADVISOR.
+          required-permissions: ["crm:party:view", "crm:party:search", "crm:vehicle:view", "vehicle-inventory:search:view", "crm:contact:view"]
         - id: "crm.party-account-model"
           source-path: "classpath:rag/crm-party-account-model-rag.md"
           rag-scope: "customer"

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/RagRequiredPermissionSeedTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/RagRequiredPermissionSeedTest.java
@@ -1,0 +1,175 @@
+package com.positivity.mcp.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * RAG {@code required-permissions} seed guard (#1525, the RAG counterpart of
+ * {@code FacadeToolPermissionSeedTest}).
+ *
+ * <p>Static RAG documents are gated fail-closed by {@code PermissionAwareMetadataFilter} on the
+ * codes each {@code mcp.rag.preload.docs} entry declares (base {@code application.yml} plus the
+ * alpha overlay). Those codes live outside {@code mcp_tool_permission}, so nothing else checks them
+ * against the platform permission model — a code retired by a grant sweep like #1499 (V28 in
+ * pos-security-service) lingers silently and, because the filter is fail-closed, a doc whose whole
+ * list is unheld becomes invisible to every caller (the pre-#1525 state of the purchase-order
+ * docs).
+ *
+ * <p>Source of truth is pos-security-service's {@code R__seed_role_permissions.sql}: its
+ * {@code INSERT INTO permissions} five-tuples are the registered catalog, and its
+ * {@code INSERT INTO role_permissions} pairs are the live grants (V28-style retirements edit that
+ * file in the same change, so it reflects the net grant state). Registration alone is not enough —
+ * V28 kept the definition rows and deleted only grants — hence the granted-to-at-least-one-role
+ * assertion, which is the check that would have caught the dead docs.
+ */
+class RagRequiredPermissionSeedTest {
+
+    private static final Path MODULE_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path BASE_YML = MODULE_DIR.resolve("src/main/resources/application.yml");
+    private static final Path ALPHA_YML = MODULE_DIR.resolve("src/main/resources/application-alpha.yml");
+    // Cross-module by design (#1525): the grant model is pos-security-service seed data, and this
+    // reactor checkout layout is what Surefire's user.dir resolves against.
+    private static final Path SECURITY_SEED =
+            MODULE_DIR.resolve("../pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql");
+
+    private static final String AUTHENTICATED = "AUTHENTICATED";
+
+    // ('code', 'domain', 'resource', 'action', bitIndex) rows of INSERT INTO permissions
+    private static final Pattern PERMISSION_DEFINITION =
+            Pattern.compile("\\('([^']+)',\\s*'[^']*',\\s*'[^']*',\\s*'[^']*',\\s*\\d+\\)");
+    // ('ROLE_NAME', 'permission:code') rows of INSERT INTO role_permissions
+    private static final Pattern ROLE_GRANT = Pattern.compile("\\('[A-Z][A-Z0-9_]*',\\s*'([^']+)'\\)");
+
+    @Test
+    @DisplayName("every RAG required-permissions code is a registered permission")
+    void everyRagCodeIsRegistered() throws IOException {
+        Set<String> registered = registeredCodes();
+
+        assertThat(registered).isNotEmpty();
+        ragDocs()
+                .forEach((file, docs) -> docs.forEach((doc, codes) -> assertThat(restricted(codes))
+                        .as(
+                                "%s doc '%s': every required-permissions code must exist in the permission "
+                                        + "catalog (R__seed_role_permissions.sql INSERT INTO permissions)",
+                                file, doc)
+                        .isSubsetOf(registered)));
+    }
+
+    @Test
+    @DisplayName("every RAG required-permissions code is granted to at least one role")
+    void everyRagCodeIsGrantedToAtLeastOneRole() throws IOException {
+        Set<String> granted = grantedCodes();
+
+        assertThat(granted).isNotEmpty();
+        ragDocs()
+                .forEach((file, docs) -> docs.forEach((doc, codes) -> assertThat(restricted(codes))
+                        .as(
+                                "%s doc '%s': a required-permissions code no role holds makes the doc "
+                                        + "invisible via that code (fail-closed filter); retarget it to the live "
+                                        + "successor (see #1499/V28 and the #1525 walk)",
+                                file, doc)
+                        .isSubsetOf(granted)));
+    }
+
+    @Test
+    @DisplayName("base and alpha preload docs stay in parity (ids and required-permissions)")
+    void baseAndAlphaStayInParity() throws IOException {
+        Map<String, Set<String>> base = loadDocs(BASE_YML);
+        Map<String, Set<String>> alpha = loadDocs(ALPHA_YML);
+
+        assertThat(alpha.keySet())
+                .as("alpha overlay redefines the whole doc list, so ids must match the base corpus")
+                .containsExactlyInAnyOrderElementsOf(base.keySet());
+        base.forEach((doc, codes) -> assertThat(alpha.get(doc))
+                .as(
+                        "doc '%s': required-permissions must match between application.yml and the "
+                                + "alpha overlay — every gating change lands in both files",
+                        doc)
+                .containsExactlyInAnyOrderElementsOf(codes));
+    }
+
+    @Test
+    @DisplayName("no doc lists AUTHENTICATED alongside a privileged permission")
+    void noDocMixesAuthenticatedWithPrivilege() throws IOException {
+        ragDocs()
+                .forEach((file, docs) -> docs.forEach((doc, codes) -> {
+                    if (codes.contains(AUTHENTICATED)) {
+                        assertThat(codes)
+                                .as(
+                                        "%s doc '%s': required-permissions is OR-semantics and every "
+                                                + "authenticated caller holds AUTHENTICATED, so listing it beside "
+                                                + "privileged codes opens the doc to everyone (#1115 failure mode)",
+                                        file, doc)
+                                .containsExactly(AUTHENTICATED);
+                    }
+                }));
+    }
+
+    // ── parsing ───────────────────────────────────────────────────────────────
+
+    /** File label → (doc id → required-permissions), for both the base config and the alpha overlay. */
+    private static Map<String, Map<String, Set<String>>> ragDocs() throws IOException {
+        Map<String, Map<String, Set<String>>> all = new LinkedHashMap<>();
+        all.put(BASE_YML.getFileName().toString(), loadDocs(BASE_YML));
+        all.put(ALPHA_YML.getFileName().toString(), loadDocs(ALPHA_YML));
+        return all;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Set<String>> loadDocs(Path yml) throws IOException {
+        Map<String, Object> root = new Yaml().load(Files.readString(yml));
+        Map<String, Object> mcp = (Map<String, Object>) root.get("mcp");
+        Map<String, Object> rag = (Map<String, Object>) mcp.get("rag");
+        Map<String, Object> preload = (Map<String, Object>) rag.get("preload");
+        List<Map<String, Object>> docs = (List<Map<String, Object>>) preload.get("docs");
+
+        Map<String, Set<String>> byId = new LinkedHashMap<>();
+        for (Map<String, Object> doc : docs) {
+            List<String> codes = (List<String>) doc.get("required-permissions");
+            byId.put((String) doc.get("id"), codes == null ? Set.of() : Set.copyOf(codes));
+        }
+        return byId;
+    }
+
+    private static Set<String> restricted(Set<String> codes) {
+        return codes.stream().filter(code -> !AUTHENTICATED.equals(code)).collect(Collectors.toSet());
+    }
+
+    private static Set<String> registeredCodes() throws IOException {
+        return extract(PERMISSION_DEFINITION, securitySeed().split("(?i)INSERT\\s+INTO\\s+role_permissions", 2)[0]);
+    }
+
+    private static Set<String> grantedCodes() throws IOException {
+        return extract(ROLE_GRANT, securitySeed().split("(?i)INSERT\\s+INTO\\s+role_permissions", 2)[1]);
+    }
+
+    private static Set<String> extract(Pattern pattern, String sql) {
+        Matcher matcher = pattern.matcher(sql);
+        Set<String> codes = new LinkedHashSet<>();
+        while (matcher.find()) {
+            codes.add(matcher.group(1));
+        }
+        return codes;
+    }
+
+    private static String securitySeed() throws IOException {
+        // Strip -- line comments so retired codes quoted in prose (e.g. the V28 narrative) are not
+        // parsed as live definitions or grants.
+        return Files.readString(SECURITY_SEED).replaceAll("(?m)--.*$", "");
+    }
+}

--- a/pos-mcp-server/src/test/resources/eval/rag-lexical/codes-catalogs.json
+++ b/pos-mcp-server/src/test/resources/eval/rag-lexical/codes-catalogs.json
@@ -32,7 +32,7 @@
     {
       "fixture_id": "rag-lexical-inventory-codes-receiving-transfer",
       "query": "RECEIVED_SHORT LOST_IN_TRANSIT",
-      "actor": { "role": "ROLE_LOCATION_MANAGER", "permission_codes": ["inventory:purchase_order:view"] },
+      "actor": { "role": "ROLE_LOCATION_MANAGER", "permission_codes": ["order:purchase_order:view"] },
       "expected": { "doc_ids": ["inventory.codes"], "k": 5 },
       "rag_scope": "inventory",
       "tags": ["positive", "lexical", "exact-code", "bare-token"],


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (`type:task` follow-up, no capability story)
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1525
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): N/A — no controllers, DTOs, events, or `openapi.yaml` change; this PR touches only RAG preload config, a test, and an eval fixture. Reference retained for the sync check: BACKEND_CONTRACT_GUIDE.md
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- What changed:
  - Walked every `mcp.rag.preload.docs` `required-permissions` entry (base `application.yml` + alpha overlay) against the V37 facade derivation table and the #1499 grant-retirement sweep (pos-security-service V28), and resolved the four mismatches:
    - `inventory.purchase-orders` / `inventory.codes`: retargeted `inventory:purchase_order:view` → `order:purchase_order:view`. V28 deleted every role grant for the old code and the RAG filter is fail-closed, so both docs had become invisible to **all** callers.
    - `accounting.journal-entries` / `accounting.codes`: dual-listed `accounting:je:view` + `reporting:view:financial-statements` — the old code is still enforced (`JournalEntryController`) and keeps the ACCOUNTING_ASSOCIATE audience; the new code covers facade callers, whose JE surface was reshaped to the general-ledger report in V37.
    - `pricing.guide`: dropped `pricing:price_book:view` (grants retired by V28; no PriceBook resource exists in pos-price) and added the ADR-0054 successor `catalog:price_book:read` alongside `pricing:rule:view`.
    - `crm.customer-vehicle`: replaced `crm:vehicle:search` (grants retired by V28) with `vehicle-inventory:search:view`, keeping the doc visible to SERVICE_ADVISOR.
  - Fixed the stale base `application.yml` comment claiming `required-permissions` is not yet bound — it is bound by `StaticDocEntry` (G5.2) and enforced fail-closed by `PermissionAwareMetadataFilter` (G5.1).
  - Added `RagRequiredPermissionSeedTest` (RAG counterpart of `FacadeToolPermissionSeedTest`): asserts every RAG code is **registered** and **granted to at least one role** in pos-security-service's `R__seed_role_permissions.sql`, locks base/alpha parity, and forbids `AUTHENTICATED` beside privileged codes (#1115 failure mode). The grant assertion is the check with teeth — V28 kept definition rows and deleted only grants, so a registration-only check would not have caught the dead docs.
  - Updated the one `rag-lexical` eval fixture whose actor held only the retired purchase-order code (its expected recall would otherwise flip).
- Why: RAG document gating codes live outside `mcp_tool_permission`, so nothing checked them against the platform permission model; #1499/#1519 retired codes had lingered, silently hiding two documents from every caller. See #1525 for the full walk.

## Tests
- [x] Unit tests added/updated (`RagRequiredPermissionSeedTest`, 4 assertions; one eval fixture corrected)
- [ ] Integration tests added/updated — N/A, config + guard test only
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run: `./mvnw -pl pos-mcp-server -am -Dtest=RagRequiredPermissionSeedTest test` (full module suite: `./mvnw -pl pos-mcp-server -am -DskipTests=false test` — 784 tests green)

## Risk & Rollback
- Risk level: Low — config-only visibility change for static RAG docs plus a build-time guard test; no runtime code or schema changes. Net effect widens visibility back to intended audiences (the two dead docs become visible again); the accounting dual-list adds `reporting:view:financial-statements` holders to the JE docs' audience by design.
- Rollback plan: revert the single commit; no migrations or data changes involved.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, task branch `claude/issue-1525-questions-2rzlk3`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability
- [x] Links to parent + child issues are present (#1525; no parent story)
- [ ] Contract guide updated — N/A, no contract semantics changed
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmsLMkmbcZQaV434syGexC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmsLMkmbcZQaV434syGexC)_