### PR TITLE
[CAP:CAP-217] Fix main: box hazardContainment so payloads omitting it stay readable

### DIFF
--- a/pos-location/openapi.yaml
+++ b/pos-location/openapi.yaml
@@ -3491,7 +3491,7 @@ components:
             maxUnits: 100
           type: object
         hazardContainment:
-          description: Whether the storage location provides spill/hazard containment; required by battery and oil storage capabilities. Defaults to false.
+          description: Whether the storage location provides spill/hazard containment; required by battery and oil storage capabilities. Omit for false.
           example: false
           type: boolean
         name:

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationRequest.java
@@ -58,12 +58,19 @@ public class StorageLocationRequest {
             requiredMode = NOT_REQUIRED)
     private StorageCategory storageCategoryCode;
 
+    /**
+     * Boxed deliberately. Jackson 3 enables {@code FAIL_ON_NULL_FOR_PRIMITIVES} by default and picks
+     * Lombok's all-args constructor as a property-based creator, so an omitted primitive arrives as
+     * null and the whole request is rejected with 400 "Failed to read request". Since this field is
+     * optional, a primitive here would have made every payload that omits it unreadable. Null means
+     * "not stated" and is coerced to false when the entity is built.
+     */
     @Schema(
             description = "Whether the storage location provides spill/hazard containment; required by battery and"
-                    + " oil storage capabilities. Defaults to false.",
+                    + " oil storage capabilities. Omit for false.",
             example = "false",
             requiredMode = NOT_REQUIRED)
-    private boolean hazardContainment;
+    private Boolean hazardContainment;
 
     @Schema(
             description = "Whether the storage location will take stock of a product it is not already holding."

--- a/pos-location/src/main/java/com/positivity/location/internal/service/StorageLocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/StorageLocationServiceImpl.java
@@ -120,7 +120,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
                 // GENERAL, so "never declared" stays distinguishable from an explicit GENERAL;
                 // toResponse resolves it for readers.
                 .storageCategoryCode(request.getStorageCategoryCode())
-                .hazardContainment(request.isHazardContainment())
+                .hazardContainment(Boolean.TRUE.equals(request.getHazardContainment()))
                 .allowNewProduct(AllowNewProductPolicy.orDefault(request.getAllowNewProduct()))
                 .capacity(serializeJson(request.getCapacity(), CAPACITY))
                 .temperature(serializeJson(request.getTemperature(), TEMPERATURE))

--- a/pos-location/src/test/java/com/positivity/location/internal/dto/StorageLocationRequestDeserializationTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/dto/StorageLocationRequestDeserializationTest.java
@@ -33,8 +33,11 @@ class StorageLocationRequestDeserializationTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    @DisplayName("#1514 - a payload carrying only the required fields is readable")
-    void minimalPayloadIsReadable() {
+    @DisplayName("#1514 - the exact payload the contract tests post is readable")
+    void contractTestPayloadIsReadable() {
+        // Copied verbatim from StorageLocationContractBehaviorIT's create tests, which is what
+        // actually broke. barcode is optional and present here for that reason rather than because
+        // it is required — the point is the payload that turned main red, character for character.
         String json = "{\"name\":\"Floor-New\",\"barcode\":\"BAR-DUP\",\"type\":\"FLOOR\"}";
 
         assertThatCode(() -> objectMapper.readValue(json, StorageLocationRequest.class))

--- a/pos-location/src/test/java/com/positivity/location/internal/dto/StorageLocationRequestDeserializationTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/dto/StorageLocationRequestDeserializationTest.java
@@ -1,0 +1,100 @@
+package com.positivity.location.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.positivity.location.internal.enums.AllowNewProductPolicy;
+import com.positivity.location.internal.enums.StorageCategory;
+import com.positivity.location.internal.enums.StorageLocationType;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Deserialization of {@link StorageLocationRequest} through a default Jackson 3 mapper.
+ *
+ * <p>This exists because a primitive {@code boolean} on this DTO made every payload that omitted it
+ * unreadable, and the only test that caught it was a Failsafe IT — which runs on {@code main} but not
+ * on pull requests, so the break reached {@code main} behind a green PR. These are plain unit tests so
+ * the contract is checked in the {@code test} phase, where a PR can see it.
+ *
+ * <p>The mechanism worth remembering: Jackson 3 enables {@code FAIL_ON_NULL_FOR_PRIMITIVES} by
+ * default (Jackson 2 did not) and treats Lombok's {@code @AllArgsConstructor} as a property-based
+ * creator, so an omitted optional field is passed to the constructor as null. A primitive parameter
+ * then fails the entire request with 400 rather than defaulting. Every optional field on a request
+ * DTO must therefore be a boxed type.
+ */
+@DisplayName("StorageLocationRequest deserialization")
+class StorageLocationRequestDeserializationTest {
+
+    /** A default mapper, matching the strictness the application context applies. */
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("#1514 - a payload carrying only the required fields is readable")
+    void minimalPayloadIsReadable() {
+        String json = "{\"name\":\"Floor-New\",\"barcode\":\"BAR-DUP\",\"type\":\"FLOOR\"}";
+
+        assertThatCode(() -> objectMapper.readValue(json, StorageLocationRequest.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("#1514 - omitting hazardContainment leaves it unstated rather than failing the request")
+    void omittedHazardContainmentIsUnstated() {
+        StorageLocationRequest request =
+                objectMapper.readValue("{\"name\":\"N\",\"type\":\"FLOOR\"}", StorageLocationRequest.class);
+
+        // Null, not false: the service coerces it when building the entity. What matters here is
+        // that an omitted optional field does not make the payload unreadable.
+        assertThat(request.getHazardContainment()).isNull();
+    }
+
+    @Test
+    @DisplayName("an explicit hazardContainment is honoured either way")
+    void explicitHazardContainmentIsRead() {
+        assertThat(objectMapper
+                        .readValue(
+                                "{\"name\":\"N\",\"type\":\"FLOOR\",\"hazardContainment\":true}",
+                                StorageLocationRequest.class)
+                        .getHazardContainment())
+                .isTrue();
+        assertThat(objectMapper
+                        .readValue(
+                                "{\"name\":\"N\",\"type\":\"FLOOR\",\"hazardContainment\":false}",
+                                StorageLocationRequest.class)
+                        .getHazardContainment())
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("the capability fields round-trip when supplied")
+    void capabilityFieldsRoundTrip() {
+        String json = "{\"name\":\"Main Battery Rack\",\"type\":\"SHELF\","
+                + "\"storageCategoryCode\":\"BATTERY_RACK\",\"hazardContainment\":true,"
+                + "\"allowNewProduct\":\"SAME_PRODUCT_ONLY\"}";
+
+        StorageLocationRequest request = objectMapper.readValue(json, StorageLocationRequest.class);
+
+        assertThat(request.getType()).isEqualTo(StorageLocationType.SHELF);
+        assertThat(request.getStorageCategoryCode()).isEqualTo(StorageCategory.BATTERY_RACK);
+        assertThat(request.getAllowNewProduct()).isEqualTo(AllowNewProductPolicy.SAME_PRODUCT_ONLY);
+        assertThat(request.getHazardContainment()).isTrue();
+    }
+
+    @Test
+    @DisplayName("no field on this DTO is a primitive, since Jackson 3 cannot default one")
+    void noFieldIsAPrimitive() {
+        // Guards the class of bug rather than one field: a future optional primitive would turn every
+        // payload omitting it into a 400, and this fails the moment one is added.
+        assertThat(Arrays.stream(StorageLocationRequest.class.getDeclaredFields())
+                        .filter(field -> !field.isSynthetic())
+                        .filter(field -> field.getType().isPrimitive())
+                        .map(Field::getName)
+                        .toList())
+                .as("request DTO fields that are primitives")
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:CAP-217`
- Parent STORY (durion): louisburroughs/durion#217
- Child issue: louisburroughs/durion-positivity-backend#1514
- Domain: `domain:location`
- Fixes the red `main` left by #1538 — [run 33081084955](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/33081084955)

## Contract References
- Contract guide entry (durion): `domains/location/.business-rules/BACKEND_CONTRACT_GUIDE.md` → CAP-214. No contract semantics change: `boolean` → `Boolean` does not alter the generated schema type or its optionality.

## Contract Chain
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated — a **one-line** description change ("Defaults to false" → "Omit for false"). The schema type and optionality are unaffected.
- [ ] Angular SDK regenerated — not required: the wire contract is unchanged

## What was failing

Three POST-create tests in `StorageLocationContractBehaviorIT` returned **400** instead of 201/409:

```
postStorageLocations_validPayload_returns201      expected:<201> but was:<400>
postStorageLocations_duplicateName_returns409     expected:<409> but was:<400>
postStorageLocations_duplicateBarcode_returns409  expected:<409> but was:<400>
```

Confirmed as introduced by #1538 rather than pre-existing: the same IT is **11/11 green at `1421be9`** (the pre-merge commit) and 3-red after.

## Root cause

`StorageLocationRequest.hazardContainment` was a primitive `boolean`.

This application runs **Jackson 3** (`tools.jackson.databind` 3.1.5), which:

1. enables `FAIL_ON_NULL_FOR_PRIMITIVES` **by default**, where Jackson 2 did not; and
2. treats Lombok's `@AllArgsConstructor` as a property-based creator.

So an omitted optional field is passed to the constructor as `null`, and a primitive parameter cannot accept it. The result is not "the field defaults to false" — it is `HttpMessageNotReadableException` and a 400 for the **whole request**:

```
JSON parse error: Cannot map `null` into type `boolean`
(set `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES` to 'false' to allow)
```

Since the field is optional, that was most payloads — including the three-field body the contract tests post.

## The fix

Box the field to `Boolean` and coerce `null` → `false` in the service when building the entity, matching the column default. `null` now means "not stated".

`StorageLocationPatchRequest` was **already** boxed (so an unrelated patch could not silently reset containment); the create DTO was the only primitive among the five request DTOs #1538 touched — I checked all five.

Deliberately *not* done: loosening `FAIL_ON_NULL_FOR_PRIMITIVES` globally. That would paper over one field's declaration by weakening deserialization strictness everywhere.

## Why this reached main behind a green PR

Two things, both worth fixing rather than just noting:

**Contract behaviour ITs are Failsafe.** They run in `verify` on `main`, but a pull request only runs the `test` phase (`ci.yml` steps 14 vs 15 — *"Test changed modules and dependents (PR)"* vs *"…incl. ITs (main)"*). The one test that covered this could not fail the PR. So the regression test added here is a **plain unit test**, and it asserts the general rule by reflection — *no field on this DTO may be a primitive* — rather than only this field, so the next optional primitive fails immediately instead of after a merge.

> This is a general CI gap, not specific to this DTO: **any** Failsafe-only regression in this repo ships behind a green PR and breaks `main` on merge. Closing it needs a workflow change, which does not belong in a hotfix — flagged for a separate decision.

**A default `new ObjectMapper()` deserializes the payload happily**, because that resolves to Jackson 2 from the classpath while the application uses `tools.jackson`. Reproducing this requires the Jackson 3 mapper — a probe with the wrong one nearly sent me to the wrong conclusion.

## Tests

- [x] Unit tests added — `StorageLocationRequestDeserializationTest` (5 tests)
- [x] Integration tests verified — the 3 failing ITs now pass
- [ ] Provider contract tests — n/a, no contract change

```
pos-location   259 unit tests + 88 integration tests, 0 failures
               jacoco check-ratchet passes
CI on 553e4ff  Backend CI/CD success, Contract Sync success
```

**Mutation-checked:** reverting the boxing makes Jackson 3 throw the exact CI error, so the regression test defends the behaviour rather than merely executing the line.

### Cross-module sweep (complete)

None of the ITs for the modules #1538 touched ran on that PR, so I ran `verify` across all of them locally. Reactor result:

| Module | Result |
|---|---|
| pos-catalog | ✅ SUCCESS |
| pos-inventory | ✅ SUCCESS |
| pos-location | ✅ SUCCESS |
| pos-api-gateway | ✅ SUCCESS |
| pos-domain-events | ✅ SUCCESS |
| pos-security-service | ⚠️ 2 errors — `RolePermissionSeedIT`, `RolePermissionAuditColumnsIT` |

The two pos-security-service errors are **environmental, not code**: `ContainerFetch — Can't get Docker image: postgres:16-alpine`. My sandbox has no Docker daemon, so those Testcontainers ITs cannot run. They passed in CI (which has Docker) on the #1538 merge run, where the only failures were the three `StorageLocationContractBehaviorIT` ones this PR fixes.

**So no other IT regression exists from #1538.**

## Risk & Rollback
- Risk level: **Low** — one field's declaration, one coercion, one new test, one generated-spec line. No schema, no migration, no wire-contract change.
- Rollback: revert this branch; `main` returns to the current red state.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/putaway-rules-flexibility-6lrpvs`, assigned by the task
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated — n/a, no contract semantics changed
- [ ] Required CI checks passing — green on `553e4ff`; re-running on `6725411`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dReXTRYLHdUTCyRaXxsx4