### PR TITLE
Revoke SYSTEM_ADMINISTRATOR's out-of-band grants (#1512)

### DIFF
--- a/docs/rbac-permission-role-audit-2026-08.md
+++ b/docs/rbac-permission-role-audit-2026-08.md
@@ -84,14 +84,16 @@ genuinely enforced — just not by `@PreAuthorize`).
 112 permission codes are required by at least one operation and granted to **no role in
 the seed — ADMIN included**. 229 contract operations have no granted alternate at all.
 
-> **Discrepancy with #1512 worth confirming:** the issue says `SecurityBootstrap` grants
-> SYSTEM_ADMINISTRATOR every registered permission at runtime on alpha. **No such class
-> exists in this repository.** `RoleAuthorityServiceImpl` resolves authorities solely
-> from `role_permissions`, and the seed explicitly makes SYSTEM_ADMINISTRATOR *not* a
-> superuser (34 grants). If alpha behaves as described, that bootstrap lives outside
-> this repo (ops tooling or environment SQL) and should be located and documented —
-> otherwise these 229 operations are unreachable by *everyone*, admin included, on a
-> fresh database.
+> **Discrepancy with #1512 — resolved, see Task 8:** the issue says `SecurityBootstrap`
+> grants SYSTEM_ADMINISTRATOR every registered permission at runtime on alpha. **No such
+> class exists in this repository**, and this audit first read that absence as evidence
+> against the claim. It was the opposite: the claim held and the absence *was* the
+> finding. `RoleAuthorityServiceImpl` resolves authorities solely from
+> `role_permissions`, the seed makes SYSTEM_ADMINISTRATOR deliberately *not* a superuser
+> (40 grants), and alpha nonetheless carried 398 — every row then in the `permissions`
+> table, granted out of band and outside version control. So on a fresh database these
+> 229 operations really were unreachable by *everyone*, admin included; alpha only looked
+> healthy because of a grant no reviewer ever saw.
 
 ### 1a. Whole feature areas with zero role wiring
 
@@ -673,7 +675,7 @@ All six flags are decided; the chart above reflects them:
 | 5 | Triage remaining ~55 ADMIN-only unenforced codes: enforce or retire | medium | **IN PROGRESS** — retirement wave DONE (34 codes, V28); enforcement wave DONE for 15 codes gated across pos-catalog/pos-price/pos-vehicle-inventory/pos-vehicle-fitment, grants paired (seed-only, no migration); 12 codes still deferred (feature not built: crm integration-audit/processing-log/suspense reads, workorder estimate-item/snapshot GETs, people:skill:* feature (3 codes), nlti:request:read status endpoint, catalog:service_type:create/edit endpoint split, pricing:normalization:view) |
 | 6 | Close the `x-required-permissions` gap | medium | **IN PROGRESS** — decomposed into 3 causes (§5 Task 6): pos-security-service (88, tooling gap) and pos-catalog (37, real phantom-role gap) each being fixed by a concurrent effort; pos-event-receiver (12) and the 3 stragglers (pos-customer, pos-invoice, pos-vehicle-inventory) verified as correct silence — no fix needed, one convention note left on vehicle-inventory's `hasRole('ADMIN')` |
 | 7 | CI check on `scripts/audit-rbac.py` output (fail on new drift) | small | **DONE** — `--check` mode + `scripts/rbac-audit-baseline.json`, wired into the `validate-permissions` job; see subsection below |
-| 8 | Locate/confirm the alpha "SecurityBootstrap" superuser behavior; document or remove | small | no |
+| 8 | Locate/confirm the alpha "SecurityBootstrap" superuser behavior; document or remove | small | **DONE for the policy half** — confirmed real (398 grants vs the seed's 40), decided unchanged and enforced by `V31__revoke_system_administrator_out_of_band_grants.sql`; the actor is still unnamed and needs alpha ops logs — see the subsection below |
 | 9 | Remove dead authorities: literal `"admin"` check, `ACCOUNTING_ADMIN`/`AR_MANAGER` alternates, `people:time:export:read` alternate | small | **DONE** — pos-people, pos-people-contact and pos-accounting code, contracts and tests cleaned |
 | 10 | Seed dummy users for the roles that currently have none (see below) so every persona is exercisable under its own login | small | **DONE** — 8 users seeded (…012–…019); felicia.grant's LOCATION-scoped assignment deferred until a location fixture exists; customer-persona flag still open |
 
@@ -778,3 +780,78 @@ Implementation notes:
 - Per ADR-0043/#714, users without a `person_id` get no `personId` claim; the existing
   17 operational users are seeded without one, so follow that precedent unless a
   persona's flow needs it (timekeeping flows for MANAGER-tier roles may).
+
+### Task 8 — the alpha SYSTEM_ADMINISTRATOR grant
+
+**Confirmed, decided and enforced. One thread is still open and it is not in this repository.**
+
+#### What was measured
+
+| | Count |
+| --- | ---: |
+| alpha SYSTEM_ADMINISTRATOR | **398** |
+| seed SYSTEM_ADMINISTRATOR | 40 |
+| seed ADMIN | 420 |
+| registered in `PermissionCode` | 481 |
+
+The 83-row gap between 481 and 398 decomposes with no remainder: 48 revoked
+role-agnostically by V25/V26/V27/V28, 35 registered after the grant ran. `481 − 48 − 35 =
+398`. All 48 role-agnostic revokes land inside the gap and none outside it, which is what
+makes the set look curated when it is not — those four migrations delete by
+`permission_id` with no `role_id` filter, so they stripped 48 grants off a role none of
+them mentions.
+
+Ruled out, each by name: **seed drift** (ADMIN reads exactly 420, matching the seed; SA
+never exceeds 40 across all 25 seed commits on all branches), **the durion seed-generator**
+(`scripts/seed-generator/src/emitters/001-security.js` emits no role/permission mapping at
+all — verified at source, one commit, never emitted a grant), and **a bootstrap running at
+startup** (Flyway runs at boot, V28 installed 2026-08-26 10:56:51 on the most recent boot,
+and SA still read 398 rather than climbing to 481).
+
+Twelve of the grants are codes **no version of the seed has ever given to any role** —
+`crm:vehicle:edit`/`deactivate` (retired by ADR-0044 §6), the `people:person:*` family
+(superseded by `people:employee:*`), `people:role:*`, `people:userLink:*` and
+`inventory:shortages:resolve`. They cannot have arrived through role grants at any point in
+the seed's history. Registration timestamps date the run to **between 2026-08-24 and
+2026-08-25 23:38** — during the week of this audit, not old residue.
+
+#### The decision
+
+**SYSTEM_ADMINISTRATOR is not a superuser.** That is what #1373 settled and what the seed's
+policy header states; the environment drifted from the model, the model did not change. The
+grants were never in version control, so there was nothing in the seed to revise —
+`V31__revoke_system_administrator_out_of_band_grants.sql` deletes the role's grants that
+`R__seed_role_permissions.sql` does not make, and nothing else.
+
+Three properties the migration is built around:
+
+- **Role-scoped on purpose.** The `DELETE` names SYSTEM_ADMINISTRATOR in its `WHERE`
+  clause. This is the deliberate opposite of the V25–V28 shape, and
+  `SystemAdministratorRevokeIT#leavesEveryOtherRoleUntouched` fails if it ever stops being
+  true. A revoke that means one role should say so.
+- **The keep list is guarded, not trusted.** SQL cannot read a repeatable migration in
+  another file, so V31 carries a copy of the seed's 40 SYSTEM_ADMINISTRATOR rows.
+  `RolePermissionBaselineTest#v31KeepListMatchesTheSeededSystemAdministratorGrants` asserts
+  the two copies are equal in both directions — a name missing from V31 revokes authority
+  the seed deliberately grants, and a name V31 keeps that the seed no longer grants
+  outlives the migration written to remove it.
+- **Safe on a fresh database.** Flyway runs versioned migrations before repeatable ones, so
+  V31 executes against an unseeded table, finds no grants, and returns. The repeatable seed
+  arrives afterwards — which on an existing environment also means the baseline is
+  re-asserted immediately after the revoke.
+
+#### Still open
+
+- **The actor.** `role_permissions` had no provenance columns until V30, so the database
+  cannot say who did this. Alpha deploy and ops logs for 2026-08-24 and 2026-08-25 should
+  name it. This needs access outside the repository. Now that V30 is in place, the same
+  question about a *future* grant is a single `SELECT`.
+- **An environment-aware check.** `scripts/audit-rbac.py --check` proves the *seed* is
+  self-consistent. It cannot see a running environment, and reported green throughout the
+  window in which alpha carried 358 grants the seed never made. Proving a deployed database
+  matches its seed is a different check, and this is the argument for having one. V31
+  corrects the environment once; it does not detect the next drift.
+- **Role-agnostic revokes as a convention.** V25–V28 reaching past the roles they name is
+  what made this set legible, so it worked out here. It is still a footgun: future revoke
+  migrations should scope to the roles they mean, or state in the header that they are
+  intentionally global.

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -29,6 +29,16 @@
 --   configuration, tool management, document ingest) and no accounting, catalog,
 --   workorder, inventory or shop authority. ADMIN remains the all-domain role
 --   and is a strict superset.
+--   This block is additive, so it could not undo a grant made outside it, and
+--   something outside it did: #1512 found SYSTEM_ADMINISTRATOR holding 398
+--   permissions on alpha -- every row then in the permissions table -- against
+--   the 40 granted here. The decision stands unchanged, and
+--   V31__revoke_system_administrator_out_of_band_grants.sql enforces it by
+--   deleting the role's grants that this block does not make. V31 carries a copy
+--   of the SYSTEM_ADMINISTRATOR rows below, because SQL cannot read a repeatable
+--   migration in another file; RolePermissionBaselineTest fails the build if the
+--   two copies ever disagree. Editing this role's grants therefore means editing
+--   V31 too.
 -- * The retired switch also expanded ACCOUNTANT, AP_CLERK, CONTROLLER, CSR,
 --   FLEET_MANAGER and GL_ANALYST. Those are NOT reproduced here except
 --   CONTROLLER (see the 2026-08 rescope bullet below): no migration and no

--- a/pos-security-service/src/main/resources/db/migration/V31__revoke_system_administrator_out_of_band_grants.sql
+++ b/pos-security-service/src/main/resources/db/migration/V31__revoke_system_administrator_out_of_band_grants.sql
@@ -1,0 +1,136 @@
+-- #1512: revoke the out-of-band grants that made SYSTEM_ADMINISTRATOR a superuser
+-- on a live environment.
+--
+-- WHAT HAPPENED
+-- Between 2026-08-24 and 2026-08-25 23:38 something granted SYSTEM_ADMINISTRATOR
+-- every row then in the permissions table. On alpha the role reads 398 grants
+-- against a seed that gives it 40. The investigation in #1512 accounted for the
+-- 83-row gap with no remainder (48 revoked role-agnostically by V25/V26/V27/V28,
+-- 35 registered after the grant ran), ruled out seed drift, the durion
+-- seed-generator and a startup bootstrap, and could not name the actor -- the
+-- table had no provenance columns until V30. Twelve of the grants are codes no
+-- version of the seed has ever given to any role, including families ADR-0044 §6
+-- retired, so this cannot be an older seed.
+--
+-- THE DECISION
+-- SYSTEM_ADMINISTRATOR is not a superuser. That is the model
+-- R__seed_role_permissions.sql documents and #1373 settled: SYSTEM_ADMINISTRATOR
+-- holds the security/admin surface plus MCP administration, ADMIN is the
+-- all-domain role. This migration makes the database agree with it. The grants
+-- were never in version control, so there is nothing to revise in the seed --
+-- the seed was right and the environment drifted from it.
+--
+-- SCOPE -- deliberately role-scoped, and only to the extra rows
+-- The DELETE names SYSTEM_ADMINISTRATOR and removes only the grants the seed
+-- does not make. It touches no other role. This is the opposite of the V25-V28
+-- shape, whose role-agnostic DELETEs reached beyond the roles those migrations
+-- were written for and silently stripped 48 grants off this very role -- the
+-- footgun #1512 called out. A revoke that means one role says so in its WHERE
+-- clause.
+--
+-- WHY A NAME LIST AND NOT A JOIN TO THE SEED
+-- The seed is a separate repeatable file; SQL cannot read it. The list below is
+-- a copy of its SYSTEM_ADMINISTRATOR grant block, and
+-- RolePermissionBaselineTest#v31KeepListMatchesTheSeededSystemAdministratorGrants
+-- fails the build if the two ever disagree. That test is the real guard: a name
+-- misspelled here would drop a legitimate grant, and no SQL-side check can tell
+-- a typo from a permission that simply is not registered yet.
+--
+-- ORDERING AND IDEMPOTENCE
+-- Flyway runs versioned migrations before repeatable ones, so on a fresh
+-- database this executes against an unseeded table and deletes nothing; the
+-- baseline arrives afterwards. On an existing database the repeatable seed
+-- re-runs immediately after this migration (its checksum changed in the same
+-- change), which both restores the 40 canonical grants if anything here were
+-- wrong and aborts loudly through its own section-4 assertion if a name failed
+-- to resolve. Re-running this statement is a no-op: the second pass finds
+-- nothing outside the keep list.
+DO $$
+DECLARE
+    -- The SYSTEM_ADMINISTRATOR grant block of R__seed_role_permissions.sql, verbatim.
+    baseline CONSTANT TEXT[] := ARRAY[
+        'image:image:store',
+        'mcp:chat:execute',
+        'mcp:chat:stream',
+        'mcp:document:ingest',
+        'mcp:llm_api:create',
+        'mcp:llm_api:delete',
+        'mcp:llm_api:update',
+        'mcp:llm_api:view',
+        'mcp:system_prompt:create',
+        'mcp:system_prompt:delete',
+        'mcp:system_prompt:update',
+        'mcp:system_prompt:view',
+        'mcp:tool:manage',
+        'mcp:tool:view',
+        'nlti:audit:read',
+        'nlti:request:read',
+        'nlti:request:submit',
+        'people:compliance:view',
+        'security:audit:create',
+        'security:audit:export',
+        'security:audit:view',
+        'security:authorization:decide',
+        'security:permission:register',
+        'security:permission:view',
+        'security:role:assign',
+        'security:role:create',
+        'security:role:delete',
+        'security:role:edit',
+        'security:role:view',
+        'security:token:issue_internal',
+        'security:user:create',
+        'security:user:delete',
+        'security:user:edit',
+        'security:user:view',
+        'security:user_account_state:manage',
+        'security:user_account_state:view',
+        'supplier:audit:read',
+        'supplier:transmission:read',
+        'supplier:transmission:resolve',
+        'workorder:events:replay'
+    ];
+    sa_role_id UUID;
+    held INTEGER;
+    unresolved TEXT[];
+    revoked INTEGER;
+BEGIN
+    SELECT id INTO sa_role_id FROM roles WHERE name = 'SYSTEM_ADMINISTRATOR';
+    IF sa_role_id IS NULL THEN
+        RAISE NOTICE 'V31: the SYSTEM_ADMINISTRATOR role does not exist; nothing to revoke.';
+        RETURN;
+    END IF;
+
+    SELECT COUNT(*) INTO held FROM role_permissions WHERE role_id = sa_role_id;
+    IF held = 0 THEN
+        -- Fresh database: the repeatable baseline has not run yet, so there is no
+        -- drift to correct and no permissions table to resolve names against.
+        RAISE NOTICE 'V31: SYSTEM_ADMINISTRATOR holds no grants yet; nothing to revoke.';
+        RETURN;
+    END IF;
+
+    -- Reported, not fatal. An unregistered baseline name cannot cause a wrong
+    -- revoke -- the role could not hold a permission that does not exist -- so
+    -- aborting a deploy over one would trade a real outage for a theoretical
+    -- defect that the parity test already covers. It is still worth naming: on an
+    -- environment where the whole catalog is registered, an unresolved name means
+    -- this list has drifted from the seed.
+    -- Aliased rather than bare: an unqualified `name` inside the NOT EXISTS would
+    -- resolve to permissions.name and make the predicate a tautology.
+    SELECT array_agg(b.n ORDER BY b.n) INTO unresolved
+    FROM unnest(baseline) AS b(n)
+    WHERE NOT EXISTS (SELECT 1 FROM permissions p WHERE p.name = b.n);
+
+    IF unresolved IS NOT NULL THEN
+        RAISE WARNING 'V31: % baseline name(s) are not registered and were skipped: %',
+            array_length(unresolved, 1), array_to_string(unresolved, ', ');
+    END IF;
+
+    DELETE FROM role_permissions
+    WHERE role_id = sa_role_id
+      AND permission_id NOT IN (SELECT id FROM permissions WHERE name = ANY(baseline));
+
+    GET DIAGNOSTICS revoked = ROW_COUNT;
+    RAISE NOTICE 'V31: revoked % grant(s) from SYSTEM_ADMINISTRATOR; % held before, % remain.',
+        revoked, held, held - revoked;
+END $$;

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
@@ -103,6 +103,25 @@ class RolePermissionBaselineTest {
     private static final Path MIGRATIONS = Path.of("src/main/resources/db/migration");
 
     /**
+     * The #1512 revoke of SYSTEM_ADMINISTRATOR's out-of-band grants. Its keep list is a copy of
+     * this seed's SYSTEM_ADMINISTRATOR block, which is what
+     * {@link #v31KeepListMatchesTheSeededSystemAdministratorGrants} exists to police.
+     */
+    private static final Path V31_REVOKE =
+            MIGRATIONS.resolve("V31__revoke_system_administrator_out_of_band_grants.sql");
+
+    /**
+     * A lower-case, colon-bearing quoted literal — a permission name. Deliberately not matched
+     * against role names (upper-case, no colon) or the migration's {@code RAISE} messages (which
+     * start upper-case and contain spaces), so the keep list is the only thing it picks up once
+     * comments are stripped.
+     */
+    private static final Pattern QUOTED_PERMISSION = Pattern.compile("'([a-z][a-z0-9_.-]*(?::[a-z0-9_.-]+)+)'");
+
+    /** A {@code --} comment, to end of line. */
+    private static final Pattern SQL_LINE_COMMENT = Pattern.compile("--.*");
+
+    /**
      * Roles the retired hardcoded switch expanded that no migration and no runtime initializer
      * ever creates. Both {@code user_roles} and {@code role_assignments} are foreign-keyed to
      * {@code roles(id)}, so no user could hold one — they were unreachable branches, and their
@@ -567,6 +586,65 @@ class RolePermissionBaselineTest {
         assertThat(assertedPermissions)
                 .as("permissions asserted in section 4 vs permissions actually granted")
                 .isEqualTo(grantedPermissions);
+    }
+
+    @Test
+    @DisplayName("V31's keep list is exactly the SYSTEM_ADMINISTRATOR grants this seed makes")
+    void v31KeepListMatchesTheSeededSystemAdministratorGrants() throws IOException {
+        // V31 (#1512) deletes every SYSTEM_ADMINISTRATOR grant *not* in a hardcoded list, because
+        // SQL cannot read a repeatable seed in another file. That makes the list a second copy of
+        // this block, and a copy drifts. Both directions are a defect, and they fail differently:
+        // a name missing from V31 revokes authority the seed deliberately gives the role, and a
+        // name in V31 that the seed no longer grants keeps an out-of-band grant alive past the
+        // migration written to remove it. Equality is the only version of this that holds.
+        Set<String> keepList = parsePermissionLiterals(Files.readString(V31_REVOKE));
+
+        assertThat(keepList).as("no keep list parsed out of %s", V31_REVOKE).isNotEmpty();
+        assertThat(keepList)
+                .as("V31's keep list vs the seed's SYSTEM_ADMINISTRATOR grants")
+                .isEqualTo(seededGrants.get("SYSTEM_ADMINISTRATOR"));
+    }
+
+    @Test
+    @DisplayName("V31 revokes from SYSTEM_ADMINISTRATOR alone, never role-agnostically")
+    void v31RevokeIsScopedToSystemAdministrator() throws IOException {
+        // The #1512 investigation turned on V25-V28 deleting by permission_id with no role filter:
+        // written to retire grants from the seeded roles, they also stripped 48 grants off
+        // SYSTEM_ADMINISTRATOR, a role none of them mentions. V31 must not repeat that. A DELETE
+        // against role_permissions here has to name the role it means.
+        String body = SQL_LINE_COMMENT.matcher(Files.readString(V31_REVOKE)).replaceAll("");
+
+        assertThat(body)
+                .as("V31 must resolve the role it revokes from")
+                .contains("FROM roles WHERE name = 'SYSTEM_ADMINISTRATOR'");
+        assertThat(body)
+                .as("every DELETE against role_permissions in V31 must be role-scoped")
+                .containsPattern("DELETE FROM role_permissions\\s+WHERE role_id = sa_role_id");
+        assertThat(countOccurrences(body, "DELETE FROM role_permissions"))
+                .as("a second, unscoped DELETE would reintroduce the V25-V28 footgun")
+                .isEqualTo(1);
+    }
+
+    /** Permission names quoted in {@code sql}, with {@code --} comments stripped first. */
+    private static Set<String> parsePermissionLiterals(String sql) {
+        // Comments first: this migration's header names permission families in prose, and the
+        // audit tooling has already been bitten once by scoring a commented-out code as real
+        // (docs/rbac-permission-role-audit-2026-08.md, task 7).
+        String body = SQL_LINE_COMMENT.matcher(sql).replaceAll("");
+        Set<String> names = new TreeSet<>();
+        Matcher literal = QUOTED_PERMISSION.matcher(body);
+        while (literal.find()) {
+            names.add(literal.group(1));
+        }
+        return names;
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int at = haystack.indexOf(needle); at >= 0; at = haystack.indexOf(needle, at + 1)) {
+            count++;
+        }
+        return count;
     }
 
     private static String readResource(String name) throws IOException {

--- a/pos-security-service/src/test/java/com/positivity/securityservice/migration/SystemAdministratorRevokeIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/migration/SystemAdministratorRevokeIT.java
@@ -1,0 +1,201 @@
+package com.positivity.securityservice.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Covers {@code V31__revoke_system_administrator_out_of_band_grants.sql} (#1512).
+ *
+ * <p>{@code RolePermissionBaselineTest} proves the migration's keep list still matches the seed;
+ * that is a static parse and cannot show the statement does anything. This class reproduces the
+ * alpha defect against a real Postgres — grant SYSTEM_ADMINISTRATOR every row in the
+ * {@code permissions} table, which is exactly what happened between 2026-08-24 and 2026-08-25 —
+ * and re-applies V31 over it.
+ *
+ * <p>Three properties matter, and the migration is only worth having if all three hold: it
+ * removes the extra grants, it leaves the seeded baseline intact, and it touches no other role.
+ * The last one is not incidental. V25–V28 deleted by {@code permission_id} with no role filter
+ * and silently stripped 48 grants off a role none of them mentions; that is the collateral damage
+ * that made this investigation legible in the first place, and repeating it here would be a worse
+ * bug than the one being fixed.
+ *
+ * <p>Requires Docker.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("pg")
+@Testcontainers
+@DisplayName("SYSTEM_ADMINISTRATOR out-of-band grant revoke (Postgres)")
+class SystemAdministratorRevokeIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private static final String SEED = "db/migration/R__seed_role_permissions.sql";
+    private static final String REVOKE = "db/migration/V31__revoke_system_administrator_out_of_band_grants.sql";
+
+    private static String seedSql;
+    private static String revokeSql;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @DynamicPropertySource
+    static void seedPlaceholders(DynamicPropertyRegistry registry) {
+        registry.add("SECURITY_SEED_ADMIN_PASSWORD_HASH", () -> "not-a-real-hash-pg-test-only");
+    }
+
+    @BeforeAll
+    static void loadSql() throws IOException {
+        seedSql = readClasspath(SEED);
+        revokeSql = readClasspath(REVOKE);
+    }
+
+    @AfterEach
+    void restoreBaseline() {
+        // Every test corrupts role_permissions on purpose; hand the next one a clean baseline.
+        jdbc().execute(seedSql);
+    }
+
+    @Test
+    @DisplayName("the full migration chain leaves SYSTEM_ADMINISTRATOR on its seeded baseline")
+    void migrationChainLeavesTheSeededBaselineIntact() {
+        // V31 runs before the repeatable seed on a fresh database, so it must find nothing to do
+        // and delete nothing. If the keep list were wrong in the over-deleting direction this
+        // would still pass — the seed re-inserts afterwards — which is precisely why the
+        // corruption tests below re-apply V31 *after* the seed.
+        assertThat(grantedTo("SYSTEM_ADMINISTRATOR"))
+                .as("the security/admin surface, not a domain superset")
+                .contains("security:role:assign", "security:user:view", "mcp:tool:manage")
+                .doesNotContain("accounting:je:post", "workorder:workorder:edit", "catalog:product:create");
+    }
+
+    @Test
+    @DisplayName("revokes every grant the seed does not make, and keeps every grant it does")
+    void revokesTheOutOfBandGrantsAndKeepsTheBaseline() {
+        Set<String> baseline = new TreeSet<>(grantedTo("SYSTEM_ADMINISTRATOR"));
+        assertThat(baseline).as("baseline did not apply").isNotEmpty();
+
+        int catalogSize = grantEverythingToSystemAdministrator();
+        assertThat(grantedTo("SYSTEM_ADMINISTRATOR"))
+                .as("the alpha shape: every registered permission held by one role")
+                .hasSize(catalogSize);
+        assertThat(catalogSize)
+                .as("the corruption has to be observable, not a no-op")
+                .isGreaterThan(baseline.size());
+
+        jdbc().execute(revokeSql);
+
+        assertThat(new TreeSet<>(grantedTo("SYSTEM_ADMINISTRATOR")))
+                .as("after V31, exactly the grants R__seed_role_permissions.sql makes")
+                .isEqualTo(baseline);
+    }
+
+    @Test
+    @DisplayName("revokes from SYSTEM_ADMINISTRATOR alone, leaving every other role untouched")
+    void leavesEveryOtherRoleUntouched() {
+        Map<String, Integer> before = grantCountsByRole();
+        grantEverythingToSystemAdministrator();
+
+        jdbc().execute(revokeSql);
+
+        Map<String, Integer> after = grantCountsByRole();
+        before.remove("SYSTEM_ADMINISTRATOR");
+        after.remove("SYSTEM_ADMINISTRATOR");
+        assertThat(after)
+                .as("a role-agnostic DELETE here would repeat the V25-V28 collateral damage")
+                .isEqualTo(before);
+    }
+
+    @Test
+    @DisplayName("re-applying the revoke changes nothing")
+    void revokeIsIdempotent() {
+        grantEverythingToSystemAdministrator();
+        jdbc().execute(revokeSql);
+        int afterFirst = totalGrants();
+
+        jdbc().execute(revokeSql);
+        jdbc().execute(revokeSql);
+
+        assertThat(totalGrants())
+                .as("the second pass finds nothing outside the keep list")
+                .isEqualTo(afterFirst);
+    }
+
+    /**
+     * Reproduces the alpha grant: every row then in {@code permissions}, handed to one role.
+     *
+     * @return the size of the permission catalog, which is what the role now holds
+     */
+    private int grantEverythingToSystemAdministrator() {
+        jdbc().update("INSERT INTO role_permissions (role_id, permission_id) "
+                + "SELECT r.id, p.id FROM roles r CROSS JOIN permissions p "
+                + "WHERE r.name = 'SYSTEM_ADMINISTRATOR' "
+                + "ON CONFLICT DO NOTHING");
+        Integer catalogSize = jdbc().queryForObject("SELECT count(*) FROM permissions", Integer.class);
+        return catalogSize == null ? 0 : catalogSize;
+    }
+
+    private Map<String, Integer> grantCountsByRole() {
+        return jdbc().query(
+                        "SELECT r.name, count(rp.permission_id) AS held FROM roles r "
+                                + "LEFT JOIN role_permissions rp ON rp.role_id = r.id "
+                                + "GROUP BY r.name",
+                        rs -> {
+                            Map<String, Integer> counts = new TreeMap<>();
+                            while (rs.next()) {
+                                counts.put(rs.getString("name"), rs.getInt("held"));
+                            }
+                            return counts;
+                        });
+    }
+
+    private List<String> grantedTo(String roleName) {
+        return jdbc().queryForList(
+                        "SELECT p.name FROM roles r "
+                                + "JOIN role_permissions rp ON rp.role_id = r.id "
+                                + "JOIN permissions p ON p.id = rp.permission_id "
+                                + "WHERE r.name = ?",
+                        String.class,
+                        roleName);
+    }
+
+    private int totalGrants() {
+        Integer count = jdbc().queryForObject("SELECT count(*) FROM role_permissions", Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    private JdbcTemplate jdbc() {
+        return new JdbcTemplate(dataSource);
+    }
+
+    private static String readClasspath(String name) throws IOException {
+        try (InputStream in = SystemAdministratorRevokeIT.class.getClassLoader().getResourceAsStream(name)) {
+            assertThat(in).as("%s not on the classpath", name).isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — bug fix, no capability id
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1512
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — no contract-relevant files change. This PR touches one Flyway
migration, the repeatable role-permission seed's comment header, two test classes
and the audit doc. No controller, DTO, request/response type, event or
`openapi.yaml` is modified, so no `BACKEND_CONTRACT_GUIDE.md` entry moves.

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

**What changed:** `V31__revoke_system_administrator_out_of_band_grants.sql` deletes
SYSTEM_ADMINISTRATOR's `role_permissions` rows that `R__seed_role_permissions.sql`
does not grant, plus the tests and documentation that keep it honest.

| File | |
| --- | --- |
| `V31__revoke_system_administrator_out_of_band_grants.sql` | new — the role-scoped revoke |
| `RolePermissionBaselineTest` | +2 tests: keep-list parity with the seed, and role-scoping |
| `SystemAdministratorRevokeIT` | new — reproduces the alpha shape under Testcontainers |
| `R__seed_role_permissions.sql` | policy bullet: the decision, and that editing this role's grants means editing V31 too |
| `docs/rbac-permission-role-audit-2026-08.md` | task 8 subsection; corrects the §1 caveat |

**Why:** this is the reopened half of #1512. Alpha carried **398** grants for
SYSTEM_ADMINISTRATOR against a seed that gives it **40** — every row then in the
`permissions` table, granted outside version control between 2026-08-24 and
2026-08-25 23:38. The investigation on the issue ruled out seed drift (ADMIN reads
exactly the seeded 420), the durion seed-generator (emits no role/permission mapping
at all) and a bootstrap running at startup (V28 installed on the most recent boot and
the count stayed at 398). Twelve of the grants are codes no version of the seed has
ever given to any role, including families ADR-0044 §6 retired, so they cannot have
arrived through role grants at any point in the seed's history.

The decision is that **SYSTEM_ADMINISTRATOR is not a superuser** — unchanged from
#1373 and from what the seed's policy header already states. The environment drifted
from the model; the model was right. The grants were never in version control, so
there is nothing in the seed to revise.

Three properties the migration is built around:

- **Role-scoped on purpose.** The `DELETE` names SYSTEM_ADMINISTRATOR in its `WHERE`
  clause. This is the deliberate opposite of the V25–V28 shape, whose role-agnostic
  deletes silently stripped 48 grants off a role none of them mentions — the footgun
  the issue called out. A revoke that means one role should say so.
- **The keep list is guarded, not trusted.** SQL cannot read a repeatable migration in
  another file, so V31 carries a copy of the seed's 40 SYSTEM_ADMINISTRATOR rows.
  `RolePermissionBaselineTest#v31KeepListMatchesTheSeededSystemAdministratorGrants`
  asserts the two copies are equal **in both directions**: a name missing from V31
  revokes authority the seed deliberately grants, and a name V31 keeps that the seed no
  longer grants outlives the migration written to remove it.
- **Safe on a fresh database.** Flyway runs versioned migrations before repeatable ones,
  so V31 finds no role and returns; the baseline arrives afterwards. On an existing
  database the seed re-runs immediately after (its checksum changes in this PR), which
  re-asserts the 40 canonical grants.

## Tests
- [x] Unit tests added/updated — 2 in `RolePermissionBaselineTest` (pure parse, no DB)
- [x] Integration tests added/updated — `SystemAdministratorRevokeIT` (Testcontainers Postgres)
- [ ] Provider behavioral contract tests added/updated — n/a, no API surface changed

**How to run:**

```bash
./mvnw -pl pos-security-service -am -Dtest=RolePermissionBaselineTest -DskipTests=false test
./mvnw -pl pos-security-service -am -Dit.test=SystemAdministratorRevokeIT verify   # requires Docker
python3 scripts/audit-rbac.py --check
```

**Results.** Full `pos-security-service` unit suite green (510 tests, with Spotless,
Checkstyle and SpotBugs in the same build). `scripts/audit-rbac.py --check` stays green —
no seed grant changed, so the gate sees no drift.

Docker Hub blob pulls are blocked in the environment this was written in, so
`SystemAdministratorRevokeIT` could not execute here. Its assertions were instead run by
hand against a local PostgreSQL 16 with the full `pos-security-service` migration chain
applied:

- Chain applies clean with V31 in it; SYSTEM_ADMINISTRATOR seeds at **40**, ADMIN at 425.
- Alpha shape reproduced — SYSTEM_ADMINISTRATOR granted all 486 rows in `permissions` —
  then V31: back to **40**, byte-identical to the pre-corruption grant list, with
  per-role grant counts unchanged for **every other role**.
- Two further runs of V31 revoke 0.
- The role-absent, no-grants-yet and unresolved-name branches were each exercised; the
  unresolved-name path warns and names the code rather than aborting the deploy.

Both new unit tests were mutation-checked: removing `security:role:view` from V31's keep
list fails the parity test, and widening the `WHERE` to `OR TRUE` fails the scoping test.

## Risk & Rollback
- **Risk level:** Low on any environment that matches its seed — V31 is a no-op there,
  as it is on a fresh database. The real change is on alpha, where it removes ~358
  grants one role should never have had. Nothing else is touched: no schema change, no
  other role, no permission definition, no bit index.
- **Rollback plan:** revert the commit. Reverting alone does not restore the deleted rows
  — nor should it, since they were never in version control; a fresh Flyway run against
  the reverted seed reproduces the intended 40. If an operator needs the wide grant back
  temporarily, re-grant explicitly through the role-permission admin API, which now stamps
  `granted_at`/`granted_by` (V30) so the next reader can see who did it.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, no capability; branch is the issue's assigned `claude/issue-1512-remaining-rvo8pw`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability id
- [x] Links to parent + child issues are present — #1512
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending on this PR

## Still open on #1512 after this PR

Both need input or access beyond this repository, and neither blocks the revoke:

- **The actor is still unnamed.** V30 gave `role_permissions` provenance columns, but
  these rows predate it. Alpha deploy and ops logs for 2026-08-24 and 2026-08-25 are the
  only thing that can identify what ran.
- **The CI gate still reads only the seed.** `scripts/audit-rbac.py --check` proves the
  seed is self-consistent and reported green throughout the window in which alpha carried
  358 grants the seed never made. V31 corrects the environment once; it does not detect
  the next drift. Proving a *running* environment matches its seed is a different check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eq1o7uJYtFFhtyHXcVJrZi)_