### PR TITLE
fix(sonar): remediate open reliability findings (xoym6g)

### DIFF
--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/RuleBasedContentDetectionServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/RuleBasedContentDetectionServiceImpl.java
@@ -113,10 +113,18 @@ public class RuleBasedContentDetectionServiceImpl implements ContentDetectionSer
     }
 
     private String normalize(String header) {
-        return header.toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9]+", "_")
-                .replaceAll("^_+", "")
-                .replaceAll("_+$", "");
+        String collapsed = header.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "_");
+        // Trim leading/trailing underscores without regex: "_+$" backtracks quadratically on
+        // underscore runs (Sonar S8786).
+        int start = 0;
+        int end = collapsed.length();
+        while (start < end && collapsed.charAt(start) == '_') {
+            start++;
+        }
+        while (end > start && collapsed.charAt(end - 1) == '_') {
+            end--;
+        }
+        return collapsed.substring(start, end);
     }
 
     private String inferTargetField(String normalized, DomainType domain) {

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogCommandListener.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogCommandListener.java
@@ -424,8 +424,8 @@ public class CatalogCommandListener {
         return Math.min(Math.max(requested, 1), MAX_REPLAY_LIMIT);
     }
 
-    private @Nullable UUID parseUuid(@Nullable JsonNode node, @NonNull String field) {
-        String value = node == null ? null : node.path(field).stringValue(null);
+    private @Nullable UUID parseUuid(@NonNull JsonNode node, @NonNull String field) {
+        String value = node.path(field).stringValue(null);
         if (value == null || value.isBlank()) {
             return null;
         }
@@ -437,8 +437,8 @@ public class CatalogCommandListener {
         }
     }
 
-    private @Nullable Instant parseInstant(@Nullable JsonNode payloadNode, @NonNull String field) {
-        String value = payloadNode == null ? null : payloadNode.path(field).stringValue(null);
+    private @Nullable Instant parseInstant(@NonNull JsonNode payloadNode, @NonNull String field) {
+        String value = payloadNode.path(field).stringValue(null);
         if (value == null || value.isBlank()) {
             return null;
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/putaway/service/PutawayValidationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/putaway/service/PutawayValidationService.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.exception.LocationAtCapacityException;
 import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
 import com.positivity.inventory.internal.exception.NoOnHandAtSourceLocationException;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Service for validating putaway operations according to business rules.
@@ -44,7 +45,8 @@ public interface PutawayValidationService {
      * @throws LocationNotValidForSkuException if location is invalid and no
      *                                         override
      */
-    ValidationResult validateLocationCompatibility(UUID destinationLocationId, String skuId);
+    @NonNull
+    ValidationResult validateLocationCompatibility(@NonNull UUID destinationLocationId, @NonNull String skuId);
 
     /**
      * Validates that the destination location has sufficient capacity.
@@ -64,7 +66,8 @@ public interface PutawayValidationService {
      * @return validation result
      * @throws LocationAtCapacityException if location is full and no override
      */
-    ValidationResult validateLocationCapacity(UUID destinationLocationId, int quantity);
+    @NonNull
+    ValidationResult validateLocationCapacity(@NonNull UUID destinationLocationId, int quantity);
 
     /**
      * Validates that the source location has on-hand inventory for the SKU.
@@ -86,7 +89,8 @@ public interface PutawayValidationService {
      * @return validation result
      * @throws NoOnHandAtSourceLocationException if no on-hand inventory found
      */
-    ValidationResult validateSourceOnHand(UUID sourceLocationId, String skuId, int quantity);
+    @NonNull
+    ValidationResult validateSourceOnHand(@NonNull UUID sourceLocationId, @NonNull String skuId, int quantity);
 
     /**
      * Performs comprehensive validation for a putaway execution request.
@@ -94,5 +98,6 @@ public interface PutawayValidationService {
      * @param request the putaway execution request
      * @return comprehensive validation result
      */
-    ValidationResult validatePutawayExecution(PutawayExecutionRequest request);
+    @NonNull
+    ValidationResult validatePutawayExecution(@NonNull PutawayExecutionRequest request);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/putaway/service/PutawayValidationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/putaway/service/PutawayValidationServiceImpl.java
@@ -20,6 +20,8 @@ import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,7 +85,8 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
      * reason text is new, and it now names the class/capability mismatch.
      */
     @Override
-    public ValidationResult validateLocationCompatibility(UUID destinationLocationId, String skuId) {
+    public @NonNull ValidationResult validateLocationCompatibility(
+            @NonNull UUID destinationLocationId, @NonNull String skuId) {
         if (log.isDebugEnabled()) {
             log.debug(
                     "Validating location compatibility: location(mask)={}, sku(mask)={}",
@@ -111,7 +114,8 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
         // closed: an item whose catalog class demands containment is refused by a destination that
         // does not declare it, and an unknown destination declares nothing. Existence is enforced
         // at execution by validateLocationCapacity.
-        StorageLocationValidation destination = getStorageLocationValidation(destinationLocationId);
+        StorageLocationValidation destination =
+                storageLocationValidationService.getStorageLocationValidation(destinationLocationId.toString());
 
         StorageCompatibilityEvaluator.Verdict verdict = storageCompatibilityEvaluator.evaluate(destination, skuId);
         if (!verdict.accepted()) {
@@ -121,14 +125,14 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
         return ValidationResult.success();
     }
 
-    private StorageLocationValidation getStorageLocationValidation(UUID destinationLocationId) {
+    private @Nullable StorageLocationValidation getStorageLocationValidation(@NonNull UUID destinationLocationId) {
         if (storageLocationValidationService == null) {
             return null;
         }
         return storageLocationValidationService.getStorageLocationValidation(destinationLocationId.toString());
     }
 
-    private void validateStorageLocation(StorageLocationValidation locationValidation) {
+    private void validateStorageLocation(@Nullable StorageLocationValidation locationValidation) {
         if (locationValidation == null) {
             return;
         }
@@ -157,7 +161,7 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
      * strongest possible refusal into unlimited acceptance, so only a null passes through as
      * uncapped and a zero flows on to the at-capacity check below.
      */
-    private Integer declaredCapacity(StorageLocationValidation locationValidation) {
+    private @Nullable Integer declaredCapacity(@Nullable StorageLocationValidation locationValidation) {
         if (locationValidation == null) {
             return null;
         }
@@ -165,7 +169,7 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
     }
 
     @Override
-    public ValidationResult validateLocationCapacity(UUID destinationLocationId, int quantity) {
+    public @NonNull ValidationResult validateLocationCapacity(@NonNull UUID destinationLocationId, int quantity) {
         if (log.isDebugEnabled()) {
             log.debug(
                     "Validating location capacity: location(mask)={}, quantity={}",
@@ -246,7 +250,8 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
     }
 
     @Override
-    public ValidationResult validateSourceOnHand(UUID sourceLocationId, String skuId, int quantity) {
+    public @NonNull ValidationResult validateSourceOnHand(
+            @NonNull UUID sourceLocationId, @NonNull String skuId, int quantity) {
         log.debug("Validating source on-hand: location={}, sku={}, quantity={}", sourceLocationId, skuId, quantity);
 
         ValidationResult result = ValidationResult.success();
@@ -273,7 +278,7 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
     }
 
     @Override
-    public ValidationResult validatePutawayExecution(PutawayExecutionRequest request) {
+    public @NonNull ValidationResult validatePutawayExecution(@NonNull PutawayExecutionRequest request) {
 
         if (log.isInfoEnabled()) {
             log.info(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -127,9 +127,6 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
     @Override
     @Transactional(readOnly = true)
     public List<LocationAvailabilityDto> getAvailabilityByProductAsOf(@NonNull UUID productId, @NonNull Instant asOf) {
-        if (productId == null) {
-            throw new InvalidInventoryAvailabilityRequestException("Product ID is required");
-        }
         asOfQueryGuard.check(asOf);
 
         // Odoo-parity A3 (#1029): direct ledger aggregation with a timestamp bound; the

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SkuCategoryCutoverServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SkuCategoryCutoverServiceImplTest.java
@@ -474,6 +474,6 @@ class SkuCategoryCutoverServiceImplTest {
                 .<Class<?>>map(java.lang.reflect.Field::getType)
                 .toList();
 
-        assertThat(fieldTypes).doesNotContain(SkuCategoryProvider.class);
+        assertThat(fieldTypes).isNotEmpty().doesNotContain(SkuCategoryProvider.class);
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeTool.java
@@ -57,6 +57,6 @@ public class WorkorderFacadeTool {
                 .uri(workorderStatusUriTemplate, Map.of("workorderId", workorderId))
                 .retrieve()
                 .body(String.class);
-        return FacadeJsonSupport.workorderStatusProjection(body);
+        return body == null ? null : FacadeJsonSupport.workorderStatusProjection(body);
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -228,9 +228,13 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
      * and swallowed so one bad op never aborts the batch. Returns {@code true} on success.
      */
     private boolean persistOne(@NonNull DiscoveredOperation operation) {
+        String httpPath = operation.httpPath();
+        if (httpPath == null) {
+            return false;
+        }
         try {
             UUID toolId = toolMetadataRepository.upsertDiscoveredOperation(
-                    operation, OpenApiToolMapper.extractDomain(operation.httpPath()));
+                    operation, OpenApiToolMapper.extractDomain(httpPath));
             toolMetadataRepository.linkToolToWorkflow(toolId, DISCOVERED_WORKFLOW_STATE);
             for (String permissionCode : operation.requiredPermissions()) {
                 toolMetadataRepository.addToolPermission(toolId, permissionCode);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -1017,7 +1018,11 @@ public class EstimateServiceImpl implements EstimateService {
         if (!((request.getQuantity() != null || uomCodeProvided) && item.getItemType() == EstimateItemType.PART)) {
             return;
         }
-        BigDecimal effectiveQuantity = request.getQuantity() != null ? request.getQuantity() : item.getQuantity();
+        // The quantity column is non-null, so a persisted item always carries one; requireNonNull
+        // states that invariant where the dataflow cannot see it.
+        BigDecimal effectiveQuantity = request.getQuantity() != null
+                ? request.getQuantity()
+                : Objects.requireNonNull(item.getQuantity(), "persisted estimate item has no quantity");
         String effectiveUomCode = uomCodeProvided ? normalizedRequestUomCode : item.getUomCode();
         partQuantityDivisibilityService.requirePermittedScale(
                 item.getProductId(),


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — SonarQube reliability remediation batch `xoym6g` (maintenance, no capability story)
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: cross-cutting (`pos-catalog`, `pos-inventory`, `pos-mcp-server`, `pos-workorder`, `pos-bulk-loader`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable: no controllers, DTOs, request/response models, events, or OpenAPI specs changed — internal service/listener/test code only, with no behavior change to any API contract.

## Contract Chain (when a Controller changed)
- No controller changed; chain not applicable.

## Scope
- What changed: fixes for all 9 open SonarQube RELIABILITY findings on overall code:
  - `javabugs:S2259` `pos-catalog/.../CatalogCommandListener` — `parseUuid`/`parseInstant` take `@NonNull JsonNode` (every caller passes the non-null `root.path("payload")` result), removing dead null branches behind the analyzer's NPE flow.
  - `java:S2637` + `javabugs:S2259` `pos-inventory/.../putaway/PutawayValidationService(+Impl)` — `@NonNull` contracts on the service surface per repo jspecify convention; the compatibility path calls `StorageLocationValidationService` directly where the existing guard proves it non-null.
  - `java:S2583` `pos-inventory/.../InventoryAvailabilityServiceImpl` — removed the always-false `productId == null` check contradicting the `@NonNull` contract (sole caller passes a Spring `@PathVariable UUID`).
  - `java:S5841` `pos-inventory/.../SkuCategoryCutoverServiceImplTest` — `isNotEmpty()` before `doesNotContain(...)` so the structural assertion cannot pass vacuously.
  - `java:S2637` `pos-mcp-server/.../WorkorderFacadeTool` — null-guard the response body before projection, matching the sibling facade tools' `body == null ? null : ...` pattern.
  - `java:S2637` `pos-mcp-server/.../ToolRegistrationServiceImpl` — `persistOne` hoists a local `httpPath` null guard (same skip semantics as the caller's pre-check) so `extractDomain` receives `@NonNull`.
  - `java:S2637` `pos-workorder/.../EstimateServiceImpl` — `Objects.requireNonNull(item.getQuantity(), ...)` states the non-null DB column invariant before `requirePermittedScale`.
  - `java:S8786` `pos-bulk-loader/.../RuleBasedContentDetectionServiceImpl` — replaced the backtracking-prone `"_+$"` trailing-trim regex with a linear character-index trim.
- Why: clear the SonarCloud reliability backlog with minimal, behavior-preserving fixes; no findings suppressed — all 9 received real fixes.

## Tests
- [x] Unit tests added/updated (`SkuCategoryCutoverServiceImplTest` assertion strengthened; existing suites cover the touched code)
- [ ] Integration tests added/updated (not needed — no behavior change)
- [ ] Provider behavioral contract tests added/updated (not needed — no contract change)
- How to run:
  ```
  ./mvnw -pl pos-catalog,pos-inventory,pos-mcp-server,pos-workorder,pos-bulk-loader -am \
    -Dtest='CatalogCommandListenerTest,CatalogCommandListenerTransactionPropagationTest,PutawayValidationServiceImplTest,PutawayExecuteServiceImplTest,InventoryAvailabilityServiceImplTest,SkuCategoryCutoverServiceImplTest,WorkorderFacadeToolTest,ToolRegistrationServiceImplTest,EstimateServiceImplTest,EstimateItemQuantityGateTest,RuleBasedContentDetectionServiceImplTest' \
    -Dsurefire.failIfNoSpecifiedTests=false test
  ```
  Result: 121 tests, 0 failures, 0 errors (JDK 25); Spotless/Checkstyle/SpotBugs clean.

## Risk & Rollback
- Risk level: Low — annotation tightening, dead-branch removal, an equivalent non-regex trim, and null guards matching established patterns; no functional behavior change intended.
- Rollback plan: revert the single commit `1f6ee166`.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a: Sonar remediation branch `claude/sonarqube-reliability-issues-xoym6g`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a: no capability; conventional `fix(sonar):` title
- [ ] Links to parent + child issues are present — n/a: maintenance batch, no story issues
- [ ] Contract guide updated — n/a: no contract semantics changed
- [x] Required CI checks passing (local verification green; CI pending on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TapdgH7k78GhFFKzBvejH5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TapdgH7k78GhFFKzBvejH5)_