### PR TITLE
fix(deps): bump embedded Tomcat to 11.0.25 for 2026-08-28 CVE batch

### DIFF
--- a/build-tools/owasp-suppressions.xml
+++ b/build-tools/owasp-suppressions.xml
@@ -78,23 +78,4 @@
         <cve>CVE-2026-18022</cve>
     </suppress>
 
-    <!--
-        tomcat-embed-core-11.0.24 — CVE-2026-66299
-        DoS via uncontrolled resource consumption in the WebSocket chat example of Tomcat's
-        examples web application.  Embedded Tomcat as used by Spring Boot never ships the
-        examples webapp, so the vulnerable code is not deployed.  The fix release (11.0.25)
-        is announced but not yet published to Maven Central (latest is 11.0.24).  Remove this
-        suppression and bump tomcat.version once 11.0.25 is available.
-
-        Pinned to version 11.0.24 (the artifact wildcard stays because CPE matching flags the
-        sibling embed artifacts — websocket, el — which version-lock with core) so that any
-        tomcat.version bump forces this suppression to be re-evaluated rather than silently
-        carrying over.
-    -->
-    <suppress>
-        <notes>Examples-webapp-only CVE; examples are never shipped with embedded Tomcat; fix release 11.0.25 not on Maven Central yet.</notes>
-        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-[^:]+:11\.0\.24$</gav>
-        <cve>CVE-2026-66299</cve>
-    </suppress>
-
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -326,8 +326,9 @@
 		-->
 		<!-- CVE-2026-42198, CVE-2026-54291 -->
 		<postgresql.version>42.7.13</postgresql.version>
-		<!-- CVE-2026-53434, CVE-2026-55276, CVE-2026-59083, CVE-2026-59084 et al. -->
-		<tomcat.version>11.0.24</tomcat.version>
+		<!-- CVE-2026-65182, CVE-2026-65637, CVE-2026-65905, CVE-2026-66299, CVE-2026-68525 et al.
+		     (2026-08-28 scan flagged 11.0.24; 11.0.25 is the fix release published 2026-08-20) -->
+		<tomcat.version>11.0.25</tomcat.version>
 		<!-- CVE-2026-56820, CVE-2026-44891 et al. (19 CVEs fixed in 4.2.16) -->
 		<netty.version>4.2.17.Final</netty.version>
 		<!-- CVE-2026-54512 .. CVE-2026-54518 (fixed in 3.1.4) -->


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — security-scan maintenance (nightly OWASP dependency-check failure)
- Parent STORY (durion): N/A
- Child issue: N/A — fixes failed Security Scan run [33142748613](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/33142748613)
- Domain: `domain:platform` (shared build/dependency management)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- N/A — no controllers, DTOs, events, or OpenAPI files change; only the managed Tomcat version and the OWASP suppression file.

## Contract Chain (when a Controller changed)
- N/A — no controller changes.

## Scope
- What changed:
  - `pom.xml`: `tomcat.version` override bumped `11.0.24` → `11.0.25`; CVE comment updated to the current batch.
  - `build-tools/owasp-suppressions.xml`: removed the CVE-2026-66299 suppression pinned to `tomcat-embed-*:11.0.24`, as its own note directed once 11.0.25 published.
- Why: the nightly Security Scan failed on `pos-web-common` — `tomcat-embed-core:11.0.24` is flagged for CVE-2026-65182, CVE-2026-65183, CVE-2026-65637, CVE-2026-65905, CVE-2026-65927, CVE-2026-66422, CVE-2026-68525, CVE-2026-68569, CVE-2026-68763 (all CVSS ≥ 7.0) and CVE-2026-73180. Tomcat 11.0.25 is the fix release these CVEs were announced with and reached Maven Central on 2026-08-20 (the bump pre-planned in the #1211 suppression note).

## Tests
- [ ] Unit tests added/updated — N/A, version-property bump only; no code changes.
- [ ] Integration tests added/updated — N/A.
- [ ] Provider behavioral contract tests added/updated — N/A.
- How to run: OWASP dependency-check verified green on this branch via workflow_dispatch: [run 33159433008](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/33159433008). Regular CI covers the build/test suite on the new Tomcat patch release.

## Risk & Rollback
- Risk level: Low — patch-level upgrade within the Tomcat 11.0.x line already managed via the `tomcat.version` override.
- Rollback plan: revert this commit (restores 11.0.24 and the CVE-2026-66299 suppression); the security scan would then fail again on the CVE batch above.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, maintenance branch `claude/security-scan-failure-yi1p5h`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability
- [x] Links to parent + child issues are present — failing and verification runs linked above
- [ ] Contract guide updated — N/A, no contract semantics changed
- [x] Required CI checks passing — dependency-check green on branch (run linked above)

---
_Generated by [Claude Code](https://claude.ai/code/session_019q2U6bEF959AsufcWfEDt7)_