### PR TITLE
Fix alpha startup: bind ignore-migration-patterns into pos-people's custom Flyway bean

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/config/FlywayConfig.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/config/FlywayConfig.java
@@ -1,8 +1,11 @@
 package com.positivity.people.internal.config;
 
 import jakarta.persistence.EntityManagerFactory;
+import java.util.Arrays;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AbstractDependsOnBeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -15,13 +18,28 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(prefix = "spring.flyway", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class FlywayConfig {
 
+    /**
+     * Hand-built Flyway instance (Boot's auto-configuration backs off), so spring.flyway.*
+     * properties are NOT applied automatically — each one this module relies on must be bound
+     * here explicitly. ignore-migration-patterns carries "repeatable:missing" for the retired
+     * timekeeping seed (docs/DATA_SEED_STRATEGY.md, #1527): without it, environments whose
+     * schema history recorded the deleted seed fail startup validation with "applied migration
+     * not resolved locally".
+     */
     @Bean(initMethod = "migrate")
     @ConditionalOnMissingBean(Flyway.class)
-    public Flyway mcpFlyway(DataSource dataSource) {
-        return Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration")
-                .load();
+    public Flyway mcpFlyway(
+            DataSource dataSource,
+            @Value("${spring.flyway.ignore-migration-patterns:}") String[] ignoreMigrationPatterns) {
+        FluentConfiguration configuration =
+                Flyway.configure().dataSource(dataSource).locations("classpath:db/migration");
+        String[] patterns = Arrays.stream(ignoreMigrationPatterns)
+                .filter(pattern -> !pattern.isBlank())
+                .toArray(String[]::new);
+        if (patterns.length > 0) {
+            configuration.ignoreMigrationPatterns(patterns);
+        }
+        return configuration.load();
     }
 
     @Bean

--- a/pos-people/src/test/java/com/positivity/people/internal/config/FlywayConfigTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/FlywayConfigTest.java
@@ -1,0 +1,43 @@
+package com.positivity.people.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The mcpFlyway bean is hand-built (Boot's Flyway auto-configuration backs off), so
+ * spring.flyway.* properties reach the instance only through explicit binding in
+ * FlywayConfig. These tests pin that binding for ignore-migration-patterns — the
+ * property that exempts the retired timekeeping seed's schema-history row (#1527);
+ * losing it makes pos-people fail startup validation in every environment that ever
+ * ran the seed. Flyway.configure().load() does not touch the DataSource, so a mock
+ * suffices.
+ */
+@SuppressWarnings("java:S100")
+class FlywayConfigTest {
+
+    private final FlywayConfig config = new FlywayConfig();
+
+    @Test
+    void mcpFlyway_appliesIgnoreMigrationPatterns() {
+        Flyway flyway = config.mcpFlyway(mock(DataSource.class), new String[] {"repeatable:missing"});
+
+        assertThat(flyway.getConfiguration().getIgnoreMigrationPatterns())
+                .hasSize(1)
+                .anySatisfy(pattern -> assertThat(pattern.toString()).contains("repeatable"));
+    }
+
+    @Test
+    void mcpFlyway_emptyPatternBinding_leavesFlywayDefaults() {
+        // @Value("${...:}") yields a single blank entry when the property is unset;
+        // it must not be passed to Flyway as a pattern.
+        Flyway defaultFlyway = config.mcpFlyway(mock(DataSource.class), new String[] {""});
+        Flyway untouched = Flyway.configure().dataSource(mock(DataSource.class)).load();
+
+        assertThat(defaultFlyway.getConfiguration().getIgnoreMigrationPatterns())
+                .hasSameSizeAs(untouched.getConfiguration().getIgnoreMigrationPatterns());
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/config/FlywayConfigTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/FlywayConfigTest.java
@@ -3,6 +3,8 @@ package com.positivity.people.internal.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.Arrays;
+import java.util.List;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.Test;
@@ -25,9 +27,13 @@ class FlywayConfigTest {
     void mcpFlyway_appliesIgnoreMigrationPatterns() {
         Flyway flyway = config.mcpFlyway(mock(DataSource.class), new String[] {"repeatable:missing"});
 
-        assertThat(flyway.getConfiguration().getIgnoreMigrationPatterns())
-                .hasSize(1)
-                .anySatisfy(pattern -> assertThat(pattern.toString()).contains("repeatable"));
+        // Assert presence rather than total count so Flyway-supplied default patterns
+        // (present or future) don't break the test; the paired default-config check
+        // proves the pattern really came from the binding.
+        assertThat(patternStrings(flyway))
+                .anySatisfy(pattern -> assertThat(pattern).contains("repeatable"));
+        assertThat(patternStrings(flywayWithDefaults()))
+                .noneSatisfy(pattern -> assertThat(pattern).contains("repeatable"));
     }
 
     @Test
@@ -35,9 +41,17 @@ class FlywayConfigTest {
         // @Value("${...:}") yields a single blank entry when the property is unset;
         // it must not be passed to Flyway as a pattern.
         Flyway defaultFlyway = config.mcpFlyway(mock(DataSource.class), new String[] {""});
-        Flyway untouched = Flyway.configure().dataSource(mock(DataSource.class)).load();
 
-        assertThat(defaultFlyway.getConfiguration().getIgnoreMigrationPatterns())
-                .hasSameSizeAs(untouched.getConfiguration().getIgnoreMigrationPatterns());
+        assertThat(patternStrings(defaultFlyway)).isEqualTo(patternStrings(flywayWithDefaults()));
+    }
+
+    private static Flyway flywayWithDefaults() {
+        return Flyway.configure().dataSource(mock(DataSource.class)).load();
+    }
+
+    private static List<String> patternStrings(Flyway flyway) {
+        return Arrays.stream(flyway.getConfiguration().getIgnoreMigrationPatterns())
+                .map(Object::toString)
+                .toList();
     }
 }


### PR DESCRIPTION
## Problem

The alpha deploy of edad503 left the pos-people container unhealthy. Startup fails with:

```
Error creating bean with name 'mcpFlyway' ...
Detected applied migration not resolved locally: seed timekeeping approval data
```

#1529 retired `R__seed_timekeeping_approval_data.sql` and set `spring.flyway.ignore-migration-patterns: "repeatable:missing"` in `application.yml` to exempt the orphaned schema-history row. The property is correct and Flyway 12.4.0 OSS honors `repeatable:missing` (verified empirically against the exact jar) — but pos-people builds its Flyway instance by hand in `FlywayConfig.mcpFlyway(...)`, which makes Boot's Flyway auto-configuration back off, so **no `spring.flyway.*` property (other than `enabled`, read by the bean's own `@ConditionalOnProperty`) ever reaches the instance**. The ignore pattern was silently inert.

## Fix

- `FlywayConfig.mcpFlyway` now binds `spring.flyway.ignore-migration-patterns` via `@Value` and applies non-blank patterns to the fluent configuration; an unset property leaves Flyway defaults untouched (the blank sentinel from the `@Value` default is filtered out).
- `FlywayConfigTest` pins both paths at the configuration level (`Flyway.configure().load()` never touches the DataSource, so a mocked one suffices — no DB needed).
- A comment on the bean documents that every `spring.flyway.*` property this module relies on must be bound explicitly there.

## Validation

- `./mvnw -pl pos-people -am test` — 177 tests, 0 failures (includes the 2 new FlywayConfigTest cases).
- Spotless applied.

## Operational notes

- **Immediate unblock for the already-deployed alpha** (no new image needed): `DELETE FROM flyway_schema_history WHERE description = 'seed timekeeping approval data';` on the pos-people schema, then restart the container. This fix makes that unnecessary for future deploys and other environments.
- **Wider latent issue, deliberately not widened into this PR**: 19 modules share this hand-rolled `FlywayConfig` shape (pos-accounting, pos-catalog, pos-customer, pos-event-receiver, pos-image, pos-inventory, pos-invoice, pos-marketing, pos-order, pos-people-contact, pos-people, pos-price, pos-security-service, pos-shop-manager, pos-tax, pos-vehicle-fitment, pos-vehicle-inventory, pos-warranty, pos-workorder). In all of them `spring.flyway.*` properties are silently ignored — including the long-standing `SPRING_FLYWAY_OUT_OF_ORDER` hook, which has never done anything. Worth a follow-up sweep (or a shared auto-config in a common library) before the seed-retirement work from `docs/DATA_SEED_STRATEGY.md` deletes seeds in other modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNrgnhykjfk9R48Lhr6E9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNrgnhykjfk9R48Lhr6E9a)_