### PR TITLE
Write a time entry when a work session is submitted

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/entity/TimeEntry.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/TimeEntry.java
@@ -55,6 +55,13 @@ public class TimeEntry {
     @Column(name = "timesheet_id")
     private String timesheetId;
 
+    /**
+     * The work session whose submission produced this entry (#1564), or null for entries
+     * from another source. Unique, so a replayed submit cannot record the same session twice.
+     */
+    @Column(name = "work_session_id", columnDefinition = "UUID", unique = true)
+    private UUID workSessionId;
+
     @Column(name = "location_id")
     private UUID locationId;
 
@@ -63,6 +70,13 @@ public class TimeEntry {
 
     @Column(name = "attendance_end_at")
     private Instant attendanceEndAt;
+
+    /**
+     * Break time taken inside the attendance window. The window is gross wall-clock time, so
+     * consumers reporting worked time (the payroll export) subtract this to get net minutes.
+     */
+    @Column(name = "break_minutes")
+    private Integer breakMinutes;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PeopleReportsServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PeopleReportsServiceImpl.java
@@ -122,9 +122,12 @@ public class PeopleReportsServiceImpl implements PeopleReportsService {
                         && entry.getAttendanceEndAt() != null
                         && !entry.getAttendanceEndAt().isBefore(entry.getAttendanceStartAt()))
                 .map(entry -> {
-                    BigDecimal hoursWorked = BigDecimal.valueOf(
-                                    Duration.between(entry.getAttendanceStartAt(), entry.getAttendanceEndAt())
-                                            .toMinutes())
+                    // The attendance window is gross wall-clock time, so breaks taken inside it
+                    // are deducted here to export worked hours rather than time on site (#1564).
+                    long grossMinutes = Duration.between(entry.getAttendanceStartAt(), entry.getAttendanceEndAt())
+                            .toMinutes();
+                    long breakMinutes = entry.getBreakMinutes() == null ? 0L : entry.getBreakMinutes();
+                    BigDecimal hoursWorked = BigDecimal.valueOf(Math.max(0L, grossMinutes - breakMinutes))
                             .divide(BigDecimal.valueOf(60), 2, RoundingMode.HALF_UP);
 
                     String employeeId = getPersonIdString(entry);

--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
@@ -3,16 +3,23 @@ package com.positivity.people.internal.service;
 import com.positivity.people.internal.dto.BreakDto;
 import com.positivity.people.internal.dto.WorkSessionDto;
 import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
+import com.positivity.people.internal.entity.EmployeeLocationAssignment;
+import com.positivity.people.internal.entity.TimeEntry;
 import com.positivity.people.internal.entity.WorkSession;
 import com.positivity.people.internal.entity.WorkSessionBreak;
+import com.positivity.people.internal.enums.TimeEntryStatus;
 import com.positivity.people.internal.exception.PersonNotFoundException;
 import com.positivity.people.internal.exception.WorkSessionNotFoundException;
+import com.positivity.people.internal.repository.EmployeeLocationAssignmentRepository;
 import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.people.internal.repository.TimeEntryRepository;
 import com.positivity.people.internal.repository.WorkSessionBreakRepository;
 import com.positivity.people.internal.repository.WorkSessionRepository;
 import com.positivity.security.common.SecurityContextHelper;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -41,10 +48,16 @@ public class WorkSessionServiceImpl implements WorkSessionService {
 
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
 
+    private final TimeEntryRepository timeEntryRepository;
+
+    private final EmployeeLocationAssignmentRepository locationAssignmentRepository;
+
     public WorkSessionServiceImpl(
             WorkSessionRepository workSessionRepository,
             WorkSessionBreakRepository workSessionBreakRepository,
             ExtPersonReplicaRepository extPersonReplicaRepository,
+            TimeEntryRepository timeEntryRepository,
+            EmployeeLocationAssignmentRepository locationAssignmentRepository,
             Clock clock) {
         this.clock = clock;
         this.workSessionRepository =
@@ -53,6 +66,9 @@ public class WorkSessionServiceImpl implements WorkSessionService {
                 Objects.requireNonNull(workSessionBreakRepository, "workSessionBreakRepository must not be null");
         this.extPersonReplicaRepository =
                 Objects.requireNonNull(extPersonReplicaRepository, "extPersonReplicaRepository must not be null");
+        this.timeEntryRepository = Objects.requireNonNull(timeEntryRepository, "timeEntryRepository must not be null");
+        this.locationAssignmentRepository =
+                Objects.requireNonNull(locationAssignmentRepository, "locationAssignmentRepository must not be null");
     }
 
     @Override
@@ -181,7 +197,45 @@ public class WorkSessionServiceImpl implements WorkSessionService {
         session.setSubmittedAt(request.getSubmittedAt());
         session.setActor(resolvedActor);
 
-        return toWorkSessionDto(workSessionRepository.save(session));
+        WorkSession submitted = workSessionRepository.save(session);
+        recordTimeEntry(submitted, request);
+        return toWorkSessionDto(submitted);
+    }
+
+    /**
+     * A submitted session is the employee's time entry (#1564). This is the only producer of
+     * {@code time_entry} rows, which the approval, adjustment, exception, and payroll-export
+     * surfaces all read; before it existed those surfaces had nothing to act on.
+     *
+     * <p>The attendance window is the server-stamped session window, so it is gross time.
+     * Breaks are carried alongside rather than deducted here, leaving consumers free to report
+     * either gross attendance or net worked time.
+     */
+    private void recordTimeEntry(WorkSession session, WorkSessionSubmitRequest request) {
+        TimeEntry entry = new TimeEntry();
+        entry.setWorkSessionId(session.getSessionId());
+        entry.setPersonId(session.getPersonId());
+        entry.setLocationId(resolveLocationId(session));
+        entry.setAttendanceStartAt(session.getStartedAt());
+        entry.setAttendanceEndAt(session.getEndedAt());
+        entry.setBreakMinutes(request.getBreakMinutes());
+        entry.setStatus(TimeEntryStatus.SUBMITTED);
+        timeEntryRepository.save(entry);
+    }
+
+    /**
+     * Attendance reporting and the payroll export both filter on location, so an entry without
+     * one is invisible to them. Resolve the assignment in effect on the day the session ended;
+     * the query orders primary assignments first, so the primary one wins when a person holds
+     * several. A person with no active assignment still gets an entry that can be approved.
+     */
+    private UUID resolveLocationId(WorkSession session) {
+        Instant endedAt = session.getEndedAt() == null ? Instant.now(clock) : session.getEndedAt();
+        LocalDate onDate = endedAt.atZone(ZoneOffset.UTC).toLocalDate();
+        return locationAssignmentRepository.findActiveByPersonIdAndDate(session.getPersonId(), onDate).stream()
+                .findFirst()
+                .map(EmployeeLocationAssignment::getLocationId)
+                .orElse(null);
     }
 
     private String resolveActorFromSecurityContext() {

--- a/pos-people/src/main/resources/db/migration/V10__link_time_entry_to_work_session.sql
+++ b/pos-people/src/main/resources/db/migration/V10__link_time_entry_to_work_session.sql
@@ -1,0 +1,20 @@
+-- Give time_entry a writer (#1564).
+--
+-- An employee's time entry is produced by the clock surface: start, break, finish, submit.
+-- Until now nothing inserted into time_entry at all, so the approval, adjustment, exception,
+-- and payroll-export surfaces that read it could only ever answer "not found" or return an
+-- empty result. Submitting a work session now writes the entry.
+--
+-- work_session_id carries provenance back to the session that produced the entry. It is
+-- unique so a replayed submit cannot create a second entry for the same session; NULLs are
+-- not compared in Postgres, so entries from other sources remain possible.
+--
+-- break_minutes is stored because the attendance window (attendance_start_at ..
+-- attendance_end_at) is gross wall-clock time and includes breaks. The payroll export
+-- subtracts it to report net worked hours.
+
+ALTER TABLE time_entry ADD COLUMN work_session_id uuid;
+ALTER TABLE time_entry ADD COLUMN break_minutes integer;
+
+ALTER TABLE time_entry
+    ADD CONSTRAINT uq_time_entry_work_session UNIQUE (work_session_id);

--- a/pos-people/src/test/java/com/positivity/people/internal/service/PeopleReportsServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/PeopleReportsServiceTest.java
@@ -117,6 +117,89 @@ class PeopleReportsServiceTest {
     }
 
     @Test
+    void getApprovedTimeForExport_deductsBreakMinutesFromTheAttendanceWindow() {
+        UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000009");
+        UUID approvedId = UUID.fromString("00000000-0000-0000-0000-000000000031");
+
+        // 8.5h on site with a 45 minute break is 7.75h worked, not 8.5h.
+        TimeEntry approved = new TimeEntry();
+        approved.setTimeEntryId(approvedId);
+        approved.setPersonId(personUuid);
+        approved.setLocationId(locationId);
+        approved.setStatus(TimeEntryStatus.APPROVED);
+        approved.setAttendanceStartAt(Instant.parse("2026-02-10T08:00:00Z"));
+        approved.setAttendanceEndAt(Instant.parse("2026-02-10T16:30:00Z"));
+        approved.setBreakMinutes(45);
+        approved.setApprovedAt(Instant.parse("2026-02-11T01:15:00Z"));
+        approved.setApprovedBy("manager-1");
+
+        when(locationReferenceService.isLocationActive(locationId)).thenReturn(true);
+        when(locationReferenceService.getLocationName(locationId)).thenReturn("North Shop");
+        when(extPersonReplicaRepository.findAllById(any()))
+                .thenReturn(List.of(ExtPersonReplica.builder()
+                        .personId(personUuid)
+                        .firstName("Jane")
+                        .lastName("Doe")
+                        .aggregateVersion(0)
+                        .updatedAt(Instant.now())
+                        .build()));
+        when(timeEntryRepository.findApprovedForExport(
+                        eq(TimeEntryStatus.APPROVED), any(), any(), eq(List.of(locationId))))
+                .thenReturn(List.of(approved));
+
+        List<ApprovedTimeExportResponse> result = service.getApprovedTimeForExport(
+                LocalDate.parse("2026-02-10"),
+                LocalDate.parse("2026-02-10"),
+                List.of(locationId),
+                "test-actor",
+                "corr-1");
+
+        assertEquals("7.75", result.get(0).hoursWorked().toPlainString());
+    }
+
+    @Test
+    void getApprovedTimeForExport_whenBreaksExceedTheWindow_reportsZeroRatherThanNegativeHours() {
+        UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000009");
+        UUID approvedId = UUID.fromString("00000000-0000-0000-0000-000000000041");
+
+        TimeEntry approved = new TimeEntry();
+        approved.setTimeEntryId(approvedId);
+        approved.setPersonId(personUuid);
+        approved.setLocationId(locationId);
+        approved.setStatus(TimeEntryStatus.APPROVED);
+        approved.setAttendanceStartAt(Instant.parse("2026-02-10T08:00:00Z"));
+        approved.setAttendanceEndAt(Instant.parse("2026-02-10T08:30:00Z"));
+        approved.setBreakMinutes(90);
+        approved.setApprovedAt(Instant.parse("2026-02-11T01:15:00Z"));
+        approved.setApprovedBy("manager-1");
+
+        when(locationReferenceService.isLocationActive(locationId)).thenReturn(true);
+        when(locationReferenceService.getLocationName(locationId)).thenReturn("North Shop");
+        when(extPersonReplicaRepository.findAllById(any()))
+                .thenReturn(List.of(ExtPersonReplica.builder()
+                        .personId(personUuid)
+                        .firstName("Jane")
+                        .lastName("Doe")
+                        .aggregateVersion(0)
+                        .updatedAt(Instant.now())
+                        .build()));
+        when(timeEntryRepository.findApprovedForExport(
+                        eq(TimeEntryStatus.APPROVED), any(), any(), eq(List.of(locationId))))
+                .thenReturn(List.of(approved));
+
+        List<ApprovedTimeExportResponse> result = service.getApprovedTimeForExport(
+                LocalDate.parse("2026-02-10"),
+                LocalDate.parse("2026-02-10"),
+                List.of(locationId),
+                "test-actor",
+                "corr-1");
+
+        assertEquals("0.00", result.get(0).hoursWorked().toPlainString());
+    }
+
+    @Test
     void getApprovedTimeForExport_emptyResultReturns200EquivalentList() {
         UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         when(locationReferenceService.isLocationActive(locationId)).thenReturn(true);

--- a/pos-people/src/test/java/com/positivity/people/internal/service/WorkSessionServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/WorkSessionServiceTest.java
@@ -9,20 +9,28 @@ import static org.mockito.Mockito.when;
 import com.positivity.people.internal.dto.BreakDto;
 import com.positivity.people.internal.dto.WorkSessionDto;
 import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
+import com.positivity.people.internal.entity.EmployeeLocationAssignment;
+import com.positivity.people.internal.entity.TimeEntry;
 import com.positivity.people.internal.entity.WorkSession;
 import com.positivity.people.internal.entity.WorkSessionBreak;
+import com.positivity.people.internal.enums.TimeEntryStatus;
 import com.positivity.people.internal.exception.WorkSessionNotFoundException;
+import com.positivity.people.internal.repository.EmployeeLocationAssignmentRepository;
 import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.people.internal.repository.TimeEntryRepository;
 import com.positivity.people.internal.repository.WorkSessionBreakRepository;
 import com.positivity.people.internal.repository.WorkSessionRepository;
 import com.positivity.security.common.SecurityContextHelper;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -40,6 +48,12 @@ class WorkSessionServiceTest {
     @Mock
     private ExtPersonReplicaRepository extPersonReplicaRepository;
 
+    @Mock
+    private TimeEntryRepository timeEntryRepository;
+
+    @Mock
+    private EmployeeLocationAssignmentRepository locationAssignmentRepository;
+
     private WorkSessionService service;
 
     private UUID personId;
@@ -47,11 +61,25 @@ class WorkSessionServiceTest {
     @BeforeEach
     void setUp() {
         service = new WorkSessionServiceImpl(
-                workSessionRepository, workSessionBreakRepository, extPersonReplicaRepository, Clock.systemUTC());
+                workSessionRepository,
+                workSessionBreakRepository,
+                extPersonReplicaRepository,
+                timeEntryRepository,
+                locationAssignmentRepository,
+                Clock.systemUTC());
         personId = UUID.fromString("10000000-0000-0000-0000-000000000001");
         org.mockito.Mockito.lenient()
                 .when(extPersonReplicaRepository.existsById(personId))
                 .thenReturn(true);
+    }
+
+    private static EmployeeLocationAssignment assignmentAt(UUID locationId) {
+        // Built field-by-field rather than via the builder: the builder requires the employee
+        // association, which this service never reads.
+        EmployeeLocationAssignment assignment = new EmployeeLocationAssignment();
+        assignment.setLocationId(locationId);
+        assignment.setPrimary(true);
+        return assignment;
     }
 
     @Test
@@ -321,6 +349,82 @@ class WorkSessionServiceTest {
             assertThat(result.getSubmittedAt()).isEqualTo(Instant.parse("2026-01-01T16:05:00Z"));
             verify(workSessionRepository).save(any(WorkSession.class));
         }
+    }
+
+    @Test
+    void submitSession_whenSessionEnded_writesTimeEntryAtTheAssignedLocation() {
+        UUID sessionId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        UUID locationId = UUID.fromString("66666666-6666-6666-6666-666666666666");
+        WorkSession ended = new WorkSession();
+        ended.setSessionId(sessionId);
+        ended.setPersonId(personId);
+        ended.setStatus("ENDED");
+        ended.setStartedAt(Instant.parse("2026-01-01T08:00:00Z"));
+        ended.setEndedAt(Instant.parse("2026-01-01T16:00:00Z"));
+
+        WorkSessionSubmitRequest request = new WorkSessionSubmitRequest();
+        request.setBillableMinutes(450);
+        request.setBreakMinutes(30);
+        request.setSubmittedAt(Instant.parse("2026-01-01T16:05:00Z"));
+
+        when(workSessionRepository.findById(sessionId)).thenReturn(Optional.of(ended));
+        when(workSessionRepository.save(any(WorkSession.class))).thenAnswer(i -> i.getArgument(0));
+        when(locationAssignmentRepository.findActiveByPersonIdAndDate(personId, LocalDate.of(2026, 1, 1)))
+                .thenReturn(List.of(assignmentAt(locationId)));
+
+        try (MockedStatic<SecurityContextHelper> helperMock = Mockito.mockStatic(SecurityContextHelper.class)) {
+            helperMock
+                    .when(() -> SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .thenReturn("worker.user");
+
+            service.submitSession(sessionId, request);
+        }
+
+        ArgumentCaptor<TimeEntry> captor = ArgumentCaptor.forClass(TimeEntry.class);
+        verify(timeEntryRepository).save(captor.capture());
+        TimeEntry entry = captor.getValue();
+
+        assertThat(entry.getWorkSessionId()).isEqualTo(sessionId);
+        assertThat(entry.getPersonId()).isEqualTo(personId);
+        assertThat(entry.getLocationId()).isEqualTo(locationId);
+        assertThat(entry.getAttendanceStartAt()).isEqualTo(Instant.parse("2026-01-01T08:00:00Z"));
+        assertThat(entry.getAttendanceEndAt()).isEqualTo(Instant.parse("2026-01-01T16:00:00Z"));
+        assertThat(entry.getBreakMinutes()).isEqualTo(30);
+        assertThat(entry.getStatus()).isEqualTo(TimeEntryStatus.SUBMITTED);
+    }
+
+    @Test
+    void submitSession_whenPersonHasNoActiveAssignment_stillWritesTimeEntryWithoutLocation() {
+        UUID sessionId = UUID.fromString("77777777-7777-7777-7777-777777777777");
+        WorkSession ended = new WorkSession();
+        ended.setSessionId(sessionId);
+        ended.setPersonId(personId);
+        ended.setStatus("ENDED");
+        ended.setStartedAt(Instant.parse("2026-01-01T08:00:00Z"));
+        ended.setEndedAt(Instant.parse("2026-01-01T16:00:00Z"));
+
+        WorkSessionSubmitRequest request = new WorkSessionSubmitRequest();
+        request.setBillableMinutes(480);
+        request.setBreakMinutes(0);
+        request.setSubmittedAt(Instant.parse("2026-01-01T16:05:00Z"));
+
+        when(workSessionRepository.findById(sessionId)).thenReturn(Optional.of(ended));
+        when(workSessionRepository.save(any(WorkSession.class))).thenAnswer(i -> i.getArgument(0));
+        when(locationAssignmentRepository.findActiveByPersonIdAndDate(personId, LocalDate.of(2026, 1, 1)))
+                .thenReturn(List.of());
+
+        try (MockedStatic<SecurityContextHelper> helperMock = Mockito.mockStatic(SecurityContextHelper.class)) {
+            helperMock
+                    .when(() -> SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .thenReturn("worker.user");
+
+            service.submitSession(sessionId, request);
+        }
+
+        ArgumentCaptor<TimeEntry> captor = ArgumentCaptor.forClass(TimeEntry.class);
+        verify(timeEntryRepository).save(captor.capture());
+        assertThat(captor.getValue().getLocationId()).isNull();
+        assertThat(captor.getValue().getStatus()).isEqualTo(TimeEntryStatus.SUBMITTED);
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (bug-fix filed directly against this repo, no capability workflow)
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1564
- Domain: `domain:people`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
No controller, DTO, event or `openapi.yaml` file changed, so no contract guide entry was updated. Flagging one behavioral change for the reviewer's judgement rather than claiming N/A outright: `ApprovedTimeExportResponse.hoursWorked` keeps its shape but changes meaning — it previously reported time on site and now reports worked hours, with breaks deducted (see Scope). If that counts as a contract-semantics change in this repo's terms, the corresponding entry in `domains/people/.business-rules/BACKEND_CONTRACT_GUIDE.md` should be updated before merge; I did not have the durion repo in scope to check or edit it.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A, no endpoint shape changed
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A, same reason

## Scope

- **What changed:** submitting a work session now writes the `time_entry` row it represents, in `SUBMITTED` status.

  Nothing in `pos-people` ever inserted into `time_entry`. #1564 reports the pos-workorder and `timekeeping_entry` dead ends; this table is a third one it did not cover, and it is the one behind the `NOT_FOUND` that integration suite F sees from `POST /v1/people/timeEntries/approve`. Because it was empty, every surface reading it was unreachable in production:

  | Surface | Behaviour before |
  |---|---|
  | `TimeEntryApprovalController` batch approve/reject | only ever `NOT_FOUND` |
  | payroll export (`PeopleReportsServiceImpl:105`) | always empty |
  | attendance-vs-job-time report (`PeopleReportsServiceImpl:184`) | attendance half always empty |
  | `TimeEntryAdjustmentServiceImpl:54` (+ real FK) | no rows to attach to |
  | `TimeEntryExceptionController` | same |

  Their unit tests pass because they construct entries directly.

  Four files carry the change:
  - `V10__link_time_entry_to_work_session.sql` — adds `work_session_id` (unique) and `break_minutes`
  - `TimeEntry.java` — the two new fields
  - `WorkSessionServiceImpl.java` — `recordTimeEntry` + `resolveLocationId`, called from `submitSession`
  - `PeopleReportsServiceImpl.java` — payroll export deducts breaks

- **Why:** without a writer the approval endpoints cannot be exercised, so suite F can only assert authorization and the error contract on the approval half. Those assertions stay correct after this change, and a positive approval test now becomes possible.

Three decisions worth review:

1. **Location** is resolved from the employee's location assignment in effect on the day the session ended, preferring the primary one. Both the export and the attendance report filter on location, so an entry without one is invisible to them. A person with no active assignment still gets an entry that can be approved — just not one that reports.
2. **Breaks are stored, not deducted from the attendance window.** The window stays gross wall-clock time, because the two consumers want different readings: the attendance report compares time on site against time booked to jobs, while payroll wants worked hours. The export therefore subtracts breaks itself, clamped at zero. **This is a behaviour fix beyond the literal scope of "give `time_entry` a writer"** — the export computed `end - start` as hours worked, so once rows existed it would have over-reported every session that included a break. Called out explicitly in case you would rather split it.
3. **Idempotency** rides on the existing `ENDED` → `SUBMITTED` precondition, which already rejects a second submit. The unique constraint on `work_session_id` is the backstop.

Deliberately not done: the attendance discrepancy report still compares gross attendance against job-booked minutes, so breaks now surface as a discrepancy. That is arguably correct (time on site vs. time booked), but it is a judgement call I left rather than fold in here.

## Tests
- [x] Unit tests added/updated — four new: time-entry fields and location resolution on submit, the no-active-assignment fallback, break deduction in the export, and the negative clamp when breaks exceed the window. Full `pos-people` suite passes 361/361 with Spotless, Checkstyle and SpotBugs enabled.
- [ ] Integration tests added/updated — none added. **The migration itself is unexercised:** the Flyway-against-Postgres path is a Failsafe IT needing Testcontainers, and no Docker daemon was reachable in this sandbox. It is plain `ALTER TABLE ADD COLUMN` and `ddl-auto: validate` will match the entity, but it has not actually run.
- [ ] Provider behavioral contract tests added/updated — N/A, no contract shape change.
- How to run: `./mvnw -pl pos-people -am -DskipTests=false test`

## Risk & Rollback
- Risk level: Medium. The schema change is additive and the new write sits inside the existing `submitSession` transaction, so the clock endpoints fail no differently than before. The risk is the export's changed arithmetic: any consumer treating `hoursWorked` as time on site now reads a smaller number. Since the table has never held a row, no existing export output changes.
- Rollback plan: revert the commit. `V10` needs a follow-up migration to drop the two columns on any database that already applied it, since Flyway migrations are not re-run on revert.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, no capability workflow for this fix
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, same reason
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — not updated; see Contract References for the one call worth a reviewer's decision
- [x] Required CI checks passing — pending CI on this PR; locally `pos-people` is 361/361 green with the full gated build (Spotless, Checkstyle, SpotBugs), and `spotless:apply` touched only the files in this diff

Follow-up filed while investigating: #1569, covering work session as the sum of service-item time estimates — unimplemented, and blocked on renaming the two `work_session` tables that currently hold time-entry clock data.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DtLBaYrAY9HHBJ2L6sxMGA)_