### PR TITLE
refactor(pos-event-receiver): move EventDao into internal.dao (#1549)

### DIFF
--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/config/EventTypeInitializer.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/config/EventTypeInitializer.java
@@ -2,7 +2,7 @@ package com.positivity.poseventreceiver.internal.config;
 
 import com.positivity.events.EventTypeInitializerSupport;
 import com.positivity.events.EventTypeRegistration;
-import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dao.EventDao;
 import com.positivity.poseventreceiver.internal.entity.EventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/dao/EventDao.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/dao/EventDao.java
@@ -1,4 +1,4 @@
-package com.positivity.poseventreceiver.dao;
+package com.positivity.poseventreceiver.internal.dao;
 
 import com.positivity.poseventreceiver.internal.dto.EmitEventRequest;
 import com.positivity.poseventreceiver.internal.entity.EmittedEvent;

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/dao/EventDaoImpl.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/dao/EventDaoImpl.java
@@ -1,6 +1,5 @@
 package com.positivity.poseventreceiver.internal.dao;
 
-import com.positivity.poseventreceiver.dao.EventDao;
 import com.positivity.poseventreceiver.internal.dto.EmitEventRequest;
 import com.positivity.poseventreceiver.internal.entity.EmittedEvent;
 import com.positivity.poseventreceiver.internal.entity.EventType;

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/service/EmitEventServiceImpl.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/service/EmitEventServiceImpl.java
@@ -1,6 +1,6 @@
 package com.positivity.poseventreceiver.internal.service;
 
-import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dao.EventDao;
 import com.positivity.poseventreceiver.internal.dto.EmitEventRequest;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImpl.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImpl.java
@@ -1,6 +1,6 @@
 package com.positivity.poseventreceiver.internal.service;
 
-import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dao.EventDao;
 import com.positivity.poseventreceiver.internal.dto.EventTypeMapper;
 import com.positivity.poseventreceiver.internal.dto.EventTypeRequest;
 import com.positivity.poseventreceiver.internal.dto.EventTypeResponse;

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventTypeInitializerTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventTypeInitializerTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.events.EventTypeRegistration;
-import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dao.EventDao;
 import com.positivity.poseventreceiver.internal.entity.EventType;
 import java.util.List;
 import java.util.Optional;

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EmitEventServiceImplTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EmitEventServiceImplTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dao.EventDao;
 import com.positivity.poseventreceiver.internal.dto.EmitEventRequest;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImplTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImplTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dao.EventDao;
 import com.positivity.poseventreceiver.internal.dto.EventTypeRequest;
 import com.positivity.poseventreceiver.internal.dto.EventTypeResponse;
 import com.positivity.poseventreceiver.internal.entity.EventType;


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (module-layout remediation task, no capability id)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1549
- Domain: `domain:event-receiver`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- n/a — no controllers, DTOs, events, or API behavior changed; package move of an internal DAO interface only (no contract-relevant files touched, so no BACKEND_CONTRACT_GUIDE.md entry applies)

## Contract Chain (when a Controller changed)
- n/a — no controller changed

## Scope
- What changed: `com.positivity.poseventreceiver.dao.EventDao` moved to `com.positivity.poseventreceiver.internal.dao.EventDao`, alongside its sole implementation `EventDaoImpl`. Imports updated in 4 main-source and 3 test-source files; the now-same-package import in `EventDaoImpl` dropped. No signature or behavior changes.
- Why: `EventDao` sat outside `internal` — nominally public API under the module-layout convention — while its signatures leak `internal.dto`/`internal.entity` types, the shape ADR-0026 D4 forbids. pos-event-receiver holds no cross-module grant (ADR-0026 D1–D5, amended 2026-08-27), so nothing belongs outside `internal` except `PosEventReceiverApplication`. All references were module-local; no other module imported it. Closes #1549. Lands ahead of #1548's ArchitectureTest anchor fix per the sequencing note in the issue.

## Tests
- [ ] Unit tests added/updated — n/a (pure package move; existing tests updated for the new import only)
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: `./mvnw -pl pos-event-receiver -am test` and `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests -Dsurefire.failIfNoSpecifiedTests=false test` — both green locally (Spotless/Checkstyle/SpotBugs run as part of the build).

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the single commit; the move is mechanical with no schema, config, or API impact.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, issue-based branch `claude/issue-1549-jjv1g1`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability id
- [x] Links to parent + child issues are present (child issue #1549; no parent story)
- [ ] Contract guide updated — n/a, no contract semantics changed
- [ ] Required CI checks passing (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qNrGFoWREo9YAkpQcMqhM

---
_Generated by [Claude Code](https://claude.ai/code/session_015qNrGFoWREo9YAkpQcMqhM)_