### PR TITLE
fix(pos-location): exempt the retired location seed from Flyway startup validation

### DIFF
--- a/pos-location/src/main/resources/application.yml
+++ b/pos-location/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
       ddl-auto: validate
   flyway:
     out-of-order: ${SPRING_FLYWAY_OUT_OF_ORDER:false}
+    # R__seed_location_2_operational_data.sql was retired in favour of the alpha
+    # fixture packs (docs/DATA_SEED_STRATEGY.md, #1554). Environments that ran it
+    # keep its schema-history row, which default validation flags as "applied
+    # migration not resolved locally" and which fails startup. Ignore missing
+    # repeatables only - versioned-migration validation stays fully enforced.
+    ignore-migration-patterns: "repeatable:missing"
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}

--- a/pos-location/src/test/java/com/positivity/location/migration/FlywayIgnoreMigrationPatternsTest.java
+++ b/pos-location/src/test/java/com/positivity/location/migration/FlywayIgnoreMigrationPatternsTest.java
@@ -1,0 +1,64 @@
+package com.positivity.location.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.flywaydb.core.api.MigrationState;
+import org.flywaydb.core.api.pattern.ValidatePattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Pins {@code spring.flyway.ignore-migration-patterns} in {@code application.yml}.
+ *
+ * <p>{@code R__seed_location_2_operational_data.sql} was deleted when the alpha fixture packs
+ * took over operational seeding (docs/DATA_SEED_STRATEGY.md, #1554). Every database that ever
+ * ran it still carries its {@code flyway_schema_history} row, and Flyway's default validation
+ * rejects that row on startup — "Detected applied migration not resolved locally: seed location
+ * 2 operational data" — which aborts the whole application context. Only the property below
+ * keeps those environments bootable, and nothing else in the module would notice its loss:
+ * Flyway is disabled under the {@code test} profile, so no Spring-context test runs validation.
+ *
+ * <p>The second assertion is the reason the pattern is scoped to repeatables rather than a blanket
+ * {@code *:missing}: a deleted or renamed <em>versioned</em> migration is a genuine defect and
+ * must keep failing startup.
+ */
+class FlywayIgnoreMigrationPatternsTest {
+
+    private static final String PROPERTY = "spring.flyway.ignore-migration-patterns";
+
+    @Test
+    @DisplayName("the configured patterns exempt a missing repeatable migration")
+    void patterns_exemptMissingRepeatable() {
+        assertThat(configuredPatterns())
+                .anyMatch(pattern -> pattern.matchesMigration(false, MigrationState.MISSING_SUCCESS));
+    }
+
+    @Test
+    @DisplayName("the configured patterns still fail a missing versioned migration")
+    void patterns_doNotExemptMissingVersioned() {
+        assertThat(configuredPatterns())
+                .noneMatch(pattern -> pattern.matchesMigration(true, MigrationState.MISSING_SUCCESS));
+    }
+
+    /** Reads the property exactly as it ships, then parses it the way Flyway itself does. */
+    private static List<ValidatePattern> configuredPatterns() {
+        YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
+        yaml.setResources(new ClassPathResource("application.yml"));
+        Properties properties = yaml.getObject();
+        assertThat(properties).isNotNull();
+
+        String raw = properties.getProperty(PROPERTY);
+        assertThat(raw).as(PROPERTY).isNotBlank();
+
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(pattern -> !pattern.isEmpty())
+                .map(ValidatePattern::fromPattern)
+                .toList();
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (startup bug/infra — no capability id)
- Parent STORY (durion): n/a
- Child issue: n/a — no issue was filed; this is a follow-up defect from the seed retirement in #1554 (PR #1556, commit fdf6cd5)
- Domain: `domain:location`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable — no controllers, DTOs, `*Request`/`*Response` types, events, validation/error models, or `openapi.yaml` changed. This PR touches one Spring config property and adds one unit test. Reference retained for the sync check: `BACKEND_CONTRACT_GUIDE.md` (no domain anchor applies).

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed:
  - `pos-location/src/main/resources/application.yml`: set `spring.flyway.ignore-migration-patterns: "repeatable:missing"`, with a comment pointing at the retirement that made it necessary.
  - New `pos-location/src/test/java/com/positivity/location/migration/FlywayIgnoreMigrationPatternsTest.java`: reads the shipped `application.yml` and asserts, through Flyway's own `ValidatePattern`, that the configured patterns exempt a **missing repeatable** migration and still reject a **missing versioned** one.
- Why: pos-location fails to start on every database that ever ran `R__seed_location_2_operational_data.sql`:

  ```
  Validate failed: Migrations have failed validation
  Detected applied migration not resolved locally: seed location 2 operational data.
  ```

  That seed was deleted in fdf6cd5 (#1554) when the alpha fixture packs took over operational seeding. Deleting the file does not delete its `flyway_schema_history` row, and Flyway's default validation rejects a history row it cannot resolve to a local file, so `flywayInitializer` fails and the whole application context is cancelled.

  pos-people hit exactly this when its own repeatable seeds were retired (#1527) and already carries the same guard; pos-location was the one module left without it. I checked the full history for deleted repeatable migrations — `pos-location/R__seed_location_2_operational_data.sql`, `pos-people/R__seed_people_operational_data.sql` (fdf6cd5) and `pos-people/R__seed_timekeeping_approval_data.sql` (ae57dc8) are the only three, so pos-location is the last gap.

  The pattern is scoped to repeatables deliberately: a deleted or renamed **versioned** migration is a genuine defect and must keep failing startup. Unlike pos-people, pos-location uses Boot's Flyway auto-configuration, so the property binds directly and no custom `Flyway` bean is needed.

  Note this is a boot fix, not a cleanup: the orphaned history rows stay until each environment is repaired. `flyway repair` would drop them for good and the property could then be removed, but it must remain until every environment has been repaired.

## Tests
- [x] Unit tests added/updated — `FlywayIgnoreMigrationPatternsTest` (2 tests). Nothing else in the module would notice the property's loss: Flyway is disabled under the `test` profile, so no Spring-context test runs validation.
- [ ] Integration tests added/updated — n/a; verified instead against a real Flyway `validate` (below)
- [ ] Provider behavioral contract tests added/updated — n/a, no contract change
- How to run:
  ```bash
  ./mvnw -pl pos-location -am test
  ```
  Result: 262 tests, 0 failures, 0 errors (JDK 25); Spotless, Checkstyle and ArchUnit clean.

  Additionally verified end-to-end with a throwaway harness against a real Flyway `validate` on H2: migrating with `R__seed_location_2_operational_data.sql` present and then validating against a location without it reproduces the reported message verbatim (`Detected applied migration not resolved locally: seed location 2 operational data.`), and adding `repeatable:missing` clears it. That harness was removed before committing; the unit test pins the same semantics without a database.

## Risk & Rollback
- Risk level: Low — one additive validation-scope property. Versioned-migration validation, checksum validation, and every other Flyway behaviour are unchanged; the only rows now tolerated are history entries for repeatable migrations that no longer exist locally.
- Rollback plan: revert the single commit. pos-location then returns to the current failing state on any database that ran the retired seed, so roll back only together with a `flyway repair` on the affected environments.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, designated session branch `claude/pos-location-flyway-migration-as1c97`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability id; conventional `fix(pos-location):` title
- [ ] Links to parent + child issues are present — n/a, no issue filed; originating PR/commit linked above
- [ ] Contract guide updated — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending on this PR (local build green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WujMLvox98H7bvY4yS45wi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WujMLvox98H7bvY4yS45wi)_