### PR TITLE
Add plan-driven cycle count task generation to pos-inventory (with seed data)

### DIFF
--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -109,13 +109,16 @@ public final class EventTypes {
                 EventTypeRegistration.write("INVENTORY_CYCLE_COUNT_RECOUNT", "Submit a recount for a cycle count task")
                         .build(),
 
-                // CycleCountPlanController - 3 events
+                // CycleCountPlanController - 4 events
                 EventTypeRegistration.write("INVENTORY_CYCLE_COUNT_PLAN_CREATE", "Create a cycle count plan")
                         .build(),
                 EventTypeRegistration.fastRead("INVENTORY_CYCLE_COUNT_PLAN_LIST", "List cycle count plans")
                         .build(),
                 EventTypeRegistration.write(
                                 "INVENTORY_CYCLE_COUNT_PLAN_STATUS_UPDATE", "Transition a cycle count plan status")
+                        .build(),
+                EventTypeRegistration.write(
+                                "INVENTORY_CYCLE_COUNT_TASK_GENERATE", "Generate count tasks for a cycle count plan")
                         .build(),
 
                 // CycleCountScheduleController - 4 events (odoo-parity I1, #1031)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountAdjustmentController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountAdjustmentController.java
@@ -86,7 +86,8 @@ public class CycleCountAdjustmentController {
                     Preconditions: countedQuantity must differ from quantityOnHandBefore (a zero variance is \
                     rejected), a supplied taskId must reference an existing cycle count task, and the auto-approve \
                     path additionally requires the linked task to have no unreviewed in-window stock movements.
-                    Required inputs: stockItemId (UUID), reasonCode, countedQuantity, quantityOnHandBefore, \
+                    Required inputs: stockItemId (the ledger's freeform stock reference text — a SKU code, or a \
+                    product UUID rendered as text; not a product id), reasonCode, countedQuantity, quantityOnHandBefore, \
                     costAtTimeOfAdjustment and createdByUserId; taskId is optional but enables conflict detection; \
                     the posted unit cost prefers the costing engine's per-SKU running cost and falls back to \
                     costAtTimeOfAdjustment only for a SKU the engine has not costed.
@@ -117,7 +118,7 @@ public class CycleCountAdjustmentController {
                                     @Content(
                                             mediaType = "application/json",
                                             examples = @ExampleObject(name = "Task-linked shortage", value = """
-                                                                    {"stockItemId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                    {"stockItemId":"OIL-5W30-5QT",
                                                                      "taskId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
                                                                      "reasonCode":"CYCLE_COUNT_VARIANCE",
                                                                      "countedQuantity":12,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountPlanController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountPlanController.java
@@ -247,8 +247,10 @@ public class CycleCountPlanController {
                     Use this tool after createCycleCountPlan to hand the count to an auditor; the tasks it creates \
                     are then counted through submitCount on the cycle count endpoint.
                     Preconditions: the plan must exist and be in PLANNED or STARTED status.
-                    Required inputs: planId (UUID) path parameter and auditorId in the body — every generated task \
-                    is assigned to that auditor.
+                    Required inputs: planId (UUID) path parameter and auditorId in the body — every task created \
+                    by THIS pass is assigned to that auditor. Assignment is create-time-only: re-generating with \
+                    a different auditorId does not reassign the plan's existing tasks (they are reported in \
+                    tasksSkippedExisting and keep their original auditor).
                     Emits an INVENTORY_CYCLE_COUNT_TASK_GENERATE event, and a PLANNED plan that has tasks after \
                     the pass is transitioned to STARTED (also emitting INVENTORY_CYCLE_COUNT_PLAN_STATUS_UPDATE); \
                     a pass that finds no stocked (location, SKU) pair creates nothing and leaves the plan PLANNED. \

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountPlanController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountPlanController.java
@@ -2,8 +2,12 @@ package com.positivity.inventory.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import com.positivity.inventory.internal.cyclecount.service.CycleCountPlanService;
+import com.positivity.inventory.internal.cyclecount.service.CycleCountTaskGenerationService;
+import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
 import com.positivity.inventory.internal.dto.cyclecount.plan.CreateCycleCountPlanRequest;
 import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountPlanResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountTaskGenerationResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.GenerateCycleCountTasksRequest;
 import com.positivity.inventory.internal.dto.cyclecount.plan.UpdateCycleCountPlanStatusRequest;
 import com.positivity.inventory.internal.enums.CycleCountPlanStatus;
 import com.positivity.inventory.internal.security.InventoryPermissionRegistry;
@@ -42,6 +46,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CycleCountPlanController {
 
     private final CycleCountPlanService cycleCountPlanService;
+    private final CycleCountTaskGenerationService cycleCountTaskGenerationService;
 
     @PostMapping
     @EmitEvent(id = "INVENTORY_CYCLE_COUNT_PLAN_CREATE", apiVersion = "1")
@@ -222,5 +227,95 @@ public class CycleCountPlanController {
                     @RequestBody
                     UpdateCycleCountPlanStatusRequest request) {
         return ResponseEntity.ok(cycleCountPlanService.updateStatus(planId, request.getStatus()));
+    }
+
+    @PostMapping("/{planId}/tasks")
+    @EmitEvent(id = "INVENTORY_CYCLE_COUNT_TASK_GENERATE", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:cycle_count:initiate"})
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.CYCLE_COUNT_INITIATE + "')")
+    @Operation(
+            operationId = "generateCycleCountTasks",
+            summary = "Generate count tasks for a cycle count plan",
+            description = """
+                    Expands the plan into ASSIGNED cycle count tasks: one task per (storage location, SKU) with \
+                    positive book stock in the plan's scope, snapshotting the ledger-derived on-hand as the \
+                    expected quantity for the blind count. Scope is the plan's zones (each zone plus its known \
+                    descendant storage locations) or, for a plan without zones, every known storage location of \
+                    the plan's site.
+                    Use this tool after createCycleCountPlan to hand the count to an auditor; the tasks it creates \
+                    are then counted through submitCount on the cycle count endpoint.
+                    Preconditions: the plan must exist and be in PLANNED or STARTED status.
+                    Required inputs: planId (UUID) path parameter and auditorId in the body — every generated task \
+                    is assigned to that auditor.
+                    Emits an INVENTORY_CYCLE_COUNT_TASK_GENERATE event, and a PLANNED plan is transitioned to \
+                    STARTED. Generation is idempotent per (plan, bin, SKU): calling it again only creates tasks \
+                    for pairs that gained stock since the last pass and reports the rest as skipped.
+                    Returns 404 when the plan does not exist, and 409 when the plan is in a status that does not \
+                    accept task generation.
+                    """,
+            tags = {"Cycle Count Plans"})
+    @ApiResponse(
+            responseCode = "201",
+            description = "Count tasks generated",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CycleCountTaskGenerationResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Validation failure")
+    @ApiResponse(responseCode = "403", description = "User lacks required permission")
+    @ApiResponse(responseCode = "404", description = "Cycle count plan not found")
+    @ApiResponse(responseCode = "409", description = "Plan status does not accept task generation")
+    public ResponseEntity<CycleCountTaskGenerationResponse> generateTasks(
+            @Parameter(description = "Cycle count plan identifier", required = true) @PathVariable UUID planId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Auditor the generated tasks are assigned to.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Assign to auditor", value = """
+                                                                    {"auditorId":"auditor-10042"}
+                                                                    """)))
+                    @jakarta.validation.Valid
+                    @RequestBody
+                    GenerateCycleCountTasksRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(cycleCountTaskGenerationService.generateTasks(planId, request));
+    }
+
+    @GetMapping("/{planId}/tasks")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:cycle_count:view"})
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.CYCLE_COUNT_VIEW + "')")
+    @Operation(
+            operationId = "listCycleCountPlanTasks",
+            summary = "List a cycle count plan's tasks",
+            description = """
+                    Returns every count task generated from the plan, in creation order, with each task's bin, \
+                    SKU, expected quantity, assigned auditor, and workflow status.
+                    Use this tool to review a plan's progress or find taskIds for submitCount; use \
+                    getCycleCountTasksByAuditor instead to see one auditor's queue across plans.
+                    Preconditions: the plan must exist.
+                    Required inputs: planId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty array for a plan whose tasks have not been generated yet, and 404 \
+                    when the plan does not exist.
+                    """,
+            tags = {"Cycle Count Plans"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Cycle count tasks returned",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = CycleCountTaskResponse.class))))
+    @ApiResponse(responseCode = "403", description = "User lacks required permission")
+    @ApiResponse(responseCode = "404", description = "Cycle count plan not found")
+    public ResponseEntity<List<CycleCountTaskResponse>> listPlanTasks(
+            @Parameter(description = "Cycle count plan identifier", required = true) @PathVariable UUID planId) {
+        return ResponseEntity.ok(cycleCountTaskGenerationService.getTasksForPlan(planId));
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountPlanController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountPlanController.java
@@ -249,9 +249,11 @@ public class CycleCountPlanController {
                     Preconditions: the plan must exist and be in PLANNED or STARTED status.
                     Required inputs: planId (UUID) path parameter and auditorId in the body — every generated task \
                     is assigned to that auditor.
-                    Emits an INVENTORY_CYCLE_COUNT_TASK_GENERATE event, and a PLANNED plan is transitioned to \
-                    STARTED. Generation is idempotent per (plan, bin, SKU): calling it again only creates tasks \
-                    for pairs that gained stock since the last pass and reports the rest as skipped.
+                    Emits an INVENTORY_CYCLE_COUNT_TASK_GENERATE event, and a PLANNED plan that has tasks after \
+                    the pass is transitioned to STARTED (also emitting INVENTORY_CYCLE_COUNT_PLAN_STATUS_UPDATE); \
+                    a pass that finds no stocked (location, SKU) pair creates nothing and leaves the plan PLANNED. \
+                    Generation is idempotent per (plan, bin, SKU): calling it again only creates tasks for pairs \
+                    that gained stock since the last pass and reports the rest as skipped.
                     Returns 404 when the plan does not exist, and 409 when the plan is in a status that does not \
                     accept task generation.
                     """,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountAdjustmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountAdjustmentServiceImpl.java
@@ -316,7 +316,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
                     : InventoryLedgerEventType.COUNT_VARIANCE_OUT;
 
             InventoryLedgerEntry ledgerEntry = InventoryLedgerEntry.builder()
-                    .stockItemId(adjustment.getStockItemId().toString())
+                    .stockItemId(adjustment.getStockItemId())
                     .locationId(locationId)
                     .adjustmentId(adjustment.getAdjustmentId())
                     .eventType(eventType)
@@ -370,8 +370,8 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
                 .orElse(null);
     }
 
-    /** Current on-hand for the SKU — location-scoped when a location is known, global otherwise. */
-    private @NonNull BigDecimal currentOnHand(@NonNull UUID stockItemId, @Nullable UUID locationId) {
+    /** Current on-hand for the stock reference — location-scoped when a location is known, global otherwise. */
+    private @NonNull BigDecimal currentOnHand(@NonNull String stockItemId, @Nullable UUID locationId) {
         return Quantities.nz(
                 locationId != null
                         ? ledgerRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId)
@@ -385,11 +385,10 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
      * {@code null} when the SKU has no {@code sku_cost_state} row or no derivable cost, so the
      * caller can fall back to the request-supplied cost.
      */
-    private @Nullable BigDecimal resolveEngineCost(@NonNull UUID stockItemId) {
-        String sku = stockItemId.toString();
+    private @Nullable BigDecimal resolveEngineCost(@NonNull String stockItemId) {
         return costStateRepository
-                .findByStockItemId(sku)
-                .map(state -> methodResolver.resolve(sku) == CostingMethod.STANDARD
+                .findByStockItemId(stockItemId)
+                .map(state -> methodResolver.resolve(stockItemId) == CostingMethod.STANDARD
                         ? (state.getStandardCost() != null ? state.getStandardCost() : state.getAvgCost())
                         : state.getAvgCost())
                 .orElse(null);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountAdjustmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountAdjustmentServiceImpl.java
@@ -238,7 +238,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
                 .orElseThrow(() -> new TaskNotFoundException(adjustment.getTaskId()));
 
         if (task.getStatus() == TaskStatus.CONFLICT) {
-            recomputeVarianceAgainstCurrentOnHand(adjustment);
+            recomputeVarianceAgainstCurrentOnHand(adjustment, task);
             return;
         }
 
@@ -251,12 +251,17 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
 
     /**
      * Replaces the stale snapshot math with current-on-hand math: quantityChange
-     * becomes countedQuantity - currentOnHand, using the same global on-hand
-     * aggregation the posting path uses for quantityAfter. The funnel's
-     * floor-at-zero matrix still applies when the recomputed variance posts.
+     * becomes countedQuantity - currentOnHand, using the same on-hand
+     * aggregation the posting path uses for quantityAfter — scoped to the
+     * task's storage location when its bin holds a location UUID (a count of
+     * bin A must never be reconciled against the SKU's stock in bins B and C),
+     * global otherwise. The funnel's floor-at-zero matrix still applies when
+     * the recomputed variance posts.
      */
-    private void recomputeVarianceAgainstCurrentOnHand(CycleCountAdjustment adjustment) {
-        BigDecimal currentOnHand = Quantities.nz(ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId()));
+    private void recomputeVarianceAgainstCurrentOnHand(CycleCountAdjustment adjustment, CycleCountTask task) {
+        BigDecimal currentOnHand = currentOnHand(
+                adjustment.getStockItemId(),
+                CycleCountConflictDetector.locationIdOf(task).orElse(null));
         BigDecimal recomputedChange = adjustment.getCountedQuantity().subtract(currentOnHand);
         log.info(
                 "Adjustment {} approved on CONFLICT task {}: variance recomputed against current on-hand"
@@ -302,8 +307,8 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
         log.info("Posting adjustment {} to inventory ledger", adjustment.getAdjustmentId());
 
         try {
-            BigDecimal currentOnHand =
-                    Quantities.nz(ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId()));
+            UUID locationId = taskLocationOf(adjustment);
+            BigDecimal currentOnHand = currentOnHand(adjustment.getStockItemId(), locationId);
             BigDecimal quantityAfter = currentOnHand.add(adjustment.getQuantityChange());
 
             InventoryLedgerEventType eventType = Quantities.isPositive(adjustment.getQuantityChange())
@@ -312,6 +317,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
 
             InventoryLedgerEntry ledgerEntry = InventoryLedgerEntry.builder()
                     .stockItemId(adjustment.getStockItemId().toString())
+                    .locationId(locationId)
                     .adjustmentId(adjustment.getAdjustmentId())
                     .eventType(eventType)
                     .changeInQuantity(adjustment.getQuantityChange())
@@ -344,6 +350,32 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
             throw new AdjustmentLedgerPostingException(
                     adjustment.getAdjustmentId(), "Failed to post adjustment to ledger", e);
         }
+    }
+
+    /**
+     * The storage location an adjustment's variance posts against: the linked task's bin when it
+     * holds a location UUID (the form plan-driven task generation writes), {@code null} for
+     * task-less adjustments and free-text bins. Carrying this onto the posted
+     * {@code COUNT_VARIANCE_*} entry is what makes a bin-scoped expected-quantity snapshot
+     * converge: without it, the correction lands on the NULL-location key and the same shrinkage
+     * is re-detected by every subsequent plan for that bin.
+     */
+    private @Nullable UUID taskLocationOf(CycleCountAdjustment adjustment) {
+        if (adjustment.getTaskId() == null) {
+            return null;
+        }
+        return taskRepository
+                .findById(adjustment.getTaskId())
+                .flatMap(CycleCountConflictDetector::locationIdOf)
+                .orElse(null);
+    }
+
+    /** Current on-hand for the SKU — location-scoped when a location is known, global otherwise. */
+    private @NonNull BigDecimal currentOnHand(@NonNull UUID stockItemId, @Nullable UUID locationId) {
+        return Quantities.nz(
+                locationId != null
+                        ? ledgerRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId)
+                        : ledgerRepository.calculateOnHandQuantity(stockItemId));
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountPlanService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountPlanService.java
@@ -38,6 +38,17 @@ public interface CycleCountPlanService {
     @NonNull
     CycleCountPlanResponse updateStatus(@NonNull UUID planId, @NonNull CycleCountPlanStatus newStatus);
 
+    /**
+     * The PLANNED → STARTED transition as task generation performs it. Same
+     * lifecycle validation as {@link #updateStatus}, but the implementation
+     * carries {@code @EmitEvent(INVENTORY_CYCLE_COUNT_PLAN_STATUS_UPDATE)} so
+     * lifecycle-event consumers see this transition exactly like one made
+     * through the status endpoint (whose controller method holds the same
+     * annotation) instead of a silent status jump.
+     */
+    @NonNull
+    CycleCountPlanResponse startForTaskGeneration(@NonNull UUID planId);
+
     @NonNull
     CycleCountPlanResponse getPlan(@NonNull UUID planId);
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountPlanService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountPlanService.java
@@ -45,6 +45,16 @@ public interface CycleCountPlanService {
      * lifecycle-event consumers see this transition exactly like one made
      * through the status endpoint (whose controller method holds the same
      * annotation) instead of a silent status jump.
+     *
+     * <p>Emission timing caveat: because this is called inside the caller's
+     * still-open generation transaction, the event is emitted before that
+     * transaction commits — a commit-time rollback after this returns leaves a
+     * STARTED event with a PLANNED row (controller-level {@code @EmitEvent}s
+     * fire after the service transaction has committed and cannot skew this
+     * way). Accepted for now: the generation pass pre-validates its writes
+     * (plan row locked, existing keys preloaded), so post-emission rollback is
+     * confined to infrastructure failures, and lifecycle consumers already
+     * tolerate at-least-once delivery.
      */
     @NonNull
     CycleCountPlanResponse startForTaskGeneration(@NonNull UUID planId);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountPlanServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountPlanServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.cyclecount.service;
 
+import com.positivity.events.EmitEvent;
 import com.positivity.inventory.internal.dto.cyclecount.plan.CreateCycleCountPlanRequest;
 import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountPlanResponse;
 import com.positivity.inventory.internal.entity.CycleCountPlan;
@@ -98,6 +99,13 @@ public class CycleCountPlanServiceImpl implements CycleCountPlanService {
         }
 
         return toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    @EmitEvent(id = "INVENTORY_CYCLE_COUNT_PLAN_STATUS_UPDATE", apiVersion = "1")
+    public @NonNull CycleCountPlanResponse startForTaskGeneration(@NonNull UUID planId) {
+        return updateStatus(planId, CycleCountPlanStatus.STARTED);
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountServiceImpl.java
@@ -18,7 +18,6 @@ import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.exception.UomConversionUndefinedException;
 import com.positivity.inventory.internal.repository.CountEntryRepository;
 import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
-import com.positivity.inventory.internal.service.BaseUnitOfMeasureResolver;
 import com.positivity.inventory.internal.service.CycleCountConflictDetector;
 import com.positivity.inventory.internal.service.CycleCountToleranceResolver;
 import com.positivity.inventory.internal.service.Quantities;
@@ -28,8 +27,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
@@ -79,7 +76,7 @@ public class CycleCountServiceImpl implements CycleCountService {
     private final CycleCountToleranceResolver toleranceResolver;
     private final UomConversionService uomConversionService;
     private final QuantityScaleGuard scaleGuard;
-    private final BaseUnitOfMeasureResolver baseUnitOfMeasureResolver;
+    private final CycleCountTaskResponseMapper taskResponseMapper;
 
     public CycleCountServiceImpl(
             CycleCountTaskRepository taskRepository,
@@ -89,7 +86,7 @@ public class CycleCountServiceImpl implements CycleCountService {
             CycleCountToleranceResolver toleranceResolver,
             UomConversionService uomConversionService,
             QuantityScaleGuard scaleGuard,
-            BaseUnitOfMeasureResolver baseUnitOfMeasureResolver) {
+            CycleCountTaskResponseMapper taskResponseMapper) {
         this.taskRepository = taskRepository;
         this.countEntryRepository = countEntryRepository;
         this.clock = clock;
@@ -97,7 +94,7 @@ public class CycleCountServiceImpl implements CycleCountService {
         this.toleranceResolver = toleranceResolver;
         this.uomConversionService = uomConversionService;
         this.scaleGuard = scaleGuard;
-        this.baseUnitOfMeasureResolver = baseUnitOfMeasureResolver;
+        this.taskResponseMapper = taskResponseMapper;
     }
 
     @Override
@@ -221,7 +218,7 @@ public class CycleCountServiceImpl implements CycleCountService {
     @Override
     @Transactional(readOnly = true)
     public CycleCountTaskResponse getTask(UUID taskId) {
-        return toTaskResponse(getTaskEntity(taskId));
+        return taskResponseMapper.toResponse(getTaskEntity(taskId));
     }
 
     @Override
@@ -242,7 +239,7 @@ public class CycleCountServiceImpl implements CycleCountService {
             log.info("GET /v1/inventory/cycle-count/auditor/{}/tasks", maskForLog(auditorId));
         }
         return taskRepository.findByAuditorId(auditorId).stream()
-                .map(this::toTaskResponse)
+                .map(taskResponseMapper::toResponse)
                 .toList();
     }
 
@@ -487,30 +484,6 @@ public class CycleCountServiceImpl implements CycleCountService {
                 .countedAt(countEntry.getCountedAt())
                 .limitExceeded(limitExceeded)
                 .message(message)
-                .build();
-    }
-
-    private CycleCountTaskResponse toTaskResponse(CycleCountTask task) {
-        return CycleCountTaskResponse.builder()
-                .taskId(task.getTaskId())
-                .binLocation(task.getBinLocation())
-                .itemSku(task.getItemSku())
-                .itemDescription(task.getItemDescription())
-                .expectedQuantity(task.getExpectedQuantity())
-                .unitOfMeasure(baseUnitOfMeasureResolver.resolve(task.getItemSku()))
-                .auditorId(task.getAuditorId())
-                .planId(task.getPlanId())
-                .status(task.getStatus())
-                .latestCountEntryId(task.getLatestCountEntryId())
-                .countEntriesCount(task.getCountEntriesCount())
-                .createdAt(
-                        task.getCreatedAt() != null
-                                ? LocalDateTime.ofInstant(task.getCreatedAt(), ZoneOffset.UTC)
-                                : null)
-                .updatedAt(
-                        task.getUpdatedAt() != null
-                                ? LocalDateTime.ofInstant(task.getUpdatedAt(), ZoneOffset.UTC)
-                                : null)
                 .build();
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountServiceImpl.java
@@ -499,6 +499,7 @@ public class CycleCountServiceImpl implements CycleCountService {
                 .expectedQuantity(task.getExpectedQuantity())
                 .unitOfMeasure(baseUnitOfMeasureResolver.resolve(task.getItemSku()))
                 .auditorId(task.getAuditorId())
+                .planId(task.getPlanId())
                 .status(task.getStatus())
                 .latestCountEntryId(task.getLatestCountEntryId())
                 .countEntriesCount(task.getCountEntriesCount())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationService.java
@@ -21,7 +21,9 @@ public interface CycleCountTaskGenerationService {
      * descendant storage locations) or, for a plan without zones, every replicated storage
      * location of the plan's site — falling back to the plan's own location id when no replicas
      * exist. Idempotent per (plan, bin, SKU): re-generation only tops up pairs that gained stock
-     * since the last pass. A PLANNED plan is transitioned to STARTED after generation.
+     * since the last pass, and the plan row is locked for the pass so concurrent requests
+     * serialize. A PLANNED plan is transitioned to STARTED once it has tasks; a pass that finds
+     * no stocked pair at all leaves the plan PLANNED rather than starting an empty count.
      *
      * @throws com.positivity.inventory.internal.exception.CycleCountPlanNotFoundException when the
      *     plan does not exist

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationService.java
@@ -1,0 +1,37 @@
+package com.positivity.inventory.internal.cyclecount.service;
+
+import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountTaskGenerationResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.GenerateCycleCountTasksRequest;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Expands a cycle count plan into the {@code CycleCountTask}s auditors actually count against —
+ * the plan → task half of the cycle count pipeline (plans and schedules on one side,
+ * count/recount/adjustment on the other side, this in between).
+ */
+public interface CycleCountTaskGenerationService {
+
+    /**
+     * Generates {@code ASSIGNED} count tasks for the plan: one task per (storage location, SKU)
+     * with positive book stock in the plan's scope, snapshotting the ledger-derived on-hand as
+     * the task's expected quantity. Scope is the plan's zones (each zone plus its replicated
+     * descendant storage locations) or, for a plan without zones, every replicated storage
+     * location of the plan's site — falling back to the plan's own location id when no replicas
+     * exist. Idempotent per (plan, bin, SKU): re-generation only tops up pairs that gained stock
+     * since the last pass. A PLANNED plan is transitioned to STARTED after generation.
+     *
+     * @throws com.positivity.inventory.internal.exception.CycleCountPlanNotFoundException when the
+     *     plan does not exist
+     * @throws IllegalStateException when the plan is not in PLANNED or STARTED status
+     */
+    @NonNull
+    CycleCountTaskGenerationResponse generateTasks(
+            @NonNull UUID planId, @NonNull GenerateCycleCountTasksRequest request);
+
+    /** Tasks generated from the plan, in creation order. */
+    @NonNull
+    List<CycleCountTaskResponse> getTasksForPlan(@NonNull UUID planId);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImpl.java
@@ -1,0 +1,193 @@
+package com.positivity.inventory.internal.cyclecount.service;
+
+import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountTaskGenerationResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.GenerateCycleCountTasksRequest;
+import com.positivity.inventory.internal.entity.CycleCountPlan;
+import com.positivity.inventory.internal.entity.CycleCountTask;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.enums.CycleCountPlanStatus;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.TaskStatus;
+import com.positivity.inventory.internal.exception.CycleCountPlanNotFoundException;
+import com.positivity.inventory.internal.repository.CycleCountPlanRepository;
+import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.service.BaseUnitOfMeasureResolver;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Default plan → task generation.
+ *
+ * <p>The expected-quantity snapshot is taken from the ledger's positive per-location on-hand
+ * aggregation ({@code findPositiveOnHandByLocation}) at generation time — the same source of
+ * truth the adjustment posting path aggregates against — so the conflict detector's window-delta
+ * math (odoo-parity I2, #1026) lines up with it exactly: any on-hand-affecting entry recorded
+ * after the task's {@code createdAt} is an interfering movement against this snapshot.
+ *
+ * <p>Task {@code binLocation} is the storage-location UUID rendered as text, which is precisely
+ * the form {@code CycleCountConflictDetector} location-scopes its window queries on.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenerationService {
+
+    /**
+     * Ceiling on parent-link hops when expanding zones/sites to descendant storage locations.
+     * Real topologies are a handful of levels deep; the cap keeps a corrupt parent cycle in the
+     * replica table from looping forever (the visited-set already stops true cycles — this is a
+     * belt for pathological breadth).
+     */
+    static final int MAX_TOPOLOGY_DEPTH = 32;
+
+    private final CycleCountPlanRepository planRepository;
+    private final CycleCountTaskRepository taskRepository;
+    private final CycleCountPlanService planService;
+    private final InventoryLedgerEntryRepository ledgerRepository;
+    private final ExtStorageLocationReplicaRepository storageLocationRepository;
+    private final BaseUnitOfMeasureResolver baseUnitOfMeasureResolver;
+
+    @Override
+    @Transactional
+    public @NonNull CycleCountTaskGenerationResponse generateTasks(
+            @NonNull UUID planId, @NonNull GenerateCycleCountTasksRequest request) {
+        CycleCountPlan plan =
+                planRepository.findById(planId).orElseThrow(() -> new CycleCountPlanNotFoundException(planId));
+
+        if (plan.getStatus() != CycleCountPlanStatus.PLANNED && plan.getStatus() != CycleCountPlanStatus.STARTED) {
+            throw new IllegalStateException("Cannot generate tasks for cycle count plan " + planId + " in status "
+                    + plan.getStatus() + "; only PLANNED or STARTED plans accept task generation");
+        }
+
+        Set<UUID> countLocations = expandCountLocations(plan);
+
+        List<CycleCountTask> created = new ArrayList<>();
+        int skippedExisting = 0;
+        for (UUID location : countLocations) {
+            String binLocation = location.toString();
+            for (InventoryLedgerEntryRepository.LocationOnHand onHand : ledgerRepository.findPositiveOnHandByLocation(
+                    location, InventoryLedgerEventType.onHandAffectingTypes())) {
+                if (taskRepository.existsByPlanIdAndBinLocationAndItemSku(
+                        planId, binLocation, onHand.getStockItemId())) {
+                    skippedExisting++;
+                    continue;
+                }
+                created.add(taskRepository.save(CycleCountTask.builder()
+                        .planId(planId)
+                        .binLocation(binLocation)
+                        .itemSku(onHand.getStockItemId())
+                        .expectedQuantity(onHand.getOnHandQuantity())
+                        .auditorId(request.getAuditorId())
+                        .status(TaskStatus.ASSIGNED)
+                        .build()));
+            }
+        }
+
+        CycleCountPlanStatus planStatus = plan.getStatus();
+        if (planStatus == CycleCountPlanStatus.PLANNED) {
+            planStatus = CycleCountPlanStatus.valueOf(planService
+                    .updateStatus(planId, CycleCountPlanStatus.STARTED)
+                    .getStatus());
+        }
+
+        log.info(
+                "Cycle count task generation for plan {}: locationsScanned={} tasksCreated={} tasksSkippedExisting={}",
+                planId,
+                countLocations.size(),
+                created.size(),
+                skippedExisting);
+
+        return CycleCountTaskGenerationResponse.builder()
+                .planId(planId)
+                .planStatus(planStatus.name())
+                .locationsScanned(countLocations.size())
+                .tasksCreated(created.size())
+                .tasksSkippedExisting(skippedExisting)
+                .tasks(created.stream().map(this::toTaskResponse).toList())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull List<CycleCountTaskResponse> getTasksForPlan(@NonNull UUID planId) {
+        if (!planRepository.existsById(planId)) {
+            throw new CycleCountPlanNotFoundException(planId);
+        }
+        return taskRepository.findByPlanId(planId).stream()
+                .map(this::toTaskResponse)
+                .toList();
+    }
+
+    /**
+     * The storage locations the plan counts, in stable order: the plan's zones when it has any,
+     * otherwise every replicated storage location of the plan's site — each expanded downward
+     * through the replicated parent links so a zone covers its bins. A plan whose scope resolves
+     * to nothing through the replicas (e.g. no {@code ext_storage_location} facts consumed yet)
+     * falls back to the plan's own location id, matching the conflict detector's SKU-global
+     * fallback philosophy: degrade to coarser scoping rather than silently doing nothing.
+     */
+    private Set<UUID> expandCountLocations(CycleCountPlan plan) {
+        LinkedHashSet<UUID> seeds = new LinkedHashSet<>();
+        if (plan.getZoneIds() != null && !plan.getZoneIds().isEmpty()) {
+            seeds.addAll(plan.getZoneIds());
+        } else {
+            storageLocationRepository.findBySiteId(plan.getLocationId()).stream()
+                    .map(ExtStorageLocationReplica::getStorageLocationId)
+                    .forEach(seeds::add);
+            if (seeds.isEmpty()) {
+                seeds.add(plan.getLocationId());
+            }
+        }
+
+        LinkedHashSet<UUID> expanded = new LinkedHashSet<>(seeds);
+        Set<UUID> frontier = seeds;
+        for (int depth = 0; depth < MAX_TOPOLOGY_DEPTH && !frontier.isEmpty(); depth++) {
+            LinkedHashSet<UUID> children = new LinkedHashSet<>();
+            for (ExtStorageLocationReplica child :
+                    storageLocationRepository.findByParentStorageLocationIdIn(frontier)) {
+                if (expanded.add(child.getStorageLocationId())) {
+                    children.add(child.getStorageLocationId());
+                }
+            }
+            frontier = children;
+        }
+        return expanded;
+    }
+
+    private CycleCountTaskResponse toTaskResponse(CycleCountTask task) {
+        return CycleCountTaskResponse.builder()
+                .taskId(task.getTaskId())
+                .binLocation(task.getBinLocation())
+                .itemSku(task.getItemSku())
+                .itemDescription(task.getItemDescription())
+                .expectedQuantity(task.getExpectedQuantity())
+                .unitOfMeasure(baseUnitOfMeasureResolver.resolve(task.getItemSku()))
+                .auditorId(task.getAuditorId())
+                .planId(task.getPlanId())
+                .status(task.getStatus())
+                .latestCountEntryId(task.getLatestCountEntryId())
+                .countEntriesCount(task.getCountEntriesCount())
+                .createdAt(
+                        task.getCreatedAt() != null
+                                ? LocalDateTime.ofInstant(task.getCreatedAt(), ZoneOffset.UTC)
+                                : null)
+                .updatedAt(
+                        task.getUpdatedAt() != null
+                                ? LocalDateTime.ofInstant(task.getUpdatedAt(), ZoneOffset.UTC)
+                                : null)
+                .build();
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImpl.java
@@ -85,12 +85,16 @@ public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenera
             existingKeys.add(taskKey(existing.getBinLocation(), existing.getItemSku()));
         }
 
+        Map<UUID, List<InventoryLedgerEntryRepository.LocationStockOnHand>> onHandByLocation =
+                ledgerRepository.findPositiveOnHandByLocationsChunked(
+                        countLocations, InventoryLedgerEventType.onHandAffectingTypes());
+
         List<CycleCountTask> toCreate = new ArrayList<>();
         int skippedExisting = 0;
         for (UUID location : countLocations) {
             String binLocation = location.toString();
-            for (InventoryLedgerEntryRepository.LocationOnHand onHand : ledgerRepository.findPositiveOnHandByLocation(
-                    location, InventoryLedgerEventType.onHandAffectingTypes())) {
+            for (InventoryLedgerEntryRepository.LocationStockOnHand onHand :
+                    onHandByLocation.getOrDefault(location, List.of())) {
                 if (!existingKeys.add(taskKey(binLocation, onHand.getStockItemId()))) {
                     skippedExisting++;
                     continue;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImpl.java
@@ -15,11 +15,13 @@ import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
 import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.service.BaseUnitOfMeasureResolver;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,13 +34,15 @@ import org.springframework.transaction.annotation.Transactional;
  * Default plan → task generation.
  *
  * <p>The expected-quantity snapshot is taken from the ledger's positive per-location on-hand
- * aggregation ({@code findPositiveOnHandByLocation}) at generation time — the same source of
- * truth the adjustment posting path aggregates against — so the conflict detector's window-delta
- * math (odoo-parity I2, #1026) lines up with it exactly: any on-hand-affecting entry recorded
- * after the task's {@code createdAt} is an interfering movement against this snapshot.
+ * aggregation ({@code findPositiveOnHandByLocation}) at generation time. Task {@code binLocation}
+ * is the storage-location UUID rendered as text — the form {@code CycleCountConflictDetector}
+ * location-scopes its window queries on and {@code CycleCountAdjustmentServiceImpl} resolves for
+ * variance recomputation and the posted {@code COUNT_VARIANCE_*} entry's location, so a task's
+ * whole count → conflict → adjustment lifecycle runs against one consistent location scope.
  *
- * <p>Task {@code binLocation} is the storage-location UUID rendered as text, which is precisely
- * the form {@code CycleCountConflictDetector} location-scopes its window queries on.
+ * <p>Generation row-locks the plan for the pass, so concurrent requests for one plan serialize:
+ * the later request observes the earlier one's tasks and skips them instead of racing the
+ * (plan, bin, SKU) unique constraint into a wholesale rollback.
  */
 @Service
 @RequiredArgsConstructor
@@ -59,13 +63,15 @@ public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenera
     private final InventoryLedgerEntryRepository ledgerRepository;
     private final ExtStorageLocationReplicaRepository storageLocationRepository;
     private final BaseUnitOfMeasureResolver baseUnitOfMeasureResolver;
+    private final CycleCountTaskResponseMapper taskResponseMapper;
 
     @Override
     @Transactional
     public @NonNull CycleCountTaskGenerationResponse generateTasks(
             @NonNull UUID planId, @NonNull GenerateCycleCountTasksRequest request) {
-        CycleCountPlan plan =
-                planRepository.findById(planId).orElseThrow(() -> new CycleCountPlanNotFoundException(planId));
+        CycleCountPlan plan = planRepository
+                .findWithLockByPlanId(planId)
+                .orElseThrow(() -> new CycleCountPlanNotFoundException(planId));
 
         if (plan.getStatus() != CycleCountPlanStatus.PLANNED && plan.getStatus() != CycleCountPlanStatus.STARTED) {
             throw new IllegalStateException("Cannot generate tasks for cycle count plan " + planId + " in status "
@@ -74,33 +80,50 @@ public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenera
 
         Set<UUID> countLocations = expandCountLocations(plan);
 
-        List<CycleCountTask> created = new ArrayList<>();
+        Set<String> existingKeys = new HashSet<>();
+        for (CycleCountTask existing : taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(planId)) {
+            existingKeys.add(taskKey(existing.getBinLocation(), existing.getItemSku()));
+        }
+
+        List<CycleCountTask> toCreate = new ArrayList<>();
         int skippedExisting = 0;
         for (UUID location : countLocations) {
             String binLocation = location.toString();
             for (InventoryLedgerEntryRepository.LocationOnHand onHand : ledgerRepository.findPositiveOnHandByLocation(
                     location, InventoryLedgerEventType.onHandAffectingTypes())) {
-                if (taskRepository.existsByPlanIdAndBinLocationAndItemSku(
-                        planId, binLocation, onHand.getStockItemId())) {
+                if (!existingKeys.add(taskKey(binLocation, onHand.getStockItemId()))) {
                     skippedExisting++;
                     continue;
                 }
-                created.add(taskRepository.save(CycleCountTask.builder()
+                toCreate.add(CycleCountTask.builder()
                         .planId(planId)
                         .binLocation(binLocation)
                         .itemSku(onHand.getStockItemId())
                         .expectedQuantity(onHand.getOnHandQuantity())
                         .auditorId(request.getAuditorId())
                         .status(TaskStatus.ASSIGNED)
-                        .build()));
+                        .build());
             }
         }
+        List<CycleCountTask> created = toCreate.isEmpty() ? List.of() : taskRepository.saveAll(toCreate);
 
+        boolean planHasTasks = !created.isEmpty() || skippedExisting > 0;
         CycleCountPlanStatus planStatus = plan.getStatus();
-        if (planStatus == CycleCountPlanStatus.PLANNED) {
-            planStatus = CycleCountPlanStatus.valueOf(planService
-                    .updateStatus(planId, CycleCountPlanStatus.STARTED)
-                    .getStatus());
+        if (planStatus == CycleCountPlanStatus.PLANNED && planHasTasks) {
+            planStatus = CycleCountPlanStatus.valueOf(
+                    planService.startForTaskGeneration(planId).getStatus());
+        }
+        if (!planHasTasks) {
+            // The scope resolved to no stocked (bin, SKU) pair at all. Leave the plan PLANNED —
+            // flipping it to STARTED would fabricate an in-progress count with nothing to count —
+            // and say so, since a 201 with zero tasks is otherwise easy to misread as success.
+            log.warn(
+                    "Cycle count task generation for plan {} found no stocked (location, SKU) pairs across {}"
+                            + " scanned locations; plan left in {} — check the plan's zones/site against where its"
+                            + " ledger stock is actually located",
+                    planId,
+                    countLocations.size(),
+                    planStatus);
         }
 
         log.info(
@@ -116,7 +139,7 @@ public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenera
                 .locationsScanned(countLocations.size())
                 .tasksCreated(created.size())
                 .tasksSkippedExisting(skippedExisting)
-                .tasks(created.stream().map(this::toTaskResponse).toList())
+                .tasks(toResponses(created))
                 .build();
     }
 
@@ -126,8 +149,23 @@ public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenera
         if (!planRepository.existsById(planId)) {
             throw new CycleCountPlanNotFoundException(planId);
         }
-        return taskRepository.findByPlanId(planId).stream()
-                .map(this::toTaskResponse)
+        return toResponses(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(planId));
+    }
+
+    private static String taskKey(String binLocation, String itemSku) {
+        return binLocation + '|' + itemSku;
+    }
+
+    /** Maps tasks with the base-UoM lookup memoized per distinct SKU instead of one call per task. */
+    private List<CycleCountTaskResponse> toResponses(List<CycleCountTask> tasks) {
+        Map<String, Optional<String>> uomBySku = new HashMap<>();
+        return tasks.stream()
+                .map(task -> taskResponseMapper.toResponse(
+                        task,
+                        uomBySku.computeIfAbsent(
+                                        task.getItemSku(),
+                                        sku -> Optional.ofNullable(baseUnitOfMeasureResolver.resolve(sku)))
+                                .orElse(null)))
                 .toList();
     }
 
@@ -165,29 +203,5 @@ public class CycleCountTaskGenerationServiceImpl implements CycleCountTaskGenera
             frontier = children;
         }
         return expanded;
-    }
-
-    private CycleCountTaskResponse toTaskResponse(CycleCountTask task) {
-        return CycleCountTaskResponse.builder()
-                .taskId(task.getTaskId())
-                .binLocation(task.getBinLocation())
-                .itemSku(task.getItemSku())
-                .itemDescription(task.getItemDescription())
-                .expectedQuantity(task.getExpectedQuantity())
-                .unitOfMeasure(baseUnitOfMeasureResolver.resolve(task.getItemSku()))
-                .auditorId(task.getAuditorId())
-                .planId(task.getPlanId())
-                .status(task.getStatus())
-                .latestCountEntryId(task.getLatestCountEntryId())
-                .countEntriesCount(task.getCountEntriesCount())
-                .createdAt(
-                        task.getCreatedAt() != null
-                                ? LocalDateTime.ofInstant(task.getCreatedAt(), ZoneOffset.UTC)
-                                : null)
-                .updatedAt(
-                        task.getUpdatedAt() != null
-                                ? LocalDateTime.ofInstant(task.getUpdatedAt(), ZoneOffset.UTC)
-                                : null)
-                .build();
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskResponseMapper.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskResponseMapper.java
@@ -1,0 +1,56 @@
+package com.positivity.inventory.internal.cyclecount.service;
+
+import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.entity.CycleCountTask;
+import com.positivity.inventory.internal.service.BaseUnitOfMeasureResolver;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Single {@link CycleCountTask} → {@link CycleCountTaskResponse} mapping, shared by
+ * {@code CycleCountServiceImpl} and {@code CycleCountTaskGenerationServiceImpl} so a new response
+ * field is added in one place instead of two diverging private copies.
+ */
+@Component
+@RequiredArgsConstructor
+public class CycleCountTaskResponseMapper {
+
+    private final BaseUnitOfMeasureResolver baseUnitOfMeasureResolver;
+
+    /** Maps one task, resolving its base UoM per call. */
+    public @NonNull CycleCountTaskResponse toResponse(@NonNull CycleCountTask task) {
+        return toResponse(task, baseUnitOfMeasureResolver.resolve(task.getItemSku()));
+    }
+
+    /**
+     * Maps one task with a pre-resolved base UoM ({@code null} when the SKU resolves to none) —
+     * for batch callers that memoize the resolver lookup per SKU.
+     */
+    public @NonNull CycleCountTaskResponse toResponse(@NonNull CycleCountTask task, @Nullable String unitOfMeasure) {
+        return CycleCountTaskResponse.builder()
+                .taskId(task.getTaskId())
+                .binLocation(task.getBinLocation())
+                .itemSku(task.getItemSku())
+                .itemDescription(task.getItemDescription())
+                .expectedQuantity(task.getExpectedQuantity())
+                .unitOfMeasure(unitOfMeasure)
+                .auditorId(task.getAuditorId())
+                .planId(task.getPlanId())
+                .status(task.getStatus())
+                .latestCountEntryId(task.getLatestCountEntryId())
+                .countEntriesCount(task.getCountEntriesCount())
+                .createdAt(
+                        task.getCreatedAt() != null
+                                ? LocalDateTime.ofInstant(task.getCreatedAt(), ZoneOffset.UTC)
+                                : null)
+                .updatedAt(
+                        task.getUpdatedAt() != null
+                                ? LocalDateTime.ofInstant(task.getUpdatedAt(), ZoneOffset.UTC)
+                                : null)
+                .build();
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/AdjustmentResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/AdjustmentResponse.java
@@ -39,11 +39,12 @@ public class AdjustmentResponse {
     private UUID adjustmentId;
 
     @Schema(
-            description = "Identifier of the stock item the adjustment applies to",
-            example = "01960003-0000-7000-8000-000000000002",
+            description = "Stock reference the adjustment applies to — the ledger's freeform stock_item_id text:"
+                    + " a SKU code, or a catalog product UUID rendered as text",
+            example = "OIL-5W30-5QT",
             requiredMode = REQUIRED)
     @NotNull
-    private UUID stockItemId;
+    private String stockItemId;
 
     @Schema(
             description = "Reason code explaining why the adjustment was made",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CreateAdjustmentRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CreateAdjustmentRequest.java
@@ -22,11 +22,13 @@ import lombok.NoArgsConstructor;
 public class CreateAdjustmentRequest {
 
     @Schema(
-            description = "Identifier of the stock item being adjusted",
-            example = "01960003-0000-7000-8000-000000000001",
+            description = "Stock reference being adjusted — the ledger's freeform stock_item_id text: a SKU code"
+                    + " (e.g. OIL-5W30-5QT), or a catalog product UUID rendered as text. Not a product id.",
+            example = "OIL-5W30-5QT",
             requiredMode = REQUIRED)
-    @NotNull(message = "Stock item ID is required")
-    private UUID stockItemId;
+    @NotBlank(message = "Stock item ID is required")
+    @Size(max = 255)
+    private String stockItemId;
 
     @Schema(
             description = "Cycle count task this adjustment settles, if created from a task. Enables"

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CycleCountTaskResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CycleCountTaskResponse.java
@@ -65,6 +65,12 @@ public class CycleCountTaskResponse {
             requiredMode = NOT_REQUIRED)
     private String auditorId;
 
+    @Schema(
+            description = "Cycle count plan the task was generated from; null for tasks created outside a plan",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = NOT_REQUIRED)
+    private UUID planId;
+
     @Schema(description = "Current status of the cycle count task", example = "ASSIGNED", requiredMode = REQUIRED)
     @NotNull
     private TaskStatus status;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/plan/CycleCountTaskGenerationResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/plan/CycleCountTaskGenerationResponse.java
@@ -1,0 +1,45 @@
+package com.positivity.inventory.internal.dto.cyclecount.plan;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Outcome of one plan-driven task generation pass. */
+@Schema(description = "Summary of one cycle-count task generation pass for a plan")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CycleCountTaskGenerationResponse {
+
+    @Schema(
+            description = "Plan the tasks were generated for",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    private UUID planId;
+
+    @Schema(description = "Plan lifecycle status after generation", example = "STARTED", requiredMode = REQUIRED)
+    private String planStatus;
+
+    @Schema(description = "Storage locations scanned for book stock", example = "10", requiredMode = REQUIRED)
+    private int locationsScanned;
+
+    @Schema(description = "Count tasks created in this pass", example = "12", requiredMode = REQUIRED)
+    private int tasksCreated;
+
+    @Schema(
+            description = "(bin, SKU) pairs skipped because the plan already has a task for them",
+            example = "0",
+            requiredMode = REQUIRED)
+    private int tasksSkippedExisting;
+
+    @Schema(description = "The tasks created in this pass", requiredMode = REQUIRED)
+    private List<CycleCountTaskResponse> tasks;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/plan/GenerateCycleCountTasksRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/plan/GenerateCycleCountTasksRequest.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,5 +22,8 @@ public class GenerateCycleCountTasksRequest {
             example = "auditor-10042",
             requiredMode = REQUIRED)
     @NotBlank
+    // Matches cycle_count_task.auditor_id varchar(100): reject over-long values as a 400 up
+    // front instead of a constraint violation after the whole generation pass has run.
+    @Size(max = 100)
     private String auditorId;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/plan/GenerateCycleCountTasksRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/plan/GenerateCycleCountTasksRequest.java
@@ -1,0 +1,25 @@
+package com.positivity.inventory.internal.dto.cyclecount.plan;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Request to generate count tasks for a cycle count plan")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GenerateCycleCountTasksRequest {
+
+    @Schema(
+            description = "Identifier of the auditor the generated tasks are assigned to",
+            example = "auditor-10042",
+            requiredMode = REQUIRED)
+    @NotBlank
+    private String auditorId;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountAdjustment.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountAdjustment.java
@@ -38,10 +38,15 @@ public class CycleCountAdjustment {
     private UUID adjustmentId;
 
     /**
-     * SKU identifier for the stock item being adjusted.
+     * Stock reference being adjusted: the same freeform text key the inventory
+     * ledger aggregates by ({@code inventory_ledger_entry.stock_item_id}) — a
+     * SKU code, or a catalog product UUID rendered as text. NOT a product id:
+     * SKU codes and product/catalog ids are different things, and the
+     * adjustment must post against exactly the key the counts and movements
+     * used.
      */
-    @Column(nullable = false)
-    private UUID stockItemId;
+    @Column(nullable = false, length = 255)
+    private String stockItemId;
 
     /**
      * Cycle count task this adjustment settles, when created from a task

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountTask.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountTask.java
@@ -85,6 +85,13 @@ public class CycleCountTask {
     private String auditorId;
 
     /**
+     * Cycle count plan this task was generated from, when the task came out of
+     * plan-driven task generation. Null for tasks created outside a plan.
+     */
+    @Column(name = "plan_id")
+    private UUID planId;
+
+    /**
      * Current status of the task in the workflow.
      */
     @Enumerated(EnumType.STRING)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountAdjustmentRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountAdjustmentRepository.java
@@ -22,10 +22,11 @@ public interface CycleCountAdjustmentRepository extends JpaRepository<CycleCount
     /**
      * Find all adjustments for a specific stock item.
      *
-     * @param stockItemId the stock item ID
+     * @param stockItemId the stock reference (ledger {@code stock_item_id} text: a SKU code, or a
+     *     product UUID rendered as text)
      * @return list of adjustments for that item
      */
-    List<CycleCountAdjustment> findByStockItemId(UUID stockItemId);
+    List<CycleCountAdjustment> findByStockItemId(String stockItemId);
 
     /**
      * Count adjustments with a specific status.

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountPlanRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountPlanRepository.java
@@ -2,15 +2,29 @@ package com.positivity.inventory.internal.repository;
 
 import com.positivity.inventory.internal.entity.CycleCountPlan;
 import com.positivity.inventory.internal.enums.CycleCountPlanStatus;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CycleCountPlanRepository extends JpaRepository<CycleCountPlan, UUID> {
+
+    /**
+     * Row-locks one plan for the duration of the transaction. Task generation
+     * takes this lock so concurrent generation requests for the same plan
+     * serialize: the second waits, then sees the first's tasks and skips them,
+     * instead of racing the (plan, bin, SKU) unique constraint and rolling
+     * back its whole pass.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM CycleCountPlan p WHERE p.planId = :planId")
+    Optional<CycleCountPlan> findWithLockByPlanId(@Param("planId") UUID planId);
 
     @Query("""
             SELECT p FROM CycleCountPlan p

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountPlanRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountPlanRepository.java
@@ -6,6 +6,7 @@ import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,7 +25,7 @@ public interface CycleCountPlanRepository extends JpaRepository<CycleCountPlan, 
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM CycleCountPlan p WHERE p.planId = :planId")
-    Optional<CycleCountPlan> findWithLockByPlanId(@Param("planId") UUID planId);
+    Optional<CycleCountPlan> findWithLockByPlanId(@Param("planId") @NonNull UUID planId);
 
     @Query("""
             SELECT p FROM CycleCountPlan p

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountTaskRepository.java
@@ -25,4 +25,15 @@ public interface CycleCountTaskRepository extends JpaRepository<CycleCountTask, 
      * Find tasks assigned to an auditor with a specific status.
      */
     List<CycleCountTask> findByAuditorIdAndStatus(String auditorId, TaskStatus status);
+
+    /**
+     * Tasks generated from one cycle count plan.
+     */
+    List<CycleCountTask> findByPlanId(UUID planId);
+
+    /**
+     * Idempotency check for plan-driven task generation: whether the plan
+     * already has a task for this (bin, SKU).
+     */
+    boolean existsByPlanIdAndBinLocationAndItemSku(UUID planId, String binLocation, String itemSku);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountTaskRepository.java
@@ -27,13 +27,9 @@ public interface CycleCountTaskRepository extends JpaRepository<CycleCountTask, 
     List<CycleCountTask> findByAuditorIdAndStatus(String auditorId, TaskStatus status);
 
     /**
-     * Tasks generated from one cycle count plan.
+     * Tasks generated from one cycle count plan, in creation order (createdAt
+     * with the time-ordered UUIDv7 taskId as tiebreaker) — the order the plan
+     * task listing endpoint documents.
      */
-    List<CycleCountTask> findByPlanId(UUID planId);
-
-    /**
-     * Idempotency check for plan-driven task generation: whether the plan
-     * already has a task for this (bin, SKU).
-     */
-    boolean existsByPlanIdAndBinLocationAndItemSku(UUID planId, String binLocation, String itemSku);
+    List<CycleCountTask> findByPlanIdOrderByCreatedAtAscTaskIdAsc(UUID planId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CycleCountTaskRepository.java
@@ -4,6 +4,7 @@ import com.positivity.inventory.internal.entity.CycleCountTask;
 import com.positivity.inventory.internal.enums.TaskStatus;
 import java.util.List;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -31,5 +32,6 @@ public interface CycleCountTaskRepository extends JpaRepository<CycleCountTask, 
      * with the time-ordered UUIDv7 taskId as tiebreaker) — the order the plan
      * task listing endpoint documents.
      */
-    List<CycleCountTask> findByPlanIdOrderByCreatedAtAscTaskIdAsc(UUID planId);
+    @NonNull
+    List<CycleCountTask> findByPlanIdOrderByCreatedAtAscTaskIdAsc(@NonNull UUID planId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -107,6 +107,10 @@ public interface InventoryLedgerEntryRepository
                 stockItemId.toString(), InventoryLedgerEventType.onHandAffectingTypes());
     }
 
+    default BigDecimal calculateOnHandQuantity(String stockItemId) {
+        return calculateOnHandQuantityForEventTypes(stockItemId, InventoryLedgerEventType.onHandAffectingTypes());
+    }
+
     @Query("""
                         SELECT COALESCE(SUM(e.changeInQuantity), 0)
                         FROM InventoryLedgerEntry e

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -175,6 +175,57 @@ public interface InventoryLedgerEntryRepository
         BigDecimal getOnHandQuantity();
     }
 
+    /**
+     * Grouped variant of {@link #findPositiveOnHandByLocation} over many locations at once:
+     * positive on-hand per (location, stockItemId), deterministically ordered. One round trip
+     * per chunk instead of one aggregation query per location — use
+     * {@link #findPositiveOnHandByLocationsChunked} rather than calling this directly.
+     */
+    @Query("""
+                        SELECT e.locationId AS locationId, e.stockItemId AS stockItemId,
+                               COALESCE(SUM(e.changeInQuantity), 0) AS onHandQuantity
+                        FROM InventoryLedgerEntry e
+                        WHERE e.locationId IN :locationIds
+                          AND e.eventType IN :eventTypes
+                        GROUP BY e.locationId, e.stockItemId
+                        HAVING COALESCE(SUM(e.changeInQuantity), 0) > 0
+                        ORDER BY e.locationId, e.stockItemId
+                        """)
+    List<LocationStockOnHand> findPositiveOnHandByLocations(
+            @Param("locationIds") Collection<UUID> locationIds,
+            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+
+    /**
+     * Chunk-safe {@link #findPositiveOnHandByLocations}, grouped per location. Locations with no
+     * positive on-hand are absent from the result (treat as empty); an empty {@code locationIds}
+     * short-circuits without executing SQL. Per-location lists keep the query's stockItemId order.
+     */
+    default Map<UUID, List<LocationStockOnHand>> findPositiveOnHandByLocationsChunked(
+            Collection<UUID> locationIds, Collection<InventoryLedgerEventType> eventTypes) {
+        if (locationIds == null || locationIds.isEmpty() || eventTypes == null || eventTypes.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> distinctIds = locationIds.stream().distinct().toList();
+        Map<UUID, List<LocationStockOnHand>> byLocation = new HashMap<>();
+        for (int start = 0; start < distinctIds.size(); start += LOCATION_ID_CHUNK_SIZE) {
+            List<UUID> chunk = distinctIds.subList(start, Math.min(start + LOCATION_ID_CHUNK_SIZE, distinctIds.size()));
+            for (LocationStockOnHand row : findPositiveOnHandByLocations(chunk, eventTypes)) {
+                byLocation
+                        .computeIfAbsent(row.getLocationId(), _ -> new java.util.ArrayList<>())
+                        .add(row);
+            }
+        }
+        return byLocation;
+    }
+
+    interface LocationStockOnHand {
+        UUID getLocationId();
+
+        String getStockItemId();
+
+        BigDecimal getOnHandQuantity();
+    }
+
     // ─── Point-in-time (as-of) aggregations (odoo-parity A3, issue #1029) ─────
     // Direct ledger math with a timestamp bound — the pre-A1 SUM queries with an
     // `e.timestamp <= :asOf` cutoff. Never touches the stock summary; acceptable

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
@@ -96,10 +96,11 @@ public class CycleCountConflictDetector {
     /**
      * Tasks store the bin as free text; when it holds a storage-location UUID
      * the window queries are location-scoped, otherwise they fall back to the
-     * SKU across all locations (consistent with the global on-hand math used
-     * by the adjustment posting path).
+     * SKU across all locations. {@code CycleCountAdjustmentServiceImpl} uses
+     * the same resolution so variance recomputation and ledger posting scope
+     * to exactly the location this detector scopes to.
      */
-    private Optional<UUID> locationIdOf(CycleCountTask task) {
+    public static Optional<UUID> locationIdOf(@NonNull CycleCountTask task) {
         try {
             return Optional.of(UUID.fromString(task.getBinLocation()));
         } catch (RuntimeException ex) {

--- a/pos-inventory/src/main/resources/db/migration/R__seed_reference_inventory.sql
+++ b/pos-inventory/src/main/resources/db/migration/R__seed_reference_inventory.sql
@@ -628,3 +628,50 @@ VALUES
   (md5('inv_seed2:WIXF-XP50003F:01960004-0003-7000-8000-000000000022')::uuid, 'WIXF-XP50003F', '01960004-0003-7000-8000-000000000022'::uuid, 'GOODS_RECEIPT', 6, 6, 'EA', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: WIX XP Series Oil Filter XP50003'),
   (md5('inv_seed2:DORM-635-422:01960004-0003-7000-8000-000000000022')::uuid, 'DORM-635-422', '01960004-0003-7000-8000-000000000022'::uuid, 'GOODS_RECEIPT', 20, 20, 'EA', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Dorman Valve Cover Gasket Set 635-422')
 ON CONFLICT (ledger_entry_id) DO NOTHING;
+
+-- =============================================================================
+-- CYCLE COUNT PLAN — Shelf A (Bins A-01..A-10), ready for task generation
+--
+-- A PLANNED plan whose zoneIds are the ten Shelf A bin storage-location UUIDs
+-- stocked by the ledger rows above. Task generation
+-- (POST /v1/inventory/cycleCountPlans/{planId}/tasks) treats each zone id as a
+-- count location directly (plus any replicated descendants), so this plan
+-- expands into ASSIGNED tasks with ledger-derived expected quantities on a
+-- database seeded only by this file — no ext_storage_location facts required.
+--
+-- scheduled_date is NOW()-relative and only matters for the API-side "must be
+-- future" rule on plan creation, which direct seeding does not go through;
+-- generation itself never reads it. Idempotent via the deterministic plan_id
+-- and the NOT EXISTS guard on the zone rows (cycle_count_plan_zone has no
+-- unique key to ON CONFLICT against).
+-- =============================================================================
+INSERT INTO cycle_count_plan (plan_id, location_id, plan_name, scheduled_date, status, created_by, created_at, updated_at)
+VALUES (
+    md5('inv_seed:cycle-count-plan-shelf-a')::uuid,
+    '96dd346a-047c-86f5-3c9a-7c8cac53da86'::uuid,
+    'Seeded count — Shelf A motor oils & fluids',
+    (NOW() + INTERVAL '7 days')::date,
+    'PLANNED',
+    'system-seed',
+    NOW(),
+    NOW())
+ON CONFLICT (plan_id) DO NOTHING;
+
+INSERT INTO cycle_count_plan_zone (plan_id, zone_id)
+SELECT md5('inv_seed:cycle-count-plan-shelf-a')::uuid, v.zone_id
+FROM (VALUES
+    ('01960004-0001-7000-8000-000000000009'::uuid),
+    ('01960004-0001-7000-8000-00000000000a'::uuid),
+    ('01960004-0001-7000-8000-00000000000b'::uuid),
+    ('01960004-0001-7000-8000-00000000000c'::uuid),
+    ('01960004-0001-7000-8000-00000000000d'::uuid),
+    ('01960004-0001-7000-8000-00000000000e'::uuid),
+    ('01960004-0001-7000-8000-00000000000f'::uuid),
+    ('01960004-0001-7000-8000-000000000010'::uuid),
+    ('01960004-0001-7000-8000-000000000011'::uuid),
+    ('01960004-0001-7000-8000-000000000012'::uuid)
+) AS v(zone_id)
+WHERE NOT EXISTS (
+    SELECT 1 FROM cycle_count_plan_zone z
+    WHERE z.plan_id = md5('inv_seed:cycle-count-plan-shelf-a')::uuid
+      AND z.zone_id = v.zone_id);

--- a/pos-inventory/src/main/resources/db/migration/V47__cycle_count_task_plan_link.sql
+++ b/pos-inventory/src/main/resources/db/migration/V47__cycle_count_task_plan_link.sql
@@ -1,0 +1,16 @@
+-- Plan → task generation: tasks created from a cycle count plan carry the
+-- originating plan_id, so generation is idempotent per (plan, bin, SKU) and a
+-- plan's tasks can be listed. plan_id stays NULL for tasks created outside a
+-- plan (direct seeding, tests), and the unique guard ignores those rows
+-- because NULLs are distinct.
+ALTER TABLE cycle_count_task ADD COLUMN plan_id uuid;
+
+ALTER TABLE cycle_count_task
+    ADD CONSTRAINT fk_cycle_count_task_plan FOREIGN KEY (plan_id) REFERENCES cycle_count_plan (plan_id);
+
+CREATE INDEX idx_cycle_count_task_plan ON cycle_count_task (plan_id);
+
+-- Hard exactly-once guard mirroring cycle_count_plan_schedule_due_key: one
+-- task per (plan, bin, SKU) regardless of application-level existence checks.
+ALTER TABLE cycle_count_task
+    ADD CONSTRAINT cycle_count_task_plan_bin_sku_key UNIQUE (plan_id, bin_location, item_sku);

--- a/pos-inventory/src/main/resources/db/migration/V48__cycle_count_adjustment_stock_ref_text.sql
+++ b/pos-inventory/src/main/resources/db/migration/V48__cycle_count_adjustment_stock_ref_text.sql
@@ -1,0 +1,10 @@
+-- The adjustment's stock reference is the same key the inventory ledger
+-- aggregates by (inventory_ledger_entry.stock_item_id, freeform text: a SKU
+-- code such as 'OIL-5W30-5QT', or a catalog product UUID rendered as text —
+-- SKU codes and product/catalog ids are different things). Typing this column
+-- uuid dead-ended the count → adjustment leg for every non-UUID SKU: no UUID
+-- could ever match those ledger rows, so their variances could never be
+-- adjusted or posted. Widened to the ledger column's own type; existing UUID
+-- values keep working verbatim as their text rendering.
+ALTER TABLE cycle_count_adjustment
+    ALTER COLUMN stock_item_id TYPE character varying(255) USING stock_item_id::text;

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountAdjustmentServiceImplTest.java
@@ -83,7 +83,7 @@ class CycleCountAdjustmentServiceImplTest {
 
     private static final String ACTOR_USER_ID = "actor-person-id-001";
     private static final String ACTOR_USERNAME = "manager-user";
-    private static final UUID STOCK_ITEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String STOCK_ITEM_ID = "SKU-ADJ-TEST-001";
     private Clock clock = Clock.systemDefaultZone();
 
     @BeforeEach

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountServiceImplTest.java
@@ -82,7 +82,7 @@ class CycleCountServiceImplTest {
                 new CycleCountToleranceResolver(toleranceRepository),
                 uomConversionService,
                 new QuantityScaleGuard(uomConversionService),
-                baseUnitOfMeasureResolver);
+                new CycleCountTaskResponseMapper(baseUnitOfMeasureResolver));
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,8 +40,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 /**
  * Unit tests for CycleCountTaskGenerationServiceImpl: plan → task expansion
  * (ledger on-hand snapshot, zone/site scope resolution, replica descendant
- * traversal), per-(plan, bin, SKU) idempotency, and the PLANNED → STARTED
- * transition.
+ * traversal), per-(plan, bin, SKU) idempotency against preloaded existing
+ * tasks, the PLANNED → STARTED transition through the event-emitting
+ * startForTaskGeneration path, and the empty-scope behavior (no tasks → plan
+ * stays PLANNED).
  */
 @ExtendWith(MockitoExtension.class)
 class CycleCountTaskGenerationServiceImplTest {
@@ -79,7 +82,8 @@ class CycleCountTaskGenerationServiceImplTest {
                 planService,
                 ledgerRepository,
                 storageLocationRepository,
-                baseUnitOfMeasureResolver);
+                baseUnitOfMeasureResolver,
+                new CycleCountTaskResponseMapper(baseUnitOfMeasureResolver));
     }
 
     private CycleCountPlan plan(CycleCountPlanStatus status, List<UUID> zoneIds) {
@@ -115,8 +119,20 @@ class CycleCountTaskGenerationServiceImplTest {
                 .build();
     }
 
-    private void stubEcho() {
-        when(taskRepository.save(any(CycleCountTask.class))).thenAnswer(inv -> inv.getArgument(0));
+    private CycleCountTask existingTask(String binLocation, String sku) {
+        return CycleCountTask.builder()
+                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000098"))
+                .planId(PLAN_ID)
+                .binLocation(binLocation)
+                .itemSku(sku)
+                .expectedQuantity(BigDecimal.ONE)
+                .auditorId(AUDITOR)
+                .status(TaskStatus.ASSIGNED)
+                .build();
+    }
+
+    private void stubSaveAllEcho() {
+        when(taskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
     }
 
     private CycleCountPlanResponse startedPlanResponse() {
@@ -130,16 +146,15 @@ class CycleCountTaskGenerationServiceImplTest {
 
     @Test
     void generatesAssignedTasksFromLedgerOnHandAndStartsPlan() {
-        when(planRepository.findById(PLAN_ID))
+        when(planRepository.findWithLockByPlanId(PLAN_ID))
                 .thenReturn(Optional.of(plan(CycleCountPlanStatus.PLANNED, List.of(ZONE_A))));
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenReturn(List.of());
+        when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
         when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
                 .thenReturn(List.of(onHand("OIL-5W30-5QT", "24"), onHand("WIXF-57356", "12.5")));
-        when(taskRepository.existsByPlanIdAndBinLocationAndItemSku(eq(PLAN_ID), any(), any()))
-                .thenReturn(false);
-        stubEcho();
-        when(planService.updateStatus(PLAN_ID, CycleCountPlanStatus.STARTED)).thenReturn(startedPlanResponse());
+        stubSaveAllEcho();
+        when(planService.startForTaskGeneration(PLAN_ID)).thenReturn(startedPlanResponse());
 
         CycleCountTaskGenerationResponse response =
                 service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
@@ -151,43 +166,45 @@ class CycleCountTaskGenerationServiceImplTest {
         assertThat(response.getTasksSkippedExisting()).isZero();
         assertThat(response.getTasks()).hasSize(2);
 
-        ArgumentCaptor<CycleCountTask> saved = ArgumentCaptor.forClass(CycleCountTask.class);
-        verify(taskRepository, org.mockito.Mockito.times(2)).save(saved.capture());
-        CycleCountTask first = saved.getAllValues().get(0);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<CycleCountTask>> saved = ArgumentCaptor.forClass(List.class);
+        verify(taskRepository).saveAll(saved.capture());
+        assertThat(saved.getValue()).hasSize(2);
+        CycleCountTask first = saved.getValue().get(0);
         assertThat(first.getPlanId()).isEqualTo(PLAN_ID);
         assertThat(first.getBinLocation()).isEqualTo(ZONE_A.toString());
         assertThat(first.getItemSku()).isEqualTo("OIL-5W30-5QT");
         assertThat(first.getExpectedQuantity()).isEqualByComparingTo("24");
         assertThat(first.getAuditorId()).isEqualTo(AUDITOR);
         assertThat(first.getStatus()).isEqualTo(TaskStatus.ASSIGNED);
-        assertThat(saved.getAllValues().get(1).getExpectedQuantity()).isEqualByComparingTo("12.5");
+        assertThat(saved.getValue().get(1).getExpectedQuantity()).isEqualByComparingTo("12.5");
     }
 
     @Test
     void skipsPairsThatAlreadyHaveATaskForThePlan() {
-        when(planRepository.findById(PLAN_ID))
+        when(planRepository.findWithLockByPlanId(PLAN_ID))
                 .thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of(ZONE_A))));
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenReturn(List.of());
+        when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID))
+                .thenReturn(List.of(existingTask(ZONE_A.toString(), "OIL-5W30-5QT")));
         when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
                 .thenReturn(List.of(onHand("OIL-5W30-5QT", "24")));
-        when(taskRepository.existsByPlanIdAndBinLocationAndItemSku(PLAN_ID, ZONE_A.toString(), "OIL-5W30-5QT"))
-                .thenReturn(true);
 
         CycleCountTaskGenerationResponse response =
                 service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
 
         assertThat(response.getTasksCreated()).isZero();
         assertThat(response.getTasksSkippedExisting()).isEqualTo(1);
-        verify(taskRepository, never()).save(any());
+        verify(taskRepository, never()).saveAll(anyList());
         // A STARTED plan stays STARTED — no lifecycle call.
-        verify(planService, never()).updateStatus(any(), any());
+        verify(planService, never()).startForTaskGeneration(any());
         assertThat(response.getPlanStatus()).isEqualTo("STARTED");
     }
 
     @Test
     void expandsZonesThroughReplicatedDescendants() {
-        when(planRepository.findById(PLAN_ID))
+        when(planRepository.findWithLockByPlanId(PLAN_ID))
                 .thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of(ZONE_A))));
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenAnswer(inv -> {
@@ -196,13 +213,12 @@ class CycleCountTaskGenerationServiceImplTest {
                             ? List.of(replica(BIN_A1, ZONE_A))
                             : List.<ExtStorageLocationReplica>of();
                 });
+        when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
         when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
                 .thenReturn(List.of());
         when(ledgerRepository.findPositiveOnHandByLocation(eq(BIN_A1), anyCollection()))
                 .thenReturn(List.of(onHand("WIXF-57356", "12")));
-        when(taskRepository.existsByPlanIdAndBinLocationAndItemSku(eq(PLAN_ID), any(), any()))
-                .thenReturn(false);
-        stubEcho();
+        stubSaveAllEcho();
 
         CycleCountTaskGenerationResponse response =
                 service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
@@ -214,11 +230,13 @@ class CycleCountTaskGenerationServiceImplTest {
 
     @Test
     void zonelessPlanScansSiteReplicasAndFallsBackToPlanLocation() {
-        // With replicas: site lookup seeds the scope.
-        when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of())));
+        // With replicas: site lookup seeds the scope. Nothing stocked → plan stays STARTED as-is.
+        when(planRepository.findWithLockByPlanId(PLAN_ID))
+                .thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of())));
         when(storageLocationRepository.findBySiteId(SITE_ID)).thenReturn(List.of(replica(BIN_A1, null)));
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenReturn(List.of());
+        when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
         when(ledgerRepository.findPositiveOnHandByLocation(eq(BIN_A1), anyCollection()))
                 .thenReturn(List.of());
 
@@ -238,19 +256,41 @@ class CycleCountTaskGenerationServiceImplTest {
     }
 
     @Test
+    void emptyScopeLeavesPlannedPlanPlanned() {
+        when(planRepository.findWithLockByPlanId(PLAN_ID))
+                .thenReturn(Optional.of(plan(CycleCountPlanStatus.PLANNED, List.of(ZONE_A))));
+        when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
+                .thenReturn(List.of());
+        when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
+                .thenReturn(List.of());
+
+        CycleCountTaskGenerationResponse response =
+                service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
+
+        // No stocked pair anywhere: nothing created, and the plan must NOT be started —
+        // an empty count in progress would be a lie.
+        assertThat(response.getTasksCreated()).isZero();
+        assertThat(response.getTasksSkippedExisting()).isZero();
+        assertThat(response.getPlanStatus()).isEqualTo("PLANNED");
+        verify(planService, never()).startForTaskGeneration(any());
+        verify(taskRepository, never()).saveAll(anyList());
+    }
+
+    @Test
     void rejectsGenerationOutsidePlannedOrStarted() {
-        when(planRepository.findById(PLAN_ID))
+        when(planRepository.findWithLockByPlanId(PLAN_ID))
                 .thenReturn(Optional.of(plan(CycleCountPlanStatus.COMPLETED_PENDING_APPROVAL, List.of(ZONE_A))));
 
         assertThatThrownBy(() -> service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("COMPLETED_PENDING_APPROVAL");
-        verify(taskRepository, never()).save(any());
+        verify(taskRepository, never()).saveAll(anyList());
     }
 
     @Test
     void unknownPlanThrowsNotFound() {
-        when(planRepository.findById(PLAN_ID)).thenReturn(Optional.empty());
+        when(planRepository.findWithLockByPlanId(PLAN_ID)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR)))
                 .isInstanceOf(CycleCountPlanNotFoundException.class);
@@ -259,9 +299,9 @@ class CycleCountTaskGenerationServiceImplTest {
     // ─── getTasksForPlan ──────────────────────────────────────────────────────
 
     @Test
-    void listsTasksForPlan() {
+    void listsTasksForPlanInCreationOrder() {
         when(planRepository.existsById(PLAN_ID)).thenReturn(true);
-        when(taskRepository.findByPlanId(PLAN_ID))
+        when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID))
                 .thenReturn(List.of(CycleCountTask.builder()
                         .taskId(UUID.fromString("00000000-0000-0000-0000-000000000099"))
                         .planId(PLAN_ID)

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImplTest.java
@@ -1,0 +1,288 @@
+package com.positivity.inventory.internal.cyclecount.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountPlanResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.CycleCountTaskGenerationResponse;
+import com.positivity.inventory.internal.dto.cyclecount.plan.GenerateCycleCountTasksRequest;
+import com.positivity.inventory.internal.entity.CycleCountPlan;
+import com.positivity.inventory.internal.entity.CycleCountTask;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.enums.CycleCountPlanStatus;
+import com.positivity.inventory.internal.enums.TaskStatus;
+import com.positivity.inventory.internal.exception.CycleCountPlanNotFoundException;
+import com.positivity.inventory.internal.repository.CycleCountPlanRepository;
+import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.service.BaseUnitOfMeasureResolver;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for CycleCountTaskGenerationServiceImpl: plan → task expansion
+ * (ledger on-hand snapshot, zone/site scope resolution, replica descendant
+ * traversal), per-(plan, bin, SKU) idempotency, and the PLANNED → STARTED
+ * transition.
+ */
+@ExtendWith(MockitoExtension.class)
+class CycleCountTaskGenerationServiceImplTest {
+
+    private static final UUID PLAN_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID SITE_ID = UUID.fromString("00000000-0000-0000-0000-000000000010");
+    private static final UUID ZONE_A = UUID.fromString("00000000-0000-0000-0000-000000000020");
+    private static final UUID BIN_A1 = UUID.fromString("00000000-0000-0000-0000-000000000021");
+    private static final String AUDITOR = "auditor-1";
+
+    @Mock
+    private CycleCountPlanRepository planRepository;
+
+    @Mock
+    private CycleCountTaskRepository taskRepository;
+
+    @Mock
+    private CycleCountPlanService planService;
+
+    @Mock
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Mock
+    private ExtStorageLocationReplicaRepository storageLocationRepository;
+
+    @Mock
+    private BaseUnitOfMeasureResolver baseUnitOfMeasureResolver;
+
+    private CycleCountTaskGenerationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CycleCountTaskGenerationServiceImpl(
+                planRepository,
+                taskRepository,
+                planService,
+                ledgerRepository,
+                storageLocationRepository,
+                baseUnitOfMeasureResolver);
+    }
+
+    private CycleCountPlan plan(CycleCountPlanStatus status, List<UUID> zoneIds) {
+        return CycleCountPlan.builder()
+                .planId(PLAN_ID)
+                .locationId(SITE_ID)
+                .zoneIds(zoneIds)
+                .planName("test plan")
+                .status(status)
+                .createdBy("user-1")
+                .build();
+    }
+
+    private InventoryLedgerEntryRepository.LocationOnHand onHand(String sku, String quantity) {
+        return new InventoryLedgerEntryRepository.LocationOnHand() {
+            @Override
+            public String getStockItemId() {
+                return sku;
+            }
+
+            @Override
+            public BigDecimal getOnHandQuantity() {
+                return new BigDecimal(quantity);
+            }
+        };
+    }
+
+    private ExtStorageLocationReplica replica(UUID id, UUID parentId) {
+        return ExtStorageLocationReplica.builder()
+                .storageLocationId(id)
+                .siteId(SITE_ID)
+                .parentStorageLocationId(parentId)
+                .build();
+    }
+
+    private void stubEcho() {
+        when(taskRepository.save(any(CycleCountTask.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private CycleCountPlanResponse startedPlanResponse() {
+        return CycleCountPlanResponse.builder()
+                .planId(PLAN_ID)
+                .status(CycleCountPlanStatus.STARTED.name())
+                .build();
+    }
+
+    // ─── generateTasks ────────────────────────────────────────────────────────
+
+    @Test
+    void generatesAssignedTasksFromLedgerOnHandAndStartsPlan() {
+        when(planRepository.findById(PLAN_ID))
+                .thenReturn(Optional.of(plan(CycleCountPlanStatus.PLANNED, List.of(ZONE_A))));
+        when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
+                .thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
+                .thenReturn(List.of(onHand("OIL-5W30-5QT", "24"), onHand("WIXF-57356", "12.5")));
+        when(taskRepository.existsByPlanIdAndBinLocationAndItemSku(eq(PLAN_ID), any(), any()))
+                .thenReturn(false);
+        stubEcho();
+        when(planService.updateStatus(PLAN_ID, CycleCountPlanStatus.STARTED)).thenReturn(startedPlanResponse());
+
+        CycleCountTaskGenerationResponse response =
+                service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
+
+        assertThat(response.getPlanId()).isEqualTo(PLAN_ID);
+        assertThat(response.getPlanStatus()).isEqualTo("STARTED");
+        assertThat(response.getLocationsScanned()).isEqualTo(1);
+        assertThat(response.getTasksCreated()).isEqualTo(2);
+        assertThat(response.getTasksSkippedExisting()).isZero();
+        assertThat(response.getTasks()).hasSize(2);
+
+        ArgumentCaptor<CycleCountTask> saved = ArgumentCaptor.forClass(CycleCountTask.class);
+        verify(taskRepository, org.mockito.Mockito.times(2)).save(saved.capture());
+        CycleCountTask first = saved.getAllValues().get(0);
+        assertThat(first.getPlanId()).isEqualTo(PLAN_ID);
+        assertThat(first.getBinLocation()).isEqualTo(ZONE_A.toString());
+        assertThat(first.getItemSku()).isEqualTo("OIL-5W30-5QT");
+        assertThat(first.getExpectedQuantity()).isEqualByComparingTo("24");
+        assertThat(first.getAuditorId()).isEqualTo(AUDITOR);
+        assertThat(first.getStatus()).isEqualTo(TaskStatus.ASSIGNED);
+        assertThat(saved.getAllValues().get(1).getExpectedQuantity()).isEqualByComparingTo("12.5");
+    }
+
+    @Test
+    void skipsPairsThatAlreadyHaveATaskForThePlan() {
+        when(planRepository.findById(PLAN_ID))
+                .thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of(ZONE_A))));
+        when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
+                .thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
+                .thenReturn(List.of(onHand("OIL-5W30-5QT", "24")));
+        when(taskRepository.existsByPlanIdAndBinLocationAndItemSku(PLAN_ID, ZONE_A.toString(), "OIL-5W30-5QT"))
+                .thenReturn(true);
+
+        CycleCountTaskGenerationResponse response =
+                service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
+
+        assertThat(response.getTasksCreated()).isZero();
+        assertThat(response.getTasksSkippedExisting()).isEqualTo(1);
+        verify(taskRepository, never()).save(any());
+        // A STARTED plan stays STARTED — no lifecycle call.
+        verify(planService, never()).updateStatus(any(), any());
+        assertThat(response.getPlanStatus()).isEqualTo("STARTED");
+    }
+
+    @Test
+    void expandsZonesThroughReplicatedDescendants() {
+        when(planRepository.findById(PLAN_ID))
+                .thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of(ZONE_A))));
+        when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
+                .thenAnswer(inv -> {
+                    Collection<?> parents = inv.getArgument(0);
+                    return parents.contains(ZONE_A)
+                            ? List.of(replica(BIN_A1, ZONE_A))
+                            : List.<ExtStorageLocationReplica>of();
+                });
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
+                .thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(BIN_A1), anyCollection()))
+                .thenReturn(List.of(onHand("WIXF-57356", "12")));
+        when(taskRepository.existsByPlanIdAndBinLocationAndItemSku(eq(PLAN_ID), any(), any()))
+                .thenReturn(false);
+        stubEcho();
+
+        CycleCountTaskGenerationResponse response =
+                service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
+
+        assertThat(response.getLocationsScanned()).isEqualTo(2);
+        assertThat(response.getTasksCreated()).isEqualTo(1);
+        assertThat(response.getTasks().get(0).getBinLocation()).isEqualTo(BIN_A1.toString());
+    }
+
+    @Test
+    void zonelessPlanScansSiteReplicasAndFallsBackToPlanLocation() {
+        // With replicas: site lookup seeds the scope.
+        when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan(CycleCountPlanStatus.STARTED, List.of())));
+        when(storageLocationRepository.findBySiteId(SITE_ID)).thenReturn(List.of(replica(BIN_A1, null)));
+        when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
+                .thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(BIN_A1), anyCollection()))
+                .thenReturn(List.of());
+
+        assertThat(service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR))
+                        .getLocationsScanned())
+                .isEqualTo(1);
+
+        // Without replicas: the plan's own location id is the single count location.
+        when(storageLocationRepository.findBySiteId(SITE_ID)).thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(SITE_ID), anyCollection()))
+                .thenReturn(List.of());
+
+        CycleCountTaskGenerationResponse fallback =
+                service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
+        assertThat(fallback.getLocationsScanned()).isEqualTo(1);
+        verify(ledgerRepository).findPositiveOnHandByLocation(eq(SITE_ID), anyCollection());
+    }
+
+    @Test
+    void rejectsGenerationOutsidePlannedOrStarted() {
+        when(planRepository.findById(PLAN_ID))
+                .thenReturn(Optional.of(plan(CycleCountPlanStatus.COMPLETED_PENDING_APPROVAL, List.of(ZONE_A))));
+
+        assertThatThrownBy(() -> service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("COMPLETED_PENDING_APPROVAL");
+        verify(taskRepository, never()).save(any());
+    }
+
+    @Test
+    void unknownPlanThrowsNotFound() {
+        when(planRepository.findById(PLAN_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR)))
+                .isInstanceOf(CycleCountPlanNotFoundException.class);
+    }
+
+    // ─── getTasksForPlan ──────────────────────────────────────────────────────
+
+    @Test
+    void listsTasksForPlan() {
+        when(planRepository.existsById(PLAN_ID)).thenReturn(true);
+        when(taskRepository.findByPlanId(PLAN_ID))
+                .thenReturn(List.of(CycleCountTask.builder()
+                        .taskId(UUID.fromString("00000000-0000-0000-0000-000000000099"))
+                        .planId(PLAN_ID)
+                        .binLocation(ZONE_A.toString())
+                        .itemSku("OIL-5W30-5QT")
+                        .expectedQuantity(new BigDecimal("24"))
+                        .auditorId(AUDITOR)
+                        .status(TaskStatus.ASSIGNED)
+                        .build()));
+
+        List<CycleCountTaskResponse> tasks = service.getTasksForPlan(PLAN_ID);
+
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getPlanId()).isEqualTo(PLAN_ID);
+        assertThat(tasks.get(0).getItemSku()).isEqualTo("OIL-5W30-5QT");
+    }
+
+    @Test
+    void listingTasksForUnknownPlanThrowsNotFound() {
+        when(planRepository.existsById(PLAN_ID)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getTasksForPlan(PLAN_ID)).isInstanceOf(CycleCountPlanNotFoundException.class);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/cyclecount/service/CycleCountTaskGenerationServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +27,7 @@ import com.positivity.inventory.internal.service.BaseUnitOfMeasureResolver;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,8 +97,13 @@ class CycleCountTaskGenerationServiceImplTest {
                 .build();
     }
 
-    private InventoryLedgerEntryRepository.LocationOnHand onHand(String sku, String quantity) {
-        return new InventoryLedgerEntryRepository.LocationOnHand() {
+    private InventoryLedgerEntryRepository.LocationStockOnHand onHand(UUID locationId, String sku, String quantity) {
+        return new InventoryLedgerEntryRepository.LocationStockOnHand() {
+            @Override
+            public UUID getLocationId() {
+                return locationId;
+            }
+
             @Override
             public String getStockItemId() {
                 return sku;
@@ -151,8 +156,9 @@ class CycleCountTaskGenerationServiceImplTest {
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenReturn(List.of());
         when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
-                .thenReturn(List.of(onHand("OIL-5W30-5QT", "24"), onHand("WIXF-57356", "12.5")));
+        when(ledgerRepository.findPositiveOnHandByLocationsChunked(anyCollection(), anyCollection()))
+                .thenReturn(Map.of(
+                        ZONE_A, List.of(onHand(ZONE_A, "OIL-5W30-5QT", "24"), onHand(ZONE_A, "WIXF-57356", "12.5"))));
         stubSaveAllEcho();
         when(planService.startForTaskGeneration(PLAN_ID)).thenReturn(startedPlanResponse());
 
@@ -188,8 +194,8 @@ class CycleCountTaskGenerationServiceImplTest {
                 .thenReturn(List.of());
         when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID))
                 .thenReturn(List.of(existingTask(ZONE_A.toString(), "OIL-5W30-5QT")));
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
-                .thenReturn(List.of(onHand("OIL-5W30-5QT", "24")));
+        when(ledgerRepository.findPositiveOnHandByLocationsChunked(anyCollection(), anyCollection()))
+                .thenReturn(Map.of(ZONE_A, List.of(onHand(ZONE_A, "OIL-5W30-5QT", "24"))));
 
         CycleCountTaskGenerationResponse response =
                 service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
@@ -214,10 +220,8 @@ class CycleCountTaskGenerationServiceImplTest {
                             : List.<ExtStorageLocationReplica>of();
                 });
         when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
-                .thenReturn(List.of());
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(BIN_A1), anyCollection()))
-                .thenReturn(List.of(onHand("WIXF-57356", "12")));
+        when(ledgerRepository.findPositiveOnHandByLocationsChunked(anyCollection(), anyCollection()))
+                .thenReturn(Map.of(BIN_A1, List.of(onHand(BIN_A1, "WIXF-57356", "12"))));
         stubSaveAllEcho();
 
         CycleCountTaskGenerationResponse response =
@@ -237,8 +241,8 @@ class CycleCountTaskGenerationServiceImplTest {
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenReturn(List.of());
         when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(BIN_A1), anyCollection()))
-                .thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocationsChunked(anyCollection(), anyCollection()))
+                .thenReturn(Map.of());
 
         assertThat(service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR))
                         .getLocationsScanned())
@@ -246,13 +250,17 @@ class CycleCountTaskGenerationServiceImplTest {
 
         // Without replicas: the plan's own location id is the single count location.
         when(storageLocationRepository.findBySiteId(SITE_ID)).thenReturn(List.of());
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(SITE_ID), anyCollection()))
-                .thenReturn(List.of());
 
         CycleCountTaskGenerationResponse fallback =
                 service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));
         assertThat(fallback.getLocationsScanned()).isEqualTo(1);
-        verify(ledgerRepository).findPositiveOnHandByLocation(eq(SITE_ID), anyCollection());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<UUID>> scannedLocations = ArgumentCaptor.forClass(Collection.class);
+        verify(ledgerRepository, org.mockito.Mockito.times(2))
+                .findPositiveOnHandByLocationsChunked(scannedLocations.capture(), anyCollection());
+        assertThat(scannedLocations.getAllValues().get(0)).containsExactly(BIN_A1);
+        assertThat(scannedLocations.getAllValues().get(1)).containsExactly(SITE_ID);
     }
 
     @Test
@@ -262,8 +270,8 @@ class CycleCountTaskGenerationServiceImplTest {
         when(storageLocationRepository.findByParentStorageLocationIdIn(anyCollection()))
                 .thenReturn(List.of());
         when(taskRepository.findByPlanIdOrderByCreatedAtAscTaskIdAsc(PLAN_ID)).thenReturn(List.of());
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(ZONE_A), anyCollection()))
-                .thenReturn(List.of());
+        when(ledgerRepository.findPositiveOnHandByLocationsChunked(anyCollection(), anyCollection()))
+                .thenReturn(Map.of());
 
         CycleCountTaskGenerationResponse response =
                 service.generateTasks(PLAN_ID, new GenerateCycleCountTasksRequest(AUDITOR));

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
@@ -119,7 +119,7 @@ class CycleCountAdjustmentServiceImplTest {
         @DisplayName("should create adjustment with PENDING_APPROVAL status when approval is required")
         void shouldCreatePendingAdjustmentWhenApprovalRequired() {
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
-                    .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                    .stockItemId("00000000-0000-0000-0000-000000000001")
                     .countedQuantity(new BigDecimal("15"))
                     .quantityOnHandBefore(new BigDecimal("10"))
                     .costAtTimeOfAdjustment(BigDecimal.TEN)
@@ -147,7 +147,7 @@ class CycleCountAdjustmentServiceImplTest {
         @Test
         @DisplayName("J3: costAtTimeOfAdjustment is sourced from the J1 engine, overriding a stale request cost")
         void shouldSourceCostFromEngineOverRequest() {
-            UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-000000000009");
+            String stockItemId = "00000000-0000-0000-0000-000000000009";
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(stockItemId)
                     .countedQuantity(new BigDecimal("15"))
@@ -155,12 +155,12 @@ class CycleCountAdjustmentServiceImplTest {
                     .costAtTimeOfAdjustment(new BigDecimal("99.0000")) // stale interim client value
                     .build();
 
-            when(costStateRepository.findByStockItemId(stockItemId.toString()))
+            when(costStateRepository.findByStockItemId(stockItemId))
                     .thenReturn(Optional.of(SkuCostState.builder()
-                            .stockItemId(stockItemId.toString())
+                            .stockItemId(stockItemId)
                             .avgCost(new BigDecimal("4.2500"))
                             .build()));
-            when(methodResolver.resolve(stockItemId.toString())).thenReturn(CostingMethod.AVERAGE);
+            when(methodResolver.resolve(stockItemId)).thenReturn(CostingMethod.AVERAGE);
             when(thresholdEvaluator.evaluateRequiredApprovalTier(any(CycleCountAdjustment.class)))
                     .thenReturn(Optional.of(ApprovalTier.TIER_1_MANAGER));
             when(adjustmentRepository.save(any(CycleCountAdjustment.class)))
@@ -176,7 +176,7 @@ class CycleCountAdjustmentServiceImplTest {
         @Test
         @DisplayName("J3: STANDARD-costed SKU sources the configured standard cost from the engine")
         void shouldSourceStandardCostFromEngine() {
-            UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+            String stockItemId = "00000000-0000-0000-0000-00000000000a";
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(stockItemId)
                     .countedQuantity(new BigDecimal("8"))
@@ -184,13 +184,13 @@ class CycleCountAdjustmentServiceImplTest {
                     .costAtTimeOfAdjustment(new BigDecimal("99.0000"))
                     .build();
 
-            when(costStateRepository.findByStockItemId(stockItemId.toString()))
+            when(costStateRepository.findByStockItemId(stockItemId))
                     .thenReturn(Optional.of(SkuCostState.builder()
-                            .stockItemId(stockItemId.toString())
+                            .stockItemId(stockItemId)
                             .avgCost(new BigDecimal("4.2500"))
                             .standardCost(new BigDecimal("6.0000"))
                             .build()));
-            when(methodResolver.resolve(stockItemId.toString())).thenReturn(CostingMethod.STANDARD);
+            when(methodResolver.resolve(stockItemId)).thenReturn(CostingMethod.STANDARD);
             when(thresholdEvaluator.evaluateRequiredApprovalTier(any(CycleCountAdjustment.class)))
                     .thenReturn(Optional.of(ApprovalTier.TIER_1_MANAGER));
             when(adjustmentRepository.save(any(CycleCountAdjustment.class)))
@@ -206,7 +206,7 @@ class CycleCountAdjustmentServiceImplTest {
         @Test
         @DisplayName("should create AUTO_APPROVED adjustment and post to ledger when no approval is required")
         void shouldAutoApproveAdjustmentWhenNoApprovalRequired() {
-            UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+            String stockItemId = "00000000-0000-0000-0000-000000000001";
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(stockItemId)
                     .countedQuantity(new BigDecimal("11"))
@@ -324,7 +324,7 @@ class CycleCountAdjustmentServiceImplTest {
         void shouldRejectPendingAdjustment() {
             CycleCountAdjustment adjustment = CycleCountAdjustment.builder()
                     .adjustmentId(adjustmentId)
-                    .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                    .stockItemId("00000000-0000-0000-0000-000000000001")
                     .reasonCode("CYCLE_COUNT_SHRINK")
                     .quantityChange(new BigDecimal("-2"))
                     .costAtTimeOfAdjustment(BigDecimal.ONE)

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
@@ -251,7 +251,7 @@ class CycleCountConflictDetectionTest {
         assertThat(count.getTaskStatus()).isEqualTo(TaskStatus.CONFLICT);
 
         AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
-                .stockItemId(stockItemId)
+                .stockItemId(sku)
                 .taskId(task.getTaskId())
                 .reasonCode("CYCLE_COUNT_VARIANCE")
                 .countedQuantity(new BigDecimal("5"))
@@ -285,8 +285,10 @@ class CycleCountConflictDetectionTest {
     void approvalOnConflict_locationBinTask_scopesRecomputeAndPostingToTheBin() {
         ensureTier1ApprovalThreshold();
 
-        UUID stockItemId = UUID.randomUUID();
-        String sku = stockItemId.toString();
+        // Freeform SKU code, not a UUID: the ledger's stock reference is text, and since the
+        // stock_item_id widening the adjustment leg accepts it too — the exact path that was
+        // dead-ended while cycle_count_adjustment.stock_item_id was typed uuid.
+        String sku = "SKU-I2-BIN-" + UUID.randomUUID();
         UUID binA = UUID.randomUUID();
         UUID binB = UUID.randomUUID();
         // Multi-bin SKU: 5 in bin A, 7 in bin B (global 12). The count is of bin A only.
@@ -305,7 +307,7 @@ class CycleCountConflictDetectionTest {
         assertThat(count.getTaskStatus()).isEqualTo(TaskStatus.CONFLICT);
 
         AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
-                .stockItemId(stockItemId)
+                .stockItemId(sku)
                 .taskId(task.getTaskId())
                 .reasonCode("CYCLE_COUNT_VARIANCE")
                 .countedQuantity(new BigDecimal("3"))
@@ -356,7 +358,7 @@ class CycleCountConflictDetectionTest {
         assertThat(count.getTaskStatus()).isEqualTo(TaskStatus.COUNTED_PENDING_REVIEW);
 
         AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
-                .stockItemId(stockItemId)
+                .stockItemId(sku)
                 .taskId(task.getTaskId())
                 .reasonCode("CYCLE_COUNT_VARIANCE")
                 .countedQuantity(new BigDecimal("8"))

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
@@ -236,8 +236,8 @@ class CycleCountConflictDetectionTest {
 
         UUID stockItemId = UUID.randomUUID();
         String sku = stockItemId.toString();
-        // Non-UUID bin ⇒ detection and recomputation both use the global
-        // (SKU-wide) on-hand math, like the adjustment posting path itself.
+        // Non-UUID bin ⇒ detection, recomputation, and the posted entry all
+        // use the global (SKU-wide) on-hand math with no ledger location.
         post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), 10);
         CycleCountTask task = task("BIN-I2-APPROVE", sku, 10);
         tick();
@@ -277,6 +277,65 @@ class CycleCountConflictDetectionTest {
 
         assertThat(taskRepository.findById(task.getTaskId()).orElseThrow().getStatus())
                 .isEqualTo(TaskStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("CONFLICT approval on a location-bin task recomputes against that bin's on-hand, not the SKU's"
+            + " global stock, and the posted variance entry carries the bin's location")
+    void approvalOnConflict_locationBinTask_scopesRecomputeAndPostingToTheBin() {
+        ensureTier1ApprovalThreshold();
+
+        UUID stockItemId = UUID.randomUUID();
+        String sku = stockItemId.toString();
+        UUID binA = UUID.randomUUID();
+        UUID binB = UUID.randomUUID();
+        // Multi-bin SKU: 5 in bin A, 7 in bin B (global 12). The count is of bin A only.
+        post(sku, binA, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("5"), 5);
+        post(sku, binB, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("7"), 7);
+        CycleCountTask task = task(binA.toString(), sku, 5);
+        tick();
+        // In-window movement at bin A ⇒ CONFLICT; bin A's current on-hand becomes 4.
+        post(sku, binA, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-1"), 4);
+
+        CountResponse count = cycleCountService.submitCount(SubmitCountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(BigDecimal.valueOf(3))
+                .build());
+        assertThat(count.getTaskStatus()).isEqualTo(TaskStatus.CONFLICT);
+
+        AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
+                .stockItemId(stockItemId)
+                .taskId(task.getTaskId())
+                .reasonCode("CYCLE_COUNT_VARIANCE")
+                .countedQuantity(new BigDecimal("3"))
+                .quantityOnHandBefore(new BigDecimal("5")) // stale bin-A snapshot
+                .costAtTimeOfAdjustment(new BigDecimal("10.00"))
+                .createdByUserId(AUDITOR)
+                .build());
+        assertThat(created.getStatus()).isEqualTo(AdjustmentStatus.PENDING_APPROVAL);
+
+        AdjustmentResponse approved = adjustmentService.approveAdjustment(
+                created.getAdjustmentId(), ApproveAdjustmentRequest.builder().build(), null);
+
+        // Recomputed against bin A's CURRENT on-hand (4): counted 3 - 4 = -1.
+        // Never against the SKU's global 11 (which would have posted -8).
+        assertThat(approved.getStatus()).isEqualTo(AdjustmentStatus.POSTED);
+        assertThat(approved.getQuantityChange()).isEqualByComparingTo("-1");
+        assertThat(approved.getQuantityOnHandBefore()).isEqualByComparingTo("4");
+
+        // The posted variance entry carries bin A's location, so bin A's ledger balance
+        // converges to the counted quantity and the next plan's snapshot sees the correction.
+        InventoryLedgerEntry posted =
+                ledgerRepository.findByAdjustmentId(created.getAdjustmentId()).orElseThrow();
+        assertThat(posted.getEventType()).isEqualTo(InventoryLedgerEventType.COUNT_VARIANCE_OUT);
+        assertThat(posted.getChangeInQuantity()).isEqualByComparingTo("-1");
+        assertThat(posted.getLocationId()).isEqualTo(binA);
+        assertThat(ledgerRepository.calculateOnHandQuantityAtLocation(sku, binA))
+                .isEqualByComparingTo("3");
+        // Bin B untouched.
+        assertThat(ledgerRepository.calculateOnHandQuantityAtLocation(sku, binB))
+                .isEqualByComparingTo("7");
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountToleranceReconciliationTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountToleranceReconciliationTest.java
@@ -170,7 +170,7 @@ class CycleCountToleranceReconciliationTest {
 
         // Count and adjustment are separate transactions: within tolerance, no adjustment is
         // ever created and the ledger gains no new entry from the count itself.
-        assertThat(adjustmentRepository.findByStockItemId(productId)).isEmpty();
+        assertThat(adjustmentRepository.findByStockItemId(productId.toString())).isEmpty();
         assertThat(ledgerRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
                 .hasSize(ledgerEntriesBeforeCount);
     }
@@ -202,14 +202,14 @@ class CycleCountToleranceReconciliationTest {
 
         // The count alone never touches the ledger or creates an adjustment — separate
         // transactions, exactly as the owner's spec requires.
-        assertThat(adjustmentRepository.findByStockItemId(productId)).isEmpty();
+        assertThat(adjustmentRepository.findByStockItemId(productId.toString())).isEmpty();
         assertThat(ledgerRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
                 .hasSize(ledgerEntriesBeforeCount);
 
         // A reviewer investigates and explicitly creates the adjustment — a second, separate
         // transaction.
         AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
-                .stockItemId(productId)
+                .stockItemId(productId.toString())
                 .taskId(task.getTaskId())
                 .reasonCode("Suspected meter drift")
                 .countedQuantity(new BigDecimal("7890"))
@@ -290,6 +290,6 @@ class CycleCountToleranceReconciliationTest {
 
         assertThat(response.isWithinTolerance()).isTrue();
         assertThat(response.getTaskStatus()).isEqualTo(TaskStatus.ACCEPTED_WITHIN_TOLERANCE);
-        assertThat(adjustmentRepository.findByStockItemId(productId)).isEmpty();
+        assertThat(adjustmentRepository.findByStockItemId(productId.toString())).isEmpty();
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:<n/a>` — gap closure requested directly (no capability issue); cycle count pipeline previously had plans/schedules on one side and count/recount/adjustment on the other with nothing creating `CycleCountTask` rows
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` → cycle count (plan → task generation is a new additive surface; the adjustment API's `stockItemId` is retyped UUID → string, see Scope — wire-compatible for existing callers, which already sent it as a JSON string)
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controllers (`generateCycleCountTasks`, `listCycleCountPlanTasks` on `CycleCountPlanController`; `stockItemId` schema on `CycleCountAdjustmentController`)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — not regenerated in this PR
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — not regenerated in this PR

## Scope
- What changed:
  - **`CycleCountTaskGenerationService(Impl)`** (`internal/cyclecount/service`): expands a PLANNED/STARTED plan into `ASSIGNED` tasks — one per (storage location, SKU) with positive book stock, via one grouped chunk-safe ledger aggregation — snapshotting on-hand as the expected quantity. Scope = plan zones plus replicated descendant storage locations; a zoneless plan uses the site's replicated locations, degrading to the plan's own location id when no `ext_storage_location` facts exist. Generation row-locks the plan (concurrent requests serialize and skip), is idempotent per (plan, bin, SKU), and transitions a PLANNED plan to STARTED only when the plan has tasks — an empty scope creates nothing and leaves the plan PLANNED with a warning. The implicit transition emits `INVENTORY_CYCLE_COUNT_PLAN_STATUS_UPDATE` via an `@EmitEvent`-annotated `CycleCountPlanService.startForTaskGeneration`.
  - **Migrations**: `V47` — `cycle_count_task.plan_id` (FK + index) and a `(plan_id, bin_location, item_sku)` unique guard. `V48` — `cycle_count_adjustment.stock_item_id` widened uuid → varchar(255): the adjustment's stock reference is the ledger's freeform `stock_item_id` text (a SKU code, or a product UUID rendered as text — SKU codes and product/catalog ids are different things), and the uuid typing dead-ended the count → adjustment leg for every non-UUID SKU. `CycleCountAdjustment`/`CreateAdjustmentRequest`/`AdjustmentResponse.stockItemId` are now String; existing UUID senders are wire-compatible (the value was already a JSON string).
  - **Adjustment scope fixes**: posted `COUNT_VARIANCE_*` ledger entries carry the linked task's storage location, and CONFLICT-approval variance recomputation is scoped to that location (shared `CycleCountConflictDetector.locationIdOf`), so bin snapshots converge and counting one bin of a multi-bin SKU no longer posts the other bins' stock as variance.
  - **Endpoints** on `CycleCountPlanController`: `POST /v1/inventory/cycleCountPlans/{planId}/tasks` (body `{"auditorId": …}`, `@Size(max=100)`-validated, permission `inventory:cycle_count:initiate`, emits `INVENTORY_CYCLE_COUNT_TASK_GENERATE`; auditor assignment is create-time-only) and `GET /v1/inventory/cycleCountPlans/{planId}/tasks` (deterministic creation order). Task responses carry `planId`; task→response mapping extracted into a shared `CycleCountTaskResponseMapper`.
  - **Seed data** (`R__seed_reference_inventory.sql`): a PLANNED "Shelf A" plan whose zone ids are the ten seeded Shelf A bin storage-location UUIDs, so one generate call produces real tasks from the seeded ledger stock, countable and adjustable end-to-end.
- Why: the count-submission flow only worked against tasks seeded externally; plans could never be executed end-to-end, and (post-review) the adjustment leg could not settle variances for SKU-coded stock at all.

## Tests
- [x] Unit tests added/updated — `CycleCountTaskGenerationServiceImplTest` (9 tests: ledger snapshot + ASSIGNED creation + PLANNED→STARTED, idempotency against preloaded tasks, zone descendant traversal, site/fallback scope, empty-scope keeps PLANNED, status/not-found rejections, ordered plan task listing); adjustment tests converted to String stock references
- [x] Integration tests added/updated — `CycleCountConflictDetectionTest`: bin-scoped CONFLICT approval recomputes against the bin (not SKU-global) and posts a location-carrying variance entry, on a freeform SKU code
- [ ] Provider behavioral contract tests added/updated
- How to run: `./mvnw -pl pos-inventory -am test` (full module: 1226 tests green with Spotless/Checkstyle/SpotBugs); `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests -Dsurefire.failIfNoSpecifiedTests=false test` (18/18 green)

## Risk & Rollback
- Risk level: Low–Medium — task generation is purely additive; the adjustment changes alter posting scope for task-linked adjustments (location-carrying entries, location-scoped recompute) and retype `stockItemId` to string (wire-compatible for UUID senders).
- Rollback plan: revert the commits; `V47` is backward-compatible (nullable column). `V48` widens a column — a code rollback keeps working against the widened column for UUID-valued rows; narrowing back would require no non-UUID adjustments to exist yet.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/pos-inventory-cycle-count-nn8vi3` (designated session branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id for this gap closure
- [x] Links to parent + child issues are present (n/a — none exist)
- [x] Contract guide updated (when contract semantics changed) — noted above; `stockItemId` retype called out for the contract guide
- [ ] Required CI checks passing — pending on latest head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaiiRCziQLu4Y4L4pboiL8