### PR TITLE
Grant cycle-count permissions to inventory roles

### DIFF
--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -255,6 +255,14 @@
 --   pricing:normalization:edit. pricing:rule:view and
 --   vehicle-inventory:registry:view/registry:create already carried the
 --   correct holder set from earlier waves and needed no new grants.
+-- * inventory:cycle_count:initiate/view/complete (#1563) were granted to ADMIN
+--   alone, with every inventory role holding only
+--   inventory:cycle_count_tolerance:manage -- a role that plans a count could
+--   not initiate, read or record one. All three now also go to
+--   INVENTORY_MANAGER, INVENTORY_CONTROLLER, INVENTORY_LEAD and
+--   LOCATION_MANAGER, matching the decision on the issue. This baseline is
+--   additive only (see IDEMPOTENCY below), so an existing database needs
+--   V32__grant_cycle_count_to_inventory_roles.sql alongside this change.
 --
 -- IDEMPOTENCY
 -- Every statement below is ON CONFLICT DO NOTHING, and role/permission ids are
@@ -1386,6 +1394,9 @@ FROM (VALUES
     ('INVENTORY_CONTROLLER', 'inventory:adjustment:create'),
     ('INVENTORY_CONTROLLER', 'inventory:adjustment:override'),
     ('INVENTORY_CONTROLLER', 'inventory:adjustment:view'),
+    ('INVENTORY_CONTROLLER', 'inventory:cycle_count:complete'),
+    ('INVENTORY_CONTROLLER', 'inventory:cycle_count:initiate'),
+    ('INVENTORY_CONTROLLER', 'inventory:cycle_count:view'),
     ('INVENTORY_CONTROLLER', 'inventory:cycle_count_tolerance:manage'),
     ('INVENTORY_CONTROLLER', 'inventory:location:sync'),
     ('INVENTORY_CONTROLLER', 'inventory:lot:manage'),
@@ -1432,6 +1443,9 @@ FROM (VALUES
     ('INVENTORY_LEAD', 'inventory:asn:view'),
     ('INVENTORY_LEAD', 'inventory:availability:read'),
     ('INVENTORY_LEAD', 'inventory:availability:search'),
+    ('INVENTORY_LEAD', 'inventory:cycle_count:complete'),
+    ('INVENTORY_LEAD', 'inventory:cycle_count:initiate'),
+    ('INVENTORY_LEAD', 'inventory:cycle_count:view'),
     ('INVENTORY_LEAD', 'inventory:goods_receipt:create'),
     ('INVENTORY_LEAD', 'inventory:goods_receipt:view'),
     ('INVENTORY_LEAD', 'inventory:issue:parts'),
@@ -1472,6 +1486,9 @@ FROM (VALUES
     ('INVENTORY_MANAGER', 'inventory:adjustment:approve'),
     ('INVENTORY_MANAGER', 'inventory:adjustment:create'),
     ('INVENTORY_MANAGER', 'inventory:adjustment:view'),
+    ('INVENTORY_MANAGER', 'inventory:cycle_count:complete'),
+    ('INVENTORY_MANAGER', 'inventory:cycle_count:initiate'),
+    ('INVENTORY_MANAGER', 'inventory:cycle_count:view'),
     ('INVENTORY_MANAGER', 'inventory:cycle_count_tolerance:manage'),
     ('INVENTORY_MANAGER', 'inventory:location:sync'),
     ('INVENTORY_MANAGER', 'inventory:lot:manage'),
@@ -1528,6 +1545,9 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'crm:tag:view'),
     ('LOCATION_MANAGER', 'crm:vehicle:view'),
     ('LOCATION_MANAGER', 'inventory:availability:read'),
+    ('LOCATION_MANAGER', 'inventory:cycle_count:complete'),
+    ('LOCATION_MANAGER', 'inventory:cycle_count:initiate'),
+    ('LOCATION_MANAGER', 'inventory:cycle_count:view'),
     ('LOCATION_MANAGER', 'inventory:pick_list:create'),
     ('LOCATION_MANAGER', 'inventory:pick_list:execute'),
     ('LOCATION_MANAGER', 'inventory:pick_list:view'),

--- a/pos-security-service/src/main/resources/db/migration/V32__grant_cycle_count_to_inventory_roles.sql
+++ b/pos-security-service/src/main/resources/db/migration/V32__grant_cycle_count_to_inventory_roles.sql
@@ -1,0 +1,34 @@
+-- #1563: inventory:cycle_count:initiate/view/complete were granted to ADMIN
+-- alone -- every inventory role (INVENTORY_LEAD, INVENTORY_MANAGER,
+-- INVENTORY_CONTROLLER) held only inventory:cycle_count_tolerance:manage,
+-- which configures tolerances but cannot touch a count. The clerk who
+-- physically counts stock could not plan, record or even read a cycle count.
+--
+-- R__seed_role_permissions.sql now grants all three permissions to
+-- INVENTORY_MANAGER, INVENTORY_CONTROLLER, INVENTORY_LEAD and
+-- LOCATION_MANAGER in the same change, so a fresh database matches. That
+-- seed is additive only (ON CONFLICT DO NOTHING, never deletes -- see its own
+-- IDEMPOTENCY note), so it cannot correct an already-populated database.
+-- This versioned migration is what reaches one, mirroring the V25/V26
+-- precedent for a deliberate, forward-only grant.
+--
+-- Purely additive: no permission is revoked from anyone, ADMIN included.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM (VALUES
+    ('INVENTORY_CONTROLLER', 'inventory:cycle_count:complete'),
+    ('INVENTORY_CONTROLLER', 'inventory:cycle_count:initiate'),
+    ('INVENTORY_CONTROLLER', 'inventory:cycle_count:view'),
+    ('INVENTORY_LEAD', 'inventory:cycle_count:complete'),
+    ('INVENTORY_LEAD', 'inventory:cycle_count:initiate'),
+    ('INVENTORY_LEAD', 'inventory:cycle_count:view'),
+    ('INVENTORY_MANAGER', 'inventory:cycle_count:complete'),
+    ('INVENTORY_MANAGER', 'inventory:cycle_count:initiate'),
+    ('INVENTORY_MANAGER', 'inventory:cycle_count:view'),
+    ('LOCATION_MANAGER', 'inventory:cycle_count:complete'),
+    ('LOCATION_MANAGER', 'inventory:cycle_count:initiate'),
+    ('LOCATION_MANAGER', 'inventory:cycle_count:view')
+) AS g(role_name, permission_name)
+JOIN roles r ON r.name = g.role_name
+JOIN permissions p ON p.name = g.permission_name
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (bug-fix filed directly against this repo, no capability workflow)
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1563
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
N/A — this PR touches only `pos-security-service`'s role-permission seed data (SQL migrations). No controller, DTO, event, or `openapi.yaml` changes.

## Contract Chain (when a Controller changed)
N/A — no controller changed.

## Scope
- What changed: `inventory:cycle_count:initiate/view/complete` were granted to `ADMIN` alone. Every inventory role (`INVENTORY_LEAD`, `INVENTORY_MANAGER`, `INVENTORY_CONTROLLER`) held only `inventory:cycle_count_tolerance:manage`, which configures tolerances but cannot touch a count. This PR grants all three permissions to `INVENTORY_MANAGER`, `INVENTORY_CONTROLLER`, `INVENTORY_LEAD` and `LOCATION_MANAGER` (per the role set agreed on the issue), in both `R__seed_role_permissions.sql` (fresh databases) and a new `V32__grant_cycle_count_to_inventory_roles.sql` (existing databases — the repeatable seed is additive-only and cannot correct one already populated, per its own IDEMPOTENCY note).
- Why: without this, the clerk who physically counts stock cannot plan a count, generate its tasks, record a count, or read a task — cycle counting was only reachable by an administrator. See #1563 for full evidence and the adjacent `inventory:adjustment:*` split that shows the intended holder set.

## Tests
- [x] Unit tests added/updated — `RolePermissionBaselineTest` continues to pass (23/23) with the new grants; no new test needed since existing tests validate the seed's structural invariants (every asserted permission/role pair resolves, no duplicate rows, etc.) generically.
- [ ] Integration tests added/updated — `RolePermissionSeedIT` (Testcontainers/Postgres) could not be run in this sandbox (no reachable Docker daemon); it exercises the same additive-INSERT pattern as the V26 precedent this migration mirrors.
- [ ] Provider behavioral contract tests added/updated — N/A, no contract change.
- How to run: `./mvnw -pl pos-security-service -Dtest=RolePermissionBaselineTest test` and `./mvnw -pl pos-security-service -Dit.test=RolePermissionSeedIT verify` (requires Docker).

## Risk & Rollback
- Risk level: Low — purely additive grants; no permission is revoked from anyone, ADMIN included.
- Rollback plan: revert this PR's commit; `V32` would need a follow-up migration to delete the granted rows on any database that already applied it (Flyway migrations aren't re-run on revert).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, no capability workflow for this fix
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, same reason
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — N/A, no contract change
- [x] Required CI checks passing (pending CI run on this PR; ran `pos-security-service` unit suite locally — 519/519 pass — and `spotless:check` clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HCmzeKtaCBQFo4DPpjrpv1)_