### PR TITLE
fix(inventory): retarget stale putaway rule destinations and guard against recurrence (#1543)

### DIFF
--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/PutawayRuleDestinationStartupCheck.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/PutawayRuleDestinationStartupCheck.java
@@ -1,0 +1,134 @@
+package com.positivity.inventory.internal.config;
+
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.entity.PutawayRule;
+import com.positivity.inventory.internal.enums.PutawayRuleMatchType;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.PutawayRuleRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Says out loud, once per boot, whether the enabled putaway rules point at storage locations that
+ * actually exist (issue #1543).
+ *
+ * <p><strong>It informs; it never fails startup.</strong> On alpha, the terminal {@code ANY} rule
+ * carried a destination that was never a {@code storage_location} row, and because {@code ANY} is
+ * the fallback tier that catches every SKU, every putaway execution on the environment failed —
+ * discovered only by symptom, one refused execution at a time. An unresolvable terminal fallback is
+ * a configuration state worth announcing at boot rather than at the first receipt, so this check
+ * reports it at ERROR; an unresolvable non-{@code ANY} rule breaks only the lines it matches and is
+ * reported at WARN.
+ *
+ * <p>Existence is judged against the {@code ext_storage_location} replica, the same source
+ * execution's {@code StorageLocationValidationService} consults — so what this check calls broken
+ * is exactly what {@code executePutaway} will refuse. A completely empty replica is the one state
+ * this cannot distinguish from misconfiguration: on a freshly provisioned environment the
+ * location facts may simply not have arrived yet, so that case gets a single WARN naming the
+ * hydration gap instead of a false alarm per rule.
+ */
+@Component
+public class PutawayRuleDestinationStartupCheck implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(PutawayRuleDestinationStartupCheck.class);
+
+    private static final String STATUS_ACTIVE = "ACTIVE";
+
+    private final PutawayRuleRepository putawayRuleRepository;
+    private final ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
+
+    public PutawayRuleDestinationStartupCheck(
+            PutawayRuleRepository putawayRuleRepository,
+            ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository) {
+        this.putawayRuleRepository = putawayRuleRepository;
+        this.extStorageLocationReplicaRepository = extStorageLocationReplicaRepository;
+    }
+
+    @Override
+    @SuppressWarnings("java:S1181") // see catch block: an advisory log line must not be able to stop a boot
+    public void run(ApplicationArguments args) {
+        try {
+            check();
+        } catch (Throwable t) {
+            // Deliberately Throwable, not Exception: this class promises never to block startup,
+            // and the promise must hold even for an Error out of the persistence layer.
+            log.warn("Putaway rule destination startup check did not complete: {}", t.toString());
+        }
+    }
+
+    private void check() {
+        List<PutawayRule> enabledRules = putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAscRuleIdAsc();
+        Set<UUID> destinationIds = enabledRules.stream()
+                .map(PutawayRule::getDestinationLocationId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (destinationIds.isEmpty()) {
+            return;
+        }
+
+        if (extStorageLocationReplicaRepository.count() == 0) {
+            log.warn(
+                    "The ext_storage_location replica is empty, so the destinations of {} enabled putaway rule(s)"
+                            + " cannot be verified. If this environment has storage locations, pos-location's facts"
+                            + " have not been replicated yet and putaway execution will fail until they are.",
+                    enabledRules.size());
+            return;
+        }
+
+        Map<UUID, ExtStorageLocationReplica> replicasById =
+                extStorageLocationReplicaRepository.findAllById(destinationIds).stream()
+                        .collect(
+                                Collectors.toMap(ExtStorageLocationReplica::getStorageLocationId, Function.identity()));
+
+        for (PutawayRule rule : enabledRules) {
+            UUID destinationId = rule.getDestinationLocationId();
+            if (destinationId == null) {
+                continue;
+            }
+            ExtStorageLocationReplica replica = replicasById.get(destinationId);
+            if (replica == null) {
+                reportMissing(rule, destinationId);
+            } else if (!STATUS_ACTIVE.equalsIgnoreCase(replica.getStatus())) {
+                log.warn(
+                        "Enabled putaway rule {} ({}) targets storage location {} whose status is {}, not ACTIVE."
+                                + " Putaway execution into it will be refused.",
+                        rule.getRuleId(),
+                        rule.getMatchType(),
+                        destinationId,
+                        replica.getStatus());
+            }
+        }
+    }
+
+    private void reportMissing(PutawayRule rule, UUID destinationId) {
+        if (rule.getMatchType() == PutawayRuleMatchType.ANY) {
+            // The terminal fallback catches every SKU no more specific rule claims, so an
+            // unresolvable destination here fails every putaway execution, not one route.
+            log.error(
+                    "The enabled ANY putaway rule {} targets storage location {}, which does not exist in the"
+                            + " ext_storage_location replica. ANY is the terminal fallback, so EVERY putaway"
+                            + " execution will fail with 'Destination storage location does not exist' until the"
+                            + " rule is retargeted at a real bin (issue #1543).",
+                    rule.getRuleId(),
+                    destinationId);
+        } else {
+            log.warn(
+                    "Enabled putaway rule {} ({}) targets storage location {}, which does not exist in the"
+                            + " ext_storage_location replica. Putaway execution for lines this rule matches will"
+                            + " fail until it is retargeted at a real bin.",
+                    rule.getRuleId(),
+                    rule.getMatchType(),
+                    destinationId);
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayRuleServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayRuleServiceImpl.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.enums.PutawayDestinationStrategy;
 import com.positivity.inventory.internal.enums.PutawayRuleMatchType;
 import com.positivity.inventory.internal.exception.DuplicateEnabledAnyPutawayRuleException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.service.PutawayRuleService;
 import java.util.Comparator;
@@ -37,6 +38,7 @@ public class PutawayRuleServiceImpl implements PutawayRuleService {
             .thenComparingInt(rule -> rule.getPriority() == null ? Integer.MAX_VALUE : rule.getPriority());
 
     private final PutawayRuleRepository putawayRuleRepository;
+    private final ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -58,6 +60,7 @@ public class PutawayRuleServiceImpl implements PutawayRuleService {
     public @NonNull PutawayRuleResponse createRule(@NonNull PutawayRuleRequest request) {
         boolean enabled = request.getIsEnabled() == null || request.getIsEnabled();
         enforceSingleEnabledAnyRule(request.getMatchType(), enabled, null);
+        requireResolvableDestination(request.getDestinationLocationId(), enabled);
 
         PutawayRule rule = PutawayRule.builder()
                 .priority(request.getPriority())
@@ -88,6 +91,7 @@ public class PutawayRuleServiceImpl implements PutawayRuleService {
         // somebody just wrote.
         boolean enabled = request.getIsEnabled() == null ? rule.isEnabled() : request.getIsEnabled();
         enforceSingleEnabledAnyRule(request.getMatchType(), enabled, parsedRuleId);
+        requireResolvableDestination(request.getDestinationLocationId(), enabled);
 
         rule.setPriority(request.getPriority());
         rule.setMatchType(request.getMatchType());
@@ -168,6 +172,41 @@ public class PutawayRuleServiceImpl implements PutawayRuleService {
                 .ifPresent(existing -> {
                     throw new DuplicateEnabledAnyPutawayRuleException(existing.getRuleId());
                 });
+    }
+
+    /**
+     * An enabled rule must target a storage location the {@code ext_storage_location} replica knows
+     * (issue #1543).
+     *
+     * <p>Rules are the only putaway artifact authored ahead of use, and a destination typo surfaces
+     * nowhere until execution: generation stamps the id onto tasks unchecked (deliberately — see the
+     * upgrade-window note in {@code PutawayValidationServiceImpl#validatePutaway}), claiming
+     * succeeds, and the first refusal is an operator with stock in hand. Alpha ran that way for
+     * months with the terminal {@code ANY} rule aimed at a bin that never existed. Refusing here
+     * moves the failure to the person editing the rule, who is the one who can fix it.
+     *
+     * <p>Two states pass without a lookup verdict. A <em>disabled</em> rule may say anything — it is
+     * unreachable, and refusing it would block the documented retire-by-disabling path when a rule's
+     * bin has since been decommissioned. And when the replica is <em>completely empty</em> the check
+     * stands down: on a freshly provisioned environment pos-location's facts may not have arrived
+     * yet, and refusing every rule until they do would turn a hydration lag into a configuration
+     * outage. That window is advisory-covered by {@code PutawayRuleDestinationStartupCheck}. A
+     * partially hydrated replica does refuse an unseen bin — by then absence is the best available
+     * evidence the id is wrong, and the error names the replica so a race with a just-created
+     * location is recognisable for what it is.
+     */
+    private void requireResolvableDestination(@Nullable UUID destinationLocationId, boolean enabled) {
+        if (!enabled || destinationLocationId == null) {
+            return;
+        }
+        if (extStorageLocationReplicaRepository.existsById(destinationLocationId)) {
+            return;
+        }
+        if (extStorageLocationReplicaRepository.count() == 0) {
+            return;
+        }
+        throw new IllegalArgumentException("Destination storage location " + destinationLocationId
+                + " does not exist in the storage-location replica");
     }
 
     /**

--- a/pos-inventory/src/main/resources/db/migration/R__seed_reference_inventory.sql
+++ b/pos-inventory/src/main/resources/db/migration/R__seed_reference_inventory.sql
@@ -39,6 +39,12 @@ ON CONFLICT (policy_id) DO NOTHING;
 -- An operator who deletes 6f46541c... and creates their own enabled ANY rule through the API will
 -- get this one re-inserted the next time the file's checksum changes, leaving two enabled ANY rules
 -- that the CRUD layer would have refused. Retarget this rule rather than replacing it.
+--
+-- The same DO NOTHING also means a correction edited into this VALUES list never reaches a database
+-- where the row already exists — the destination retarget above only ever applied to databases
+-- seeded from empty, which left every pre-existing environment broken (issue #1543). A correction
+-- to an already-seeded value needs a versioned migration; V46__retarget_stale_putaway_rule_destination.sql
+-- is the one that repairs this row's destination, and any future correction needs its own.
 INSERT INTO putaway_rule (rule_id, priority, match_type, match_value, destination_location_id, is_enabled, created_at, updated_at)
 VALUES ('6f46541c-937d-397a-076f-63e092cabed6'::uuid, 1, 'ANY', NULL, '01960004-0001-7000-8000-000000000003'::uuid, TRUE, NOW(), NOW())
 ON CONFLICT (rule_id) DO NOTHING;

--- a/pos-inventory/src/main/resources/db/migration/V46__retarget_stale_putaway_rule_destination.sql
+++ b/pos-inventory/src/main/resources/db/migration/V46__retarget_stale_putaway_rule_destination.sql
@@ -1,0 +1,27 @@
+-- Retarget putaway rules still pointing at the destination the seeded ANY rule originally shipped
+-- with (issue #1543).
+--
+-- 96dd346a-047c-86f5-3c9a-7c8cac53da86 is a site-level location id reused from a replenishment
+-- policy row; it is not, and never was, a row in storage_location. While the seeded ANY rule
+-- carried it, every putaway execution failed at PutawayValidationServiceImpl with "Destination
+-- storage location does not exist" — and because ANY is the terminal fallback tier, that meant
+-- every putaway on the environment, whatever the SKU.
+--
+-- 819a3e0bb retargeted the seed (R__seed_reference_inventory.sql) to
+-- 01960004-0001-7000-8000-000000000003 ('Main Parts Shelf', seeded by pos-location
+-- R__seed_location_2_operational_data.sql), but that seed inserts with ON CONFLICT (rule_id)
+-- DO NOTHING: on any database where the rule row already existed, the repeatable migration re-runs
+-- and changes nothing. The correction therefore only ever reached databases seeded from empty;
+-- every environment seeded before 819a3e0bb (alpha among them) kept the broken destination
+-- indefinitely. A repeatable additive seed cannot express a correction — this versioned migration
+-- can, the same forward-only pattern V25/V26 used for the RBAC revokes.
+--
+-- Scoped by the bad value rather than by rule_id, so an operator-authored rule that copied the
+-- destination is repaired too. Rows are matched on the one value known to be wrong, so this cannot
+-- touch legitimate configuration; on databases already carrying the corrected seed it matches
+-- nothing and is a no-op.
+
+UPDATE putaway_rule
+SET    destination_location_id = '01960004-0001-7000-8000-000000000003',
+       updated_at = NOW()
+WHERE  destination_location_id = '96dd346a-047c-86f5-3c9a-7c8cac53da86';

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/config/PutawayRuleDestinationStartupCheckTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/config/PutawayRuleDestinationStartupCheckTest.java
@@ -1,0 +1,209 @@
+package com.positivity.inventory.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.entity.PutawayRule;
+import com.positivity.inventory.internal.enums.PutawayRuleMatchType;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.PutawayRuleRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The boot-time notice about enabled putaway rules whose destinations do not resolve (#1543).
+ *
+ * <p>Every test asserts the runner does not throw, because that is its central promise: it advises
+ * and never vetoes startup.
+ */
+@DisplayName("PutawayRuleDestinationStartupCheck")
+class PutawayRuleDestinationStartupCheckTest {
+
+    private static final UUID ANY_RULE_ID = UUID.fromString("6f46541c-937d-397a-076f-63e092cabed6");
+    private static final UUID CATEGORY_RULE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a01");
+    private static final UUID KNOWN_BIN = UUID.fromString("01960004-0001-7000-8000-000000000003");
+    private static final UUID UNKNOWN_BIN = UUID.fromString("96dd346a-047c-86f5-3c9a-7c8cac53da86");
+
+    private final PutawayRuleRepository ruleRepository = mock(PutawayRuleRepository.class);
+    private final ExtStorageLocationReplicaRepository replicaRepository =
+            mock(ExtStorageLocationReplicaRepository.class);
+
+    private ListAppender<ILoggingEvent> appender;
+    private ch.qos.logback.classic.Logger logger;
+    private Level originalLevel;
+
+    @BeforeEach
+    void captureLogs() {
+        logger =
+                ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(PutawayRuleDestinationStartupCheck.class);
+        originalLevel = logger.getLevel();
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void releaseLogs() {
+        logger.detachAppender(appender);
+        appender.stop();
+        // Restore rather than leave INFO pinned on a shared, JVM-wide logger: the level outlives
+        // this class and would otherwise silently reconfigure logging for every test after it.
+        logger.setLevel(originalLevel);
+    }
+
+    private void run() {
+        assertThatCode(() -> new PutawayRuleDestinationStartupCheck(ruleRepository, replicaRepository).run(null))
+                .doesNotThrowAnyException();
+    }
+
+    private static PutawayRule rule(UUID ruleId, PutawayRuleMatchType matchType, UUID destination) {
+        return PutawayRule.builder()
+                .ruleId(ruleId)
+                .priority(1)
+                .matchType(matchType)
+                .destinationLocationId(destination)
+                .isEnabled(true)
+                .build();
+    }
+
+    private static ExtStorageLocationReplica replica(UUID locationId, String status) {
+        return ExtStorageLocationReplica.builder()
+                .storageLocationId(locationId)
+                .status(status)
+                .build();
+    }
+
+    private void withEnabledRules(PutawayRule... rules) {
+        when(ruleRepository.findAllByIsEnabledTrueOrderByPriorityAscRuleIdAsc()).thenReturn(List.of(rules));
+        when(replicaRepository.count()).thenReturn(1L);
+    }
+
+    @Test
+    @DisplayName("every destination resolving to an ACTIVE bin says nothing at all")
+    void healthyConfigurationLogsNothing() {
+        withEnabledRules(rule(ANY_RULE_ID, PutawayRuleMatchType.ANY, KNOWN_BIN));
+        when(replicaRepository.findAllById(anyCollection())).thenReturn(List.of(replica(KNOWN_BIN, "ACTIVE")));
+
+        run();
+
+        // The common case. A boot line about healthy configuration is noise, and noise is how the
+        // one ERROR this check exists for gets ignored.
+        assertThat(appender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("#1543 - the ANY rule aimed at a bin the replica has never seen is an ERROR: all putaway fails")
+    void missingAnyDestinationIsAnError() {
+        withEnabledRules(rule(ANY_RULE_ID, PutawayRuleMatchType.ANY, UNKNOWN_BIN));
+        when(replicaRepository.findAllById(anyCollection())).thenReturn(List.of());
+
+        run();
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+            assertThat(event.getFormattedMessage())
+                    .contains(ANY_RULE_ID.toString(), UNKNOWN_BIN.toString(), "EVERY putaway");
+        });
+    }
+
+    @Test
+    @DisplayName("an unresolvable non-ANY rule breaks only its own routes, so it warns")
+    void missingNonAnyDestinationWarns() {
+        withEnabledRules(rule(CATEGORY_RULE_ID, PutawayRuleMatchType.CATEGORY, UNKNOWN_BIN));
+        when(replicaRepository.findAllById(anyCollection())).thenReturn(List.of());
+
+        run();
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains(CATEGORY_RULE_ID.toString(), "CATEGORY");
+        });
+    }
+
+    @Test
+    @DisplayName("a destination that exists but is not ACTIVE warns, since execution will refuse it")
+    void inactiveDestinationWarns() {
+        withEnabledRules(rule(ANY_RULE_ID, PutawayRuleMatchType.ANY, KNOWN_BIN));
+        when(replicaRepository.findAllById(anyCollection())).thenReturn(List.of(replica(KNOWN_BIN, "DECOMMISSIONED")));
+
+        run();
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains(KNOWN_BIN.toString(), "DECOMMISSIONED");
+        });
+    }
+
+    @Test
+    @DisplayName("an empty replica is a hydration gap, not a per-rule alarm: one WARN, no false ERROR")
+    void emptyReplicaWarnsOnceInsteadOfAccusingEveryRule() {
+        when(ruleRepository.findAllByIsEnabledTrueOrderByPriorityAscRuleIdAsc())
+                .thenReturn(List.of(
+                        rule(ANY_RULE_ID, PutawayRuleMatchType.ANY, KNOWN_BIN),
+                        rule(CATEGORY_RULE_ID, PutawayRuleMatchType.CATEGORY, KNOWN_BIN)));
+        when(replicaRepository.count()).thenReturn(0L);
+
+        run();
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains("replica is empty", "2");
+        });
+        verify(replicaRepository, never()).findAllById(anyCollection());
+    }
+
+    @Test
+    @DisplayName("no enabled rules says nothing and never touches the replica")
+    void noEnabledRulesLogsNothing() {
+        when(ruleRepository.findAllByIsEnabledTrueOrderByPriorityAscRuleIdAsc()).thenReturn(List.of());
+
+        run();
+
+        assertThat(appender.list).isEmpty();
+        verify(replicaRepository, never()).count();
+    }
+
+    @Test
+    @DisplayName("a failing repository is swallowed so startup never blocks")
+    void repositoryFailureIsSwallowed() {
+        when(ruleRepository.findAllByIsEnabledTrueOrderByPriorityAscRuleIdAsc())
+                .thenThrow(new IllegalStateException("database unavailable"));
+
+        run();
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains("database unavailable");
+        });
+    }
+
+    @Test
+    @DisplayName("even an Error is swallowed — the promise is never to block startup, not merely to catch Exception")
+    void errorIsAlsoSwallowed() {
+        when(ruleRepository.findAllByIsEnabledTrueOrderByPriorityAscRuleIdAsc())
+                .thenThrow(new OutOfMemoryError("rule set too large"));
+
+        run();
+
+        assertThat(appender.list).singleElement().satisfies(event -> {
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains("rule set too large");
+        });
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayRuleServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayRuleServiceImplTest.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.enums.PutawayDestinationStrategy;
 import com.positivity.inventory.internal.enums.PutawayRuleMatchType;
 import com.positivity.inventory.internal.exception.DuplicateEnabledAnyPutawayRuleException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import java.util.List;
 import java.util.Optional;
@@ -43,11 +44,17 @@ class PutawayRuleServiceImplTest {
     @Mock
     private PutawayRuleRepository putawayRuleRepository;
 
+    @Mock
+    private ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
+
     private PutawayRuleServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new PutawayRuleServiceImpl(putawayRuleRepository);
+        service = new PutawayRuleServiceImpl(putawayRuleRepository, extStorageLocationReplicaRepository);
+        // Destinations resolve by default so the pre-#1543 cases keep exercising what they exercise;
+        // the DestinationValidation nest overrides this to test the refusal itself.
+        when(extStorageLocationReplicaRepository.existsById(any(UUID.class))).thenReturn(true);
         when(putawayRuleRepository.saveAndFlush(any(PutawayRule.class))).thenAnswer(inv -> {
             PutawayRule saved = inv.getArgument(0);
             if (saved.getRuleId() == null) {
@@ -182,6 +189,75 @@ class PutawayRuleServiceImplTest {
             assertThat(service.createRule(request(PutawayRuleMatchType.CATEGORY, TIRES_CATEGORY.toString()))
                             .getMatchType())
                     .isEqualTo("CATEGORY");
+        }
+    }
+
+    @Nested
+    @DisplayName("destination validation (#1543)")
+    class DestinationValidation {
+
+        @Test
+        @DisplayName("refuses creating an enabled rule aimed at a bin the replica has never seen")
+        void refusesAnUnknownDestinationOnCreate() {
+            when(extStorageLocationReplicaRepository.existsById(DESTINATION)).thenReturn(false);
+            when(extStorageLocationReplicaRepository.count()).thenReturn(5L);
+            PutawayRuleRequest request = request(PutawayRuleMatchType.ANY, null);
+
+            assertThatThrownBy(() -> service.createRule(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(DESTINATION.toString())
+                    .hasMessageContaining("does not exist");
+
+            verify(putawayRuleRepository, never()).saveAndFlush(any(PutawayRule.class));
+        }
+
+        @Test
+        @DisplayName("refuses retargeting an enabled rule at a bin the replica has never seen")
+        void refusesAnUnknownDestinationOnUpdate() {
+            when(putawayRuleRepository.findById(RULE_ID))
+                    .thenReturn(Optional.of(entity(RULE_ID, PutawayRuleMatchType.CATEGORY, 10)));
+            when(extStorageLocationReplicaRepository.existsById(DESTINATION)).thenReturn(false);
+            when(extStorageLocationReplicaRepository.count()).thenReturn(5L);
+            PutawayRuleRequest request = request(PutawayRuleMatchType.CATEGORY, TIRES_CATEGORY.toString());
+            String ruleId = RULE_ID.toString();
+
+            assertThatThrownBy(() -> service.updateRule(ruleId, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(DESTINATION.toString());
+
+            verify(putawayRuleRepository, never()).saveAndFlush(any(PutawayRule.class));
+        }
+
+        @Test
+        @DisplayName("a DISABLED rule may say anything — retiring a rule whose bin is gone must stay possible")
+        void allowsAnUnknownDestinationOnADisabledRule() {
+            when(extStorageLocationReplicaRepository.existsById(DESTINATION)).thenReturn(false);
+            when(extStorageLocationReplicaRepository.count()).thenReturn(5L);
+            PutawayRuleRequest request = request(PutawayRuleMatchType.ANY, null);
+            request.setIsEnabled(false);
+
+            assertThat(service.createRule(request).getIsEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("an empty replica stands the check down: hydration lag must not become a config outage")
+        void allowsAnyDestinationWhileTheReplicaIsEmpty() {
+            when(extStorageLocationReplicaRepository.existsById(DESTINATION)).thenReturn(false);
+            when(extStorageLocationReplicaRepository.count()).thenReturn(0L);
+
+            assertThat(service.createRule(request(PutawayRuleMatchType.ANY, null))
+                            .getIsEnabled())
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("a resolvable destination passes without consulting the replica row count")
+        void acceptsAKnownDestinationWithoutCounting() {
+            when(extStorageLocationReplicaRepository.existsById(DESTINATION)).thenReturn(true);
+
+            service.createRule(request(PutawayRuleMatchType.CATEGORY, TIRES_CATEGORY.toString()));
+
+            verify(extStorageLocationReplicaRepository, never()).count();
         }
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/migration/PutawayRuleRetargetStaleDestinationMigrationTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/migration/PutawayRuleRetargetStaleDestinationMigrationTest.java
@@ -1,0 +1,178 @@
+package com.positivity.inventory.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Runs {@code V46__retarget_stale_putaway_rule_destination.sql} verbatim against an in-memory H2 in
+ * PostgreSQL mode (issue #1543).
+ *
+ * <p>The point of V46 is that the correction the repeatable seed could not deliver — its
+ * {@code ON CONFLICT (rule_id) DO NOTHING} never touches an existing row — reaches every
+ * already-seeded database. So beyond parsing on the engine the {@code dev} profile runs, the tests
+ * pin the migration's scoping: every rule carrying the known-bad destination is retargeted whatever
+ * its id or tier (operator copies included), and any other destination is left alone.
+ */
+class PutawayRuleRetargetStaleDestinationMigrationTest {
+
+    private static final String MIGRATION = "/db/migration/V46__retarget_stale_putaway_rule_destination.sql";
+
+    /** The destination that was never a storage_location row; see the migration header. */
+    private static final String STALE_DESTINATION = "96dd346a-047c-86f5-3c9a-7c8cac53da86";
+
+    /** 'Main Parts Shelf' — the destination the seed has carried since 819a3e0bb. */
+    private static final String CORRECTED_DESTINATION = "01960004-0001-7000-8000-000000000003";
+
+    private Connection connection;
+
+    @BeforeEach
+    void openConnection() throws Exception {
+        connection = DriverManager.getConnection(
+                "jdbc:h2:mem:v46_" + UUID.randomUUID() + ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1", "sa", "");
+        createPutawayRuleTable();
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        connection.close();
+    }
+
+    /** The columns V46 touches, in the shape V42/V44 leave them; same reduction as the V44 test. */
+    private void createPutawayRuleTable() throws SQLException {
+        MigrationScripts.execute(connection, """
+                CREATE TABLE putaway_rule (
+                    rule_id uuid NOT NULL PRIMARY KEY,
+                    priority integer NOT NULL,
+                    match_type character varying(20) NOT NULL,
+                    match_value character varying(128),
+                    destination_location_id uuid NOT NULL,
+                    destination_strategy character varying(32) NOT NULL DEFAULT 'FIXED',
+                    is_enabled boolean NOT NULL,
+                    enabled_any_guard character varying(3),
+                    created_at timestamp(6) with time zone NOT NULL,
+                    updated_at timestamp(6) with time zone NOT NULL
+                )
+                """);
+    }
+
+    private void applyMigration() throws Exception {
+        for (String statement : MigrationScripts.statements(MIGRATION)) {
+            MigrationScripts.execute(connection, statement);
+        }
+    }
+
+    private void insertRule(String ruleId, String matchType, String destination) throws SQLException {
+        MigrationScripts.execute(
+                connection,
+                String.format(
+                        "INSERT INTO putaway_rule (rule_id, priority, match_type, match_value,"
+                                + " destination_location_id, destination_strategy, is_enabled, created_at,"
+                                + " updated_at) VALUES ('%s', 1, '%s', NULL, '%s', 'FIXED', TRUE,"
+                                + " CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                        ruleId, matchType, destination));
+    }
+
+    private static String rule(int n) {
+        return String.format("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a%02d", n);
+    }
+
+    @Test
+    @DisplayName("#1543 - the migration parses and applies on H2 in PostgreSQL mode")
+    void appliesOnH2() throws Exception {
+        applyMigration();
+
+        assertThat(MigrationScripts.count(connection, "putaway_rule", "1 = 1")).isZero();
+    }
+
+    @Test
+    @DisplayName("#1543 - the seeded ANY rule still carrying the stale destination is retargeted")
+    void retargetsTheStaleSeededRule() throws Exception {
+        insertRule("6f46541c-937d-397a-076f-63e092cabed6", "ANY", STALE_DESTINATION);
+
+        applyMigration();
+
+        assertThat(MigrationScripts.count(
+                        connection,
+                        "putaway_rule",
+                        "rule_id = '6f46541c-937d-397a-076f-63e092cabed6'" + " AND destination_location_id = '"
+                                + CORRECTED_DESTINATION + "'"))
+                .isEqualTo(1);
+        assertThat(MigrationScripts.count(
+                        connection, "putaway_rule", "destination_location_id = '" + STALE_DESTINATION + "'"))
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("#1543 - scoping is by the bad value, so an operator-authored copy is repaired too")
+    void retargetsOperatorCopiesOfTheStaleDestination() throws Exception {
+        insertRule(rule(1), "CATEGORY", STALE_DESTINATION);
+        insertRule(rule(2), "SKU", STALE_DESTINATION);
+
+        applyMigration();
+
+        assertThat(MigrationScripts.count(
+                        connection, "putaway_rule", "destination_location_id = '" + CORRECTED_DESTINATION + "'"))
+                .isEqualTo(2);
+        assertThat(MigrationScripts.count(
+                        connection, "putaway_rule", "destination_location_id = '" + STALE_DESTINATION + "'"))
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("#1543 - any other destination is legitimate configuration and is left untouched")
+    void leavesOtherDestinationsAlone() throws Exception {
+        String operatorBin = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5aff";
+        insertRule(rule(1), "CATEGORY", operatorBin);
+        insertRule(rule(2), "ANY", CORRECTED_DESTINATION);
+
+        applyMigration();
+
+        assertThat(MigrationScripts.count(
+                        connection,
+                        "putaway_rule",
+                        "rule_id = '" + rule(1) + "' AND destination_location_id = '" + operatorBin + "'"))
+                .isEqualTo(1);
+        assertThat(MigrationScripts.count(
+                        connection,
+                        "putaway_rule",
+                        "rule_id = '" + rule(2) + "' AND destination_location_id = '" + CORRECTED_DESTINATION + "'"))
+                .isEqualTo(1);
+    }
+
+    /**
+     * The migration's target must be the destination the repeatable seed carries, read from the real
+     * seed file so the two cannot drift: if the seed is ever retargeted again, this fails until a new
+     * versioned migration ships the correction to existing databases (the seed's own header says
+     * why editing its VALUES list is not enough).
+     */
+    @Test
+    @DisplayName("#1543 - the migration's corrected destination matches the seeded ANY rule's")
+    void correctedDestinationMatchesTheSeed() throws IOException {
+        Path seed = Path.of(System.getProperty("user.dir"))
+                .resolve("src/main/resources/db/migration/R__seed_reference_inventory.sql");
+        String seedSql = Files.readString(seed, StandardCharsets.UTF_8);
+
+        Matcher seededAnyRule = Pattern.compile(
+                        "VALUES \\('6f46541c-937d-397a-076f-63e092cabed6'::uuid, \\d+, 'ANY', NULL,"
+                                + " '([0-9a-f-]{36})'::uuid")
+                .matcher(seedSql);
+        assertThat(seededAnyRule.find())
+                .as("the seeded ANY putaway rule insert in R__seed_reference_inventory.sql")
+                .isTrue();
+        assertThat(seededAnyRule.group(1)).isEqualTo(CORRECTED_DESTINATION);
+    }
+}


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: n/a — bug fix, not capability work
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1543
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics changed; the putaway-rule endpoints keep their shapes. The only externally visible behavior change is that `POST`/`PUT /v1/inventory/putaway/rules` now returns the existing 400 `VALIDATION_ERROR` envelope when an **enabled** rule targets a destination the `ext_storage_location` replica has never seen.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed. No OpenAPI annotation, spec, or SDK impact.

## Scope
- What changed:
  - **`V46__retarget_stale_putaway_rule_destination.sql`** — versioned migration that retargets any `putaway_rule` still carrying `96dd346a-047c-86f5-3c9a-7c8cac53da86` (never a `storage_location` row) to `01960004-0001-7000-8000-000000000003` ('Main Parts Shelf'). Scoped by the bad value, not by `rule_id`, so operator-authored copies are repaired too; a no-op on databases already carrying the corrected seed.
  - **`PutawayRuleDestinationStartupCheck`** — boot-time advisory (never blocks startup) that reports enabled rules whose destinations do not resolve in the `ext_storage_location` replica: ERROR for the terminal `ANY` rule (its being unresolvable fails *every* putaway execution), WARN for tier rules and for existing-but-inactive bins. A completely empty replica gets one hydration-gap WARN instead of a false alarm per rule.
  - **`PutawayRuleServiceImpl`** — creating or updating an **enabled** rule whose destination the replica has never seen is now refused (400), moving the failure from the operator with stock in hand to the person editing the rule. Disabled rules are exempt (retiring a rule whose bin was decommissioned must stay possible), as is a completely un-hydrated replica (bootstrap ordering must not become a configuration outage).
  - **`R__seed_reference_inventory.sql`** — comment now documents that `ON CONFLICT DO NOTHING` means corrections edited into the seed never reach existing databases and need a versioned migration.
- Why: every environment seeded before `819a3e0bb` (alpha included) kept the broken `ANY`-rule destination indefinitely, because the seed's retarget only applied to databases seeded from empty. Every putaway execution on such an environment fails with `Destination storage location does not exist` (issue #1543, found by SDK integration suite D5). The two safeguards close the issue's open questions 1–2: the misconfiguration is now refused at authoring time and announced at boot, while generation-time semantics stay deliberately unchanged (see the upgrade-window note in `PutawayValidationServiceImpl#validatePutaway`).

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- `PutawayRuleRetargetStaleDestinationMigrationTest` runs V46 verbatim on H2 in PostgreSQL mode (the engine the `dev` profile runs): retargets the seeded rule and operator copies, leaves other destinations untouched, and pins the migration's corrected destination to the seeded `ANY` rule's destination read from the real seed file, so the two cannot drift.
- `PutawayRuleDestinationStartupCheckTest` covers ERROR/WARN classification, the empty-replica hydration WARN, silence on healthy config, and the never-blocks-startup promise (Exception and Error both swallowed).
- `PutawayRuleServiceImplTest` gains a `destination validation (#1543)` nest: refusal on create and update, disabled-rule exemption, empty-replica exemption.
- How to run: `./mvnw -pl pos-inventory -am test` (full module run: 1215 tests, 0 failures, ArchUnit included). After deploy, alpha verification is SDK suite `D5` (`npm run test:integration -- receiving`) going green end to end.

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the commit. V46 only rewrites rows carrying the one known-bad destination — a value that made those rules unusable — so there is no data state worth restoring; the startup check is advisory-only; the CRUD validation can be reverted independently if the replica-lag refusal proves too strict for a seeding flow.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, issue-fix branch `claude/issue-1543-analysis-dorvt8`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, bug fix
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — none changed
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6hNGaY6aVSwmFXwLrENUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6hNGaY6aVSwmFXwLrENUT)_