### PR TITLE
fix(coverage): clear the two coverage floor-drift failures on main

### DIFF
--- a/pos-event-receiver/pom.xml
+++ b/pos-event-receiver/pom.xml
@@ -14,11 +14,11 @@
     <description>POS Event Receiver module</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 77.6% line / 87.2% branch by the gate's own
+        <!-- Coverage ratchet: measured 80.3% line / 86.7% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->
-        <jacoco.line.min>0.74</jacoco.line.min>
+        <jacoco.line.min>0.77</jacoco.line.min>
         <jacoco.branch.min>0.84</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>

--- a/pos-tax-common/pom.xml
+++ b/pos-tax-common/pom.xml
@@ -16,7 +16,7 @@
     <description>Shared DTOs and validation types for consuming POS Tax APIs</description>
 
     <properties>
-        <!-- Coverage ratchet: measured 89.4% line / 74.1% branch by the gate's own
+        <!-- Coverage ratchet: measured 89.6% line / 74.1% branch by the gate's own
              command, `verify -DskipITs` (docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.1).
              Floors sit 3 points under. Re-derive them ONLY from a -DskipITs run — an
              IT-inclusive measurement describes coverage the gate cannot see. -->

--- a/pos-tax-common/src/test/java/com/positivity/tax/common/TaxCommonContractTest.java
+++ b/pos-tax-common/src/test/java/com/positivity/tax/common/TaxCommonContractTest.java
@@ -6,10 +6,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxJurisdiction;
+import com.positivity.tax.common.dto.TaxRateComponent;
+import com.positivity.tax.common.dto.TaxRateLookupResponse;
 import com.positivity.tax.common.enums.ExemptionReasonCode;
 import com.positivity.tax.common.enums.TaxJurisdictionType;
 import com.positivity.tax.common.enums.TaxProviderTransactionStatus;
 import com.positivity.tax.common.enums.TaxReferenceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -246,6 +257,113 @@ class TaxCommonContractTest {
             // omitting it leaves these null for every request built through the builder.
             assertThat(request.getCurrencyCode()).isEqualTo("USD");
             assertThat(request.getCalculationType()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("jurisdiction rate lookup (#1522)")
+    class RateLookup {
+
+        @Test
+        @DisplayName("the record components are the JSON field names the lookup responds with")
+        void recordComponentsAreTheWireContract() {
+            // Neither record carries @JsonProperty, so Jackson names each field after its record
+            // component. Renaming one is a source-local edit that silently changes the response
+            // body -- and the Angular SDK is generated from that body, so the break surfaces in
+            // the browser rather than here. Order is asserted too: it is the order the generated
+            // OpenAPI schema lists the properties in.
+            assertThat(componentNames(TaxRateLookupResponse.class))
+                    .containsExactly(
+                            "countryCode",
+                            "regionCode",
+                            "city",
+                            "postalCode",
+                            "asOf",
+                            "components",
+                            "combinedRate",
+                            "source");
+            assertThat(componentNames(TaxRateComponent.class)).containsExactly("jurisdictionType", "rate");
+        }
+
+        @Test
+        @DisplayName("lookup rates use the decimal-fraction convention, not percentage points")
+        void ratesAreDecimalFractions() {
+            // This module ships both conventions: TaxJurisdiction.taxRate is percentage points
+            // (7.25) while JurisdictionTax.rate is a fraction (0.0725). TaxRateComponent
+            // deliberately follows the latter, and the @Schema example is where a caller reading
+            // the generated spec learns which. An example "corrected" to 7.25 would document a
+            // hundredfold error, so pin it against both neighbours rather than on its own.
+            BigDecimal componentRate = schemaExample(TaxRateComponent.class, "rate");
+            assertThat(componentRate)
+                    .isEqualByComparingTo(schemaExample(TaxCalculationResponse.JurisdictionTax.class, "rate"))
+                    .isLessThan(BigDecimal.ONE);
+            assertThat(schemaExample(TaxJurisdiction.class, "taxRate")).isGreaterThan(BigDecimal.ONE);
+
+            // combinedRate is documented as the sum of components[].rate, so it has to be on the
+            // same scale as the components it sums.
+            assertThat(schemaExample(TaxRateLookupResponse.class, "combinedRate"))
+                    .isLessThan(BigDecimal.ONE);
+        }
+
+        @Test
+        @DisplayName("a lookup by country and postal code alone is representable")
+        void regionAndCityMayBeAbsent() {
+            // regionCode and city are NOT_REQUIRED query parameters echoed back, and a US ZIP is
+            // enough to resolve rates without either. A compact constructor rejecting nulls here
+            // would make the endpoint's own documented minimal request unrepresentable.
+            TaxRateLookupResponse response = new TaxRateLookupResponse(
+                    "US",
+                    null,
+                    null,
+                    "94103",
+                    LocalDate.of(2026, 8, 27),
+                    List.of(new TaxRateComponent(TaxJurisdictionType.STATE, new BigDecimal("0.0725"))),
+                    new BigDecimal("0.0725"),
+                    "TEST_MODE");
+
+            assertThat(response.regionCode()).isNull();
+            assertThat(response.city()).isNull();
+            assertThat(response.countryCode()).isEqualTo("US");
+            assertThat(response.postalCode()).isEqualTo("94103");
+        }
+
+        @Test
+        @DisplayName("a jurisdiction that taxes at zero keeps its row in the breakdown")
+        void zeroRateJurisdictionIsRepresentable() {
+            // A 0% level of government is real data -- several US states levy no sales tax while
+            // their counties do. Dropping or rejecting the row would leave the caller unable to
+            // tell "this jurisdiction charges nothing" from "this jurisdiction was not consulted".
+            TaxRateComponent component = new TaxRateComponent(TaxJurisdictionType.STATE, BigDecimal.ZERO);
+
+            assertThat(component.rate()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(component.jurisdictionType()).isEqualTo(TaxJurisdictionType.STATE);
+        }
+
+        private List<String> componentNames(Class<?> record) {
+            return Arrays.stream(record.getRecordComponents())
+                    .map(RecordComponent::getName)
+                    .toList();
+        }
+
+        /**
+         * The {@code example} of the {@code @Schema} on a declared field, as a BigDecimal.
+         *
+         * <p>
+         * Read off the field rather than the record component: {@code @Schema} predates records
+         * and does not target {@code RECORD_COMPONENT}, so javac propagates it to the generated
+         * field, not to the component.
+         */
+        private BigDecimal schemaExample(Class<?> owner, String fieldName) {
+            try {
+                Field field = owner.getDeclaredField(fieldName);
+                Schema schema = field.getAnnotation(Schema.class);
+                assertThat(schema)
+                        .describedAs("@Schema on %s.%s", owner.getSimpleName(), fieldName)
+                        .isNotNull();
+                return new BigDecimal(schema.example());
+            } catch (NoSuchFieldException e) {
+                throw new AssertionError("no field " + owner.getSimpleName() + "." + fieldName, e);
+            }
         }
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — CI repair on `main`, not capability work
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:build` / `domain:tax` (the covered DTOs originate from #1522)
- Failing run: [Backend CI/CD #2800](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/33056925711) on `main` @ `652d378`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable. This PR changes two `pom.xml` files and one test class; no
controller, DTO, event, validation model, or `openapi.yaml` is touched, so no
`BACKEND_CONTRACT_GUIDE.md` entry needs updating and Contract Sync Enforcement
does not fire. No API or event behaviour changes.

## Contract Chain (when a Controller changed)
No controller changed — not applicable.

## Scope

**What changed:** the scheduled `Backend CI/CD` run failed in the
**coverage floor drift** step, not in the ratchet itself — the log line above it
reads `Coverage ratchet: every module met its floor.` `scripts/coverage_floors.py`
requires each floor to sit 2–6 points under measured coverage
(`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §6.2). Two modules were outside that
band, in opposite directions:

| Module | Status | Measured (line) | Floor | Cushion |
| --- | --- | --- | --- | --- |
| `pos-event-receiver` | STALE | 80.3% | 0.74 | +6.3 (max 6) |
| `pos-tax-common` | THIN | 87.7% | 0.86 | +1.7 (min 2) |

**`pos-event-receiver` — floor left behind.** Coverage rose from the 77.6% the
floor was derived at and nothing raised the floor after it, so the module could
have shed six points without one build turning red. Re-derived with
`scripts/update-coverage-floors.sh --apply`: `jacoco.line.min` `0.74` → `0.77`
(+3.3 cushion). The branch floor stays at `0.84` — the script's `0.83` proposal
was a *lowering*, which the ratchet refuses, and its 2.7-pt cushion is already
in range.

**`pos-tax-common` — coverage fell instead.** #1522 (`9840ef8`) added
`TaxRateComponent` and `TaxRateLookupResponse` to this module with no tests; on
a 106-line library, two uncovered lines cost 1.7 points and squeezed the cushion
to THIN. Lowering the floor would ratify the regression, so the DTOs are covered
instead: 87.7% → 89.6%, restoring the 3.6-pt cushion the `0.86` floor was
originally derived against. The floor itself is unchanged.

**Why:** `main` is red, and both findings are real. A stale floor is slack the
ratchet was built to remove; a thin one is a gate that fails on run-to-run
variance rather than on regressions.

## Tests
- [x] Unit tests added/updated — 4 tests in `TaxCommonContractTest.RateLookup`
- [ ] Integration tests added/updated — none needed; no runtime behaviour changed
- [ ] Provider behavioral contract tests added/updated — n/a

The new tests hold the guarantees these DTOs exist to make rather than
exercising accessors:

- **The record components are the wire contract.** Neither record carries
  `@JsonProperty`, so Jackson names each JSON field after its record component
  — and the Angular SDK is generated from that body. Renaming one looks like a
  source-local edit and breaks in the browser.
- **The rates are decimal fractions, not percentage points.** This module ships
  both conventions (`TaxJurisdiction.taxRate` is `7.25`;
  `JurisdictionTax.rate` is `0.0725`). `TaxRateComponent` deliberately follows
  the latter, and the `@Schema` example is where a caller reading the generated
  spec learns which. Crossing them is a hundredfold error.
- Plus two representability cases: a lookup by country + postal code alone
  (`regionCode`/`city` are `NOT_REQUIRED` echoes), and a 0%-rate jurisdiction
  keeping its row — several US states levy no sales tax while their counties do,
  and dropping the row loses "charges nothing" vs. "was not consulted".

Both guarantees were mutation-checked: renaming `combinedRate` → `totalRate`
fails 2 tests, and "correcting" the `0.0725` example to `7.25` fails 1. Sources
were restored after each.

**How to run:**

```bash
# the gate's own command
./mvnw -pl pos-tax-common,pos-event-receiver -am verify -DskipITs -Darchunit.skipTests=true
scripts/check-coverage-floor-drift.sh pos-tax-common pos-event-receiver
```

Both pass locally (187 + 96 tests, `All coverage checks have been met`, Spotless
/ Checkstyle / SpotBugs clean). The local environment reproduced the CI figures
exactly — 80.3/86.7 and 87.7/74.1 — before the fix.

## Risk & Rollback
- **Risk level: Low.** No production code changes at all: two `pom.xml` build
  properties and one test class. The only floor that moved, moved *up*.
- **Rollback plan:** revert the commit. That restores the previous floors and
  drops the new tests; `main` returns to the same red drift check.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, this is a CI-repair branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability
- [ ] Links to parent + child issues are present — n/a; the failing run is linked instead
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending on this PR

## Verification caveat
I verified the two affected modules plus their reactor dependencies, not all 40
modules. The other 38 were reported `OK` by the same drift check in the failing
run, and nothing they depend on changed — `pos-tax-common`'s only edit is
test-side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuiZvB4HyUaHFmzadDqijN)_