### PR TITLE
fix: declare array schema on list endpoints missing ArraySchema

### DIFF
--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -340,7 +340,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuditTrailResponse'
+                items:
+                  $ref: '#/components/schemas/AuditTrailResponse'
+                type: array
           description: Audit entries retrieved successfully
         '400':
           content:
@@ -404,7 +406,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuditTrailResponse'
+                items:
+                  $ref: '#/components/schemas/AuditTrailResponse'
+                type: array
           description: Audit entries retrieved successfully
         '404':
           content:
@@ -526,7 +530,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuditTrailResponse'
+                items:
+                  $ref: '#/components/schemas/AuditTrailResponse'
+                type: array
           description: Audit entries retrieved successfully
         '404':
           content:
@@ -582,7 +588,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuditTrailResponse'
+                items:
+                  $ref: '#/components/schemas/AuditTrailResponse'
+                type: array
           description: Audit entries retrieved successfully
         '404':
           content:
@@ -718,7 +726,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuditTrailResponse'
+                items:
+                  $ref: '#/components/schemas/AuditTrailResponse'
+                type: array
           description: Audit entries retrieved successfully
         '400':
           content:
@@ -863,7 +873,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuditTrailResponse'
+                items:
+                  $ref: '#/components/schemas/AuditTrailResponse'
+                type: array
           description: Audit entries retrieved successfully
         '400':
           content:
@@ -7450,7 +7462,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorBillMatchCandidateResponse'
+                items:
+                  $ref: '#/components/schemas/VendorBillMatchCandidateResponse'
+                type: array
           description: Match candidates returned
       security:
       - bearerAuth:

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/audit/controller/AuditTrailController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/audit/controller/AuditTrailController.java
@@ -10,6 +10,7 @@ import com.positivity.events.EmitEvent;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -293,7 +294,9 @@ public class AuditTrailController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = AuditTrailResponse.class))),
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = AuditTrailResponse.class)))),
                 @ApiResponse(responseCode = "404", description = "Order not found"),
                 @ApiResponse(responseCode = "500", description = "Internal server error")
             })
@@ -331,7 +334,9 @@ public class AuditTrailController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = AuditTrailResponse.class))),
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = AuditTrailResponse.class)))),
                 @ApiResponse(responseCode = "404", description = "Invoice not found"),
                 @ApiResponse(responseCode = "500", description = "Internal server error")
             })
@@ -370,7 +375,9 @@ public class AuditTrailController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = AuditTrailResponse.class))),
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = AuditTrailResponse.class)))),
                 @ApiResponse(responseCode = "400", description = "Invalid date range or exception type"),
                 @ApiResponse(responseCode = "500", description = "Internal server error")
             })
@@ -415,7 +422,9 @@ public class AuditTrailController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = AuditTrailResponse.class))),
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = AuditTrailResponse.class)))),
                 @ApiResponse(responseCode = "400", description = "Invalid date range or actor ID"),
                 @ApiResponse(responseCode = "404", description = "Actor not found"),
                 @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -460,7 +469,9 @@ public class AuditTrailController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = AuditTrailResponse.class))),
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = AuditTrailResponse.class)))),
                 @ApiResponse(responseCode = "400", description = "Invalid date range"),
                 @ApiResponse(responseCode = "500", description = "Internal server error")
             })

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/VendorBillController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/VendorBillController.java
@@ -9,6 +9,7 @@ import com.positivity.accounting.internal.service.VendorBillService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -394,7 +395,11 @@ public class VendorBillController {
     @ApiResponse(
             responseCode = "200",
             description = "Match candidates returned",
-            content = @Content(schema = @Schema(implementation = VendorBillMatchCandidateResponse.class)))
+            content =
+                    @Content(
+                            array =
+                                    @ArraySchema(
+                                            schema = @Schema(implementation = VendorBillMatchCandidateResponse.class))))
     public ResponseEntity<List<VendorBillMatchCandidateResponse>> listMatchCandidates(
             @Parameter(description = "Invoice event identifier", example = "550e8400-e29b-41d4-a716-446655440020")
                     @NonNull

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -1224,7 +1224,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ItemCostAuditDto'
+                items:
+                  $ref: '#/components/schemas/ItemCostAuditDto'
+                type: array
           description: Found
       security:
       - bearerAuth:
@@ -1648,7 +1650,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PriceBookRuleDto'
+                items:
+                  $ref: '#/components/schemas/PriceBookRuleDto'
+                type: array
           description: Rule list returned
       security:
       - bearerAuth:
@@ -3218,7 +3222,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductMsrpDto'
+                items:
+                  $ref: '#/components/schemas/ProductMsrpDto'
+                type: array
           description: MSRP records returned
       security:
       - bearerAuth:
@@ -3573,7 +3579,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductDto'
+                items:
+                  $ref: '#/components/schemas/ProductDto'
+                type: array
           description: Substitute parts returned
         '404':
           content:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ItemCostController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ItemCostController.java
@@ -8,6 +8,7 @@ import com.positivity.catalog.internal.service.ItemCostService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -124,7 +125,9 @@ public class ItemCostController {
             responseCode = "200",
             description = "Found",
             content =
-                    @Content(mediaType = "application/json", schema = @Schema(implementation = ItemCostAuditDto.class)))
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ItemCostAuditDto.class))))
     public ResponseEntity<List<ItemCostAuditDto>> getAuditHistory(
             @Parameter(required = true) @PathVariable UUID itemId) {
         return ResponseEntity.ok(itemCostService.getAuditHistory(itemId));

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/PriceBookController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/PriceBookController.java
@@ -11,6 +11,7 @@ import com.positivity.catalog.internal.service.PriceBookService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -307,7 +308,9 @@ public class PriceBookController {
             responseCode = "200",
             description = "Rule list returned",
             content =
-                    @Content(mediaType = "application/json", schema = @Schema(implementation = PriceBookRuleDto.class)))
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = PriceBookRuleDto.class))))
     public ResponseEntity<List<PriceBookRuleDto>> listRules(
             @Parameter(required = true) @PathVariable UUID priceBookId) {
         return ResponseEntity.ok(priceBookService.listRules(priceBookId));

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -1104,7 +1104,10 @@ public class ProductController {
     @ApiResponse(
             responseCode = "200",
             description = "Substitute parts returned",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductDto.class)))
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ProductDto.class))))
     @ApiResponse(responseCode = "404", description = "Product not found")
     public ResponseEntity<List<ProductDto>> getPartSubstitutes(
             @Parameter(description = "ID of the product", required = true) @PathVariable UUID productId) {

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductMsrpController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductMsrpController.java
@@ -9,6 +9,7 @@ import com.positivity.catalog.internal.service.ProductMsrpService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -195,7 +196,10 @@ public class ProductMsrpController {
     @ApiResponse(
             responseCode = "200",
             description = "MSRP records returned",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductMsrpDto.class)))
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ProductMsrpDto.class))))
     public ResponseEntity<List<ProductMsrpDto>> listMsrp(@Parameter(required = true) @PathVariable UUID productId) {
         return ResponseEntity.ok(productMsrpService.getAllMsrp(productId));
     }

--- a/pos-event-receiver/openapi.yaml
+++ b/pos-event-receiver/openapi.yaml
@@ -36,7 +36,9 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/EventTypeResponse'
+                items:
+                  $ref: '#/components/schemas/EventTypeResponse'
+                type: array
           description: List of event types returned successfully
       summary: List all registered event types
       tags:
@@ -111,7 +113,9 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/EventTypeResponse'
+                items:
+                  $ref: '#/components/schemas/EventTypeResponse'
+                type: array
           description: List of active event types returned successfully
       summary: List only active event types
       tags:
@@ -480,7 +484,9 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/EventSummaryResponse'
+                items:
+                  $ref: '#/components/schemas/EventSummaryResponse'
+                type: array
           description: Summary returned successfully
       summary: Get event summary for the last day
       tags:
@@ -506,7 +512,9 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/EventSummaryResponse'
+                items:
+                  $ref: '#/components/schemas/EventSummaryResponse'
+                type: array
           description: Summary returned successfully
       summary: Get event summary for the last hour
       tags:
@@ -532,7 +540,9 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/EventSummaryResponse'
+                items:
+                  $ref: '#/components/schemas/EventSummaryResponse'
+                type: array
           description: Summary returned successfully
       summary: Get event summary for the last week
       tags:

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventSummaryController.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventSummaryController.java
@@ -4,6 +4,7 @@ import com.positivity.events.EmitEvent;
 import com.positivity.poseventreceiver.internal.dto.EventSummaryResponse;
 import com.positivity.poseventreceiver.internal.service.EventSummaryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -59,7 +60,7 @@ public class EventSummaryController {
     @ApiResponse(
             responseCode = "200",
             description = "Summary returned successfully",
-            content = @Content(schema = @Schema(implementation = EventSummaryResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventSummaryResponse.class))))
     public ResponseEntity<List<EventSummaryResponse>> getLastHourSummary() {
         log.info("Fetching event summary for the last hour");
         return ResponseEntity.ok(eventSummaryService.getLastHourSummary());
@@ -88,7 +89,7 @@ public class EventSummaryController {
     @ApiResponse(
             responseCode = "200",
             description = "Summary returned successfully",
-            content = @Content(schema = @Schema(implementation = EventSummaryResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventSummaryResponse.class))))
     public ResponseEntity<List<EventSummaryResponse>> getLastDaySummary() {
         log.info("Fetching event summary for the last day");
         return ResponseEntity.ok(eventSummaryService.getLastDaySummary());
@@ -117,7 +118,7 @@ public class EventSummaryController {
     @ApiResponse(
             responseCode = "200",
             description = "Summary returned successfully",
-            content = @Content(schema = @Schema(implementation = EventSummaryResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventSummaryResponse.class))))
     public ResponseEntity<List<EventSummaryResponse>> getLastWeekSummary() {
         log.info("Fetching event summary for the last week");
         return ResponseEntity.ok(eventSummaryService.getLastWeekSummary());

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventTypeController.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventTypeController.java
@@ -6,6 +6,7 @@ import com.positivity.poseventreceiver.internal.dto.EventTypeResponse;
 import com.positivity.poseventreceiver.internal.service.EventTypeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -62,7 +63,7 @@ public class EventTypeController {
     @ApiResponse(
             responseCode = "200",
             description = "List of event types returned successfully",
-            content = @Content(schema = @Schema(implementation = EventTypeResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventTypeResponse.class))))
     public ResponseEntity<List<EventTypeResponse>> getAllEventTypes() {
         log.info("Fetching all event types");
         return ResponseEntity.ok(eventTypeService.getAllEventTypes());
@@ -88,7 +89,7 @@ public class EventTypeController {
     @ApiResponse(
             responseCode = "200",
             description = "List of active event types returned successfully",
-            content = @Content(schema = @Schema(implementation = EventTypeResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventTypeResponse.class))))
     public ResponseEntity<List<EventTypeResponse>> getActiveEventTypes() {
         log.info("Fetching active event types");
         return ResponseEntity.ok(eventTypeService.getActiveEventTypes());

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -1076,7 +1076,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CycleCountTaskResponse'
+                items:
+                  $ref: '#/components/schemas/CycleCountTaskResponse'
+                type: array
           description: Tasks retrieved successfully
       security:
       - bearerAuth:
@@ -1291,7 +1293,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CountEntryResponse'
+                items:
+                  $ref: '#/components/schemas/CountEntryResponse'
+                type: array
           description: History retrieved successfully
       security:
       - bearerAuth:

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountController.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.dto.cyclecount.SubmitRecountRequest;
 import com.positivity.inventory.internal.security.InventoryPermissionRegistry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -240,7 +241,7 @@ public class CycleCountController {
             content =
                     @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = CountEntryResponse.class)))
+                            array = @ArraySchema(schema = @Schema(implementation = CountEntryResponse.class))))
     public ResponseEntity<List<CountEntryResponse>> getCountHistory(
             @Parameter(description = "Task ID") @PathVariable UUID taskId) {
         List<CountEntryResponse> history = cycleCountService.getCountHistory(taskId);
@@ -287,9 +288,7 @@ public class CycleCountController {
             content =
                     @Content(
                             mediaType = "application/json",
-                            array =
-                                    @io.swagger.v3.oas.annotations.media.ArraySchema(
-                                            schema = @Schema(implementation = InterferingMovementResponse.class))))
+                            array = @ArraySchema(schema = @Schema(implementation = InterferingMovementResponse.class))))
     @ApiResponse(
             responseCode = "404",
             description = "Task not found",
@@ -332,7 +331,7 @@ public class CycleCountController {
             content =
                     @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = CycleCountTaskResponse.class)))
+                            array = @ArraySchema(schema = @Schema(implementation = CycleCountTaskResponse.class))))
     public ResponseEntity<List<CycleCountTaskResponse>> getAuditorTasks(
             @Parameter(description = "Auditor ID") @PathVariable String auditorId) {
         List<CycleCountTaskResponse> tasks = cycleCountService.getTasksByAuditor(auditorId);

--- a/pos-people-contact/openapi.yaml
+++ b/pos-people-contact/openapi.yaml
@@ -475,7 +475,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserPersonLinkResponse'
+                items:
+                  $ref: '#/components/schemas/UserPersonLinkResponse'
+                type: array
           description: Links found
         '404':
           content:

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
@@ -9,6 +9,7 @@ import com.positivity.peoplecontact.internal.security.PeopleContactPermissions;
 import com.positivity.peoplecontact.internal.service.UserPersonLinkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -238,7 +239,7 @@ public class UserPersonLinkController {
     @ApiResponse(
             responseCode = "200",
             description = "Links found",
-            content = @Content(schema = @Schema(implementation = UserPersonLinkResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = UserPersonLinkResponse.class))))
     @ApiResponse(responseCode = "404", description = "Link or person not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -645,7 +645,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkexecTimerEntryResponse'
+                items:
+                  $ref: '#/components/schemas/WorkexecTimerEntryResponse'
+                type: array
           description: Active timers returned successfully
         '400':
           content:
@@ -4194,7 +4196,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkorderPartAdjustmentEventResponse'
+                items:
+                  $ref: '#/components/schemas/WorkorderPartAdjustmentEventResponse'
+                type: array
           description: Adjustment history retrieved successfully (newest first)
         '404':
           content:
@@ -4698,7 +4702,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkorderPartUsageEventResponse'
+                items:
+                  $ref: '#/components/schemas/WorkorderPartUsageEventResponse'
+                type: array
           description: Usage history retrieved successfully
         '404':
           content:

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingController.java
@@ -12,6 +12,7 @@ import com.positivity.workorder.internal.security.WorkorderPermissions;
 import com.positivity.workorder.internal.service.WorkexecTimeTrackingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -221,7 +222,8 @@ public class WorkexecTimeTrackingController {
     @ApiResponse(
             responseCode = "200",
             description = "Active timers returned successfully",
-            content = @Content(schema = @Schema(implementation = WorkexecTimerEntryResponse.class)))
+            content =
+                    @Content(array = @ArraySchema(schema = @Schema(implementation = WorkexecTimerEntryResponse.class))))
     @ApiResponse(responseCode = "400", description = "Missing or invalid authenticated user id")
     public ResponseEntity<Object> getActiveTimerEntries() {
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPartAdjustmentController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPartAdjustmentController.java
@@ -7,6 +7,7 @@ import com.positivity.workorder.internal.service.WorkorderPartAdjustmentService;
 import com.positivity.workorder.internal.service.WorkorderSubstitutionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -273,7 +274,14 @@ public class WorkorderPartAdjustmentController {
     @ApiResponse(
             responseCode = "200",
             description = "Adjustment history retrieved successfully (newest first)",
-            content = @Content(schema = @Schema(implementation = WorkorderPartAdjustmentEventResponse.class)))
+            content =
+                    @Content(
+                            array =
+                                    @ArraySchema(
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    WorkorderPartAdjustmentEventResponse.class))))
     @ApiResponse(responseCode = "404", description = "Workorder or part not found")
     public ResponseEntity<List<WorkorderPartAdjustmentEventResponse>> getAdjustmentHistory(
             @PathVariable @NonNull UUID workorderId,

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPartsUsageController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPartsUsageController.java
@@ -6,6 +6,7 @@ import com.positivity.workorder.internal.security.WorkorderPermissions;
 import com.positivity.workorder.internal.service.WorkorderPartUsageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -259,7 +260,11 @@ public class WorkorderPartsUsageController {
     @ApiResponse(
             responseCode = "200",
             description = "Usage history retrieved successfully",
-            content = @Content(schema = @Schema(implementation = WorkorderPartUsageEventResponse.class)))
+            content =
+                    @Content(
+                            array =
+                                    @ArraySchema(
+                                            schema = @Schema(implementation = WorkorderPartUsageEventResponse.class))))
     @ApiResponse(responseCode = "404", description = "Workorder or part not found")
     public ResponseEntity<List<WorkorderPartUsageEventResponse>> getUsageHistory(
             @PathVariable @NonNull UUID workorderId,


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — this is a direct bug-fix issue, not a capability-tracked story
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1565
- Domain: `domain:workorder`, `domain:inventory`, `domain:catalog`, `domain:people-contact`, `domain:event-receiver`, `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): not updated — this PR corrects an existing OpenAPI annotation to match already-documented/actual list behavior; no business-rules semantics changed. BACKEND_CONTRACT_GUIDE.md
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated per module (via `-Popenapi clean verify`)
- [ ] `pos-api-gateway/docs/openapi-aggregate.yaml` regenerated — not touched; out of scope for this fix, should be regenerated in a follow-up if it aggregates these specs
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — out of scope, lives in a separate repo not attached to this session

## Scope
- What changed: 21 endpoints across 6 services (`pos-workorder`, `pos-inventory`, `pos-catalog`, `pos-people-contact`, `pos-event-receiver`, `pos-accounting`) return `List<T>`/`ResponseEntity<List<T>>` but declared `@Schema(implementation = T.class)` without `array = true`/`@ArraySchema`. The generated OpenAPI spec therefore described a single object instead of an array, so generated SDK clients deserialize the JSON array through that model's `FromJSON` and silently destroy the payload (every field reads back as `undefined`/`{}`).
- Why: Issue #1565 reported this for 3 endpoints (`getActiveTimers`, `listCycleCountHistory`, `listCycleCountAuditorTasks`) with a concrete repro showing `getActiveTimers()` returning `{}` instead of the real array. Per the issue's request for "a sweep for the same pattern across the other services," I grepped every `*Controller.java` for the same `@Schema(implementation = ...)`-without-array pattern, matched each hit to the method's actual return type, and fixed every case where a `List`/`Collection`-returning endpoint was mis-annotated as a single object. Endpoints that genuinely return a single object were left untouched — several files have both patterns mixed together.

## Tests
- [x] Existing unit/architecture tests pass unchanged (no test updates were needed; this is a doc/schema-only annotation fix, not a behavior change)
- [ ] Integration tests added/updated — N/A, response bodies are unchanged; only the OpenAPI schema metadata was wrong
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run: `./mvnw -pl pos-workorder,pos-inventory,pos-catalog,pos-people-contact,pos-event-receiver,pos-accounting -am -DskipTests=false test`

## Risk & Rollback
- Risk level: Low — annotation-only change plus regenerated `openapi.yaml` files; no controller logic, request/response bodies, or database access changed. Confirmed via `spotless:apply`, module compiles, and full test suites (966 tests in pos-workorder, 188 in pos-event-receiver, etc.) all green.
- Rollback plan: revert this commit; no schema/data migration involved.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/issue-1565-fqpze6` (assigned by the issue-fix workflow); not part of the cap-tracked branch scheme
- [ ] PR title starts with `[CAP:<cap-id>]` — not applicable, no capability id for this fix
- [x] Links to parent + child issues are present (child issue linked above)
- [ ] Contract guide updated (when contract semantics changed) — no semantics changed, see note above
- [ ] Required CI checks passing — pending CI run on this PR

Fixes #1565.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cn9cScEnJgA1mgQzLhBJGj)_