### PR TITLE
fix(people): align FlywayMigrationIT seed counts with the retired staffing seed

### DIFF
--- a/pos-people/src/test/java/com/positivity/people/migration/FlywayMigrationIT.java
+++ b/pos-people/src/test/java/com/positivity/people/migration/FlywayMigrationIT.java
@@ -40,9 +40,11 @@ class FlywayMigrationIT {
         JdbcTemplate jdbc = new JdbcTemplate(dataSource);
 
         // HR-only schema (ADR-0044 Phase 3.2, #875): identity tables dropped, replicas + outbox
-        // created; employees survive the split.
+        // created; the admin.alpha employment record survives the split. The bulk staffing seed
+        // was retired in #1554 — operational people now enter through the fixture API pipeline —
+        // so the Flyway-owned rows are the admin.alpha bootstrap only.
         assertThat(jdbc.queryForObject("SELECT count(*) FROM employee", Integer.class))
-                .isGreaterThanOrEqualTo(39);
+                .isGreaterThanOrEqualTo(1);
         assertThat(droppedTable(jdbc, "person")).isTrue();
         assertThat(droppedTable(jdbc, "person_contact_point")).isTrue();
         assertThat(droppedTable(jdbc, "user_person_links")).isTrue();
@@ -53,11 +55,19 @@ class FlywayMigrationIT {
         assertThat(hasColumn(jdbc, "event_outbox", "record_key")).isTrue();
         assertThat(hasColumn(jdbc, "processed_events", "owner")).isTrue();
 
-        // Dev-bootstrap replica seeds loaded (names + usernames for HR views).
+        // Dev-bootstrap replica seeds loaded (names + usernames for HR views), and the employment
+        // record joins to its replica person — the seed's cross-table keys still line up.
         assertThat(jdbc.queryForObject("SELECT count(*) FROM ext_people_contact_person", Integer.class))
-                .isGreaterThanOrEqualTo(39);
+                .isGreaterThanOrEqualTo(1);
         assertThat(jdbc.queryForObject("SELECT count(*) FROM ext_people_contact_user_link", Integer.class))
                 .isGreaterThanOrEqualTo(1);
+        assertThat(jdbc.queryForObject(
+                        "SELECT count(*) FROM employee e"
+                                + " JOIN ext_people_contact_person p ON p.person_id = e.person_id"
+                                + " JOIN ext_people_contact_user_link l ON l.person_id = e.person_id"
+                                + " WHERE l.username = 'admin.alpha'",
+                        Integer.class))
+                .isEqualTo(1);
     }
 
     private boolean hasColumn(JdbcTemplate jdbc, String table, String column) {


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — build fix on `main`, no capability
- Parent STORY (durion): n/a
- Child issue: n/a (follow-up to louisburroughs/durion-positivity-backend#1554)
- Domain: `domain:people`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — this PR changes one integration test only. No controllers, DTOs, `*Request`/`*Response` types, events, `openapi.yaml`, or validation/error models are touched, so no contract semantics change.

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- **What changed:** `pos-people/src/test/java/com/positivity/people/migration/FlywayMigrationIT.java` only.
  - Both `isGreaterThanOrEqualTo(39)` assertions (`employee`, `ext_people_contact_person`) lowered to `1`.
  - Added a join assertion tying `employee` → `ext_people_contact_person` → `ext_people_contact_user_link` on `username = 'admin.alpha'`.
  - Comments updated to say where the row counts now come from.
  - Structural assertions (dropped identity tables, replica/outbox columns) unchanged.
- **Why:** The reactor build on `main` is red — [run 33230097867](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/33230097867) — with `FlywayMigrationIT.baselineAndSeedsApply_andStructuralChangesTookEffect` expecting `1` to be `>= 39`.

  Those counts came from `R__seed_people_operational_data.sql`, which #1554 deleted along with the pos-location seed whose fixed UUIDs its staffing rows were keyed to. Operational people now enter through the fixture API pipeline instead. The only Flyway-owned rows left are the admin.alpha bootstrap in `R__seed_reference_people.sql`: one employee, one replica person, one replica user link. The assertions were stale, not the seed or the schema.

  At one row a count says very little, so the join replaces what the counts used to be worth: it still catches the failure mode this test exists to guard — a seed whose cross-table keys drift apart from the schema — which a bare `>= 1` on each table would not.

## Tests
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (`FlywayMigrationIT` — the change *is* the test)
- [ ] Provider behavioral contract tests added/updated
- **How to run:** `./mvnw -pl pos-people -am verify` (requires Docker; the test is Testcontainers-backed against `postgres:16-alpine`).
- **Verified locally:** Spotless and Checkstyle clean, `test-compile` green. The IT itself was *not* run locally — no Docker in the session container — so CI on this PR is the first real execution.

## Risk & Rollback
- Risk level: Low — test-only change; no production code, SQL, or migration is touched.
- Rollback plan: revert this commit. `main` returns to its current red state.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — build fix, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — same
- [ ] Links to parent + child issues are present — no issue filed; the CI run is linked above
- [x] Contract guide updated (when contract semantics changed) — none changed
- [ ] Required CI checks passing — pending on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S51Hx2uuPFgxJs2MLzA3Cz)_