### PR TITLE
Write new time entries as PENDING_APPROVAL, not SUBMITTED

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
@@ -210,6 +210,12 @@ public class WorkSessionServiceImpl implements WorkSessionService {
      * <p>The attendance window is the server-stamped session window, so it is gross time.
      * Breaks are carried alongside rather than deducted here, leaving consumers free to report
      * either gross attendance or net worked time.
+     *
+     * <p>The entry lands in {@code PENDING_APPROVAL}, which is the state an approver acts on:
+     * the approvals screen selects, enables its actions on, and transitions only entries in
+     * that state. {@code SUBMITTED} stays a legal status other producers may use, and
+     * {@link TimeEntryServiceImpl} still accepts it, but an entry written in it would sit
+     * unapprovable in the approval UI while the API alone would take a decision on it.
      */
     private void recordTimeEntry(WorkSession session, WorkSessionSubmitRequest request) {
         TimeEntry entry = new TimeEntry();
@@ -219,7 +225,7 @@ public class WorkSessionServiceImpl implements WorkSessionService {
         entry.setAttendanceStartAt(session.getStartedAt());
         entry.setAttendanceEndAt(session.getEndedAt());
         entry.setBreakMinutes(request.getBreakMinutes());
-        entry.setStatus(TimeEntryStatus.SUBMITTED);
+        entry.setStatus(TimeEntryStatus.PENDING_APPROVAL);
         timeEntryRepository.save(entry);
     }
 

--- a/pos-people/src/test/java/com/positivity/people/internal/service/WorkSessionServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/WorkSessionServiceTest.java
@@ -390,7 +390,9 @@ class WorkSessionServiceTest {
         assertThat(entry.getAttendanceStartAt()).isEqualTo(Instant.parse("2026-01-01T08:00:00Z"));
         assertThat(entry.getAttendanceEndAt()).isEqualTo(Instant.parse("2026-01-01T16:00:00Z"));
         assertThat(entry.getBreakMinutes()).isEqualTo(30);
-        assertThat(entry.getStatus()).isEqualTo(TimeEntryStatus.SUBMITTED);
+        // Not SUBMITTED: the approvals screen only selects and acts on PENDING_APPROVAL, so an
+        // entry written as SUBMITTED would be approvable through the API but not through the UI.
+        assertThat(entry.getStatus()).isEqualTo(TimeEntryStatus.PENDING_APPROVAL);
     }
 
     @Test
@@ -424,7 +426,7 @@ class WorkSessionServiceTest {
         ArgumentCaptor<TimeEntry> captor = ArgumentCaptor.forClass(TimeEntry.class);
         verify(timeEntryRepository).save(captor.capture());
         assertThat(captor.getValue().getLocationId()).isNull();
-        assertThat(captor.getValue().getStatus()).isEqualTo(TimeEntryStatus.SUBMITTED);
+        assertThat(captor.getValue().getStatus()).isEqualTo(TimeEntryStatus.PENDING_APPROVAL);
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: `CAP:139` — the status contract this fixes comes from `CAP_139.130`
- Parent STORY (durion): `CAP_139.130` — *[FRONTEND] [STORY] Timekeeping: Approve Submitted Time for a Day/Workorder*
- Child issue: louisburroughs/durion-positivity-backend#1564 (follow-up to #1570, which introduced the defect)
- Domain: `domain:people`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
No controller, DTO, event or `openapi.yaml` file changed — this alters only which enum value a service writes, and `PENDING_APPROVAL` is already a declared value of the `status` field in `domains/people/.business-rules/BACKEND_CONTRACT_GUIDE.md`'s referenced schema and in the `time_entry` check constraint. The change makes behaviour match the documented story rather than departing from it, so no BACKEND_CONTRACT_GUIDE.md entry needs amending.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A, no endpoint shape changed
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A, same reason

## Scope

- **What changed:** `WorkSessionServiceImpl.recordTimeEntry` now writes `TimeEntryStatus.PENDING_APPROVAL` instead of `SUBMITTED`. One line, plus the two test assertions that pinned the old value and a comment explaining why it must not drift back.

- **Why:** #1570 gave `time_entry` its first writer and chose `SUBMITTED`. `CAP_139.130` — the binding frontend story for this screen — makes `PENDING_APPROVAL` the **only** approvable state, in five separate places:

  | Story location | Rule |
  |---|---|
  | §Preconditions | "There exist time entries in `PENDING_APPROVAL` for the selected day and/or work order" |
  | §Functional Behavior | "Select rows (multi-select) limited to eligible statuses (must be `PENDING_APPROVAL`)" |
  | §Enable/disable rules | "Approve enabled only when selection contains ≥1 entry and all selected are `PENDING_APPROVAL`" (and the same for Reject) |
  | §Approve conditions | "Entry status is `PENDING_APPROVAL`" |
  | §State transitions | `PENDING_APPROVAL` → `APPROVED`, `PENDING_APPROVAL` → `REJECTED` |

  `SUBMITTED` appears nowhere in the story as an approvable state.

  `TimeEntryServiceImpl.isPendingOrSubmitted` accepts either status, which is why this was invisible: approval through the API worked, and the unit and contract tests passed. The gap only appears in a UI built to the story — every entry the clock produced would be listed as ineligible, unselectable and undecidable, while the very same entry could be approved by calling the endpoint directly. That split between what the API allows and what the UI offers is the defect.

- **Deliberately unchanged:** `SUBMITTED` remains a legal status, `isPendingOrSubmitted` still accepts it, and `TimeEntryApprovalContractIT` still builds its fixture in `SUBMITTED` to cover that tolerance. Narrowing the accepted set would be a behaviour change beyond this fix, and would break any other producer.

Found by running the durion `pr-review` runbook against #1571; the story evidence was not available to #1570 because the durion repo was out of scope at the time.

## Tests
- [x] Unit tests added/updated — the two `WorkSessionServiceTest` assertions that pinned `SUBMITTED` now pin `PENDING_APPROVAL`, with a comment recording why, so a future change back is a deliberate act rather than an accident.
- [ ] Integration tests added/updated — none needed; no schema or endpoint change. `PENDING_APPROVAL` is already permitted by the `time_entry` status check constraint in `V1__baseline_people_schema.sql`, so no migration is involved.
- [ ] Provider behavioral contract tests added/updated — N/A; `TimeEntryApprovalContractIT` is intentionally left on `SUBMITTED`, since it covers the service's tolerance of that status rather than what the clock writes.
- How to run: `./mvnw -pl pos-people -am -DskipTests=false test`

Local result, full gated build (Spotless, Checkstyle, SpotBugs enabled): **361/361** green.

## Risk & Rollback
- Risk level: Low. One enum value, on a table whose only writer is the code being changed, and both values were already accepted downstream. No schema change, no API shape change, no migration.
- One operational note: any `time_entry` row already written as `SUBMITTED` by a deployed build of #1570 keeps that status. Those rows stay approvable through the API but not through a story-conformant UI. If #1570 has reached an environment with real submissions, they need a one-off `UPDATE time_entry SET status = 'PENDING_APPROVAL' WHERE status = 'SUBMITTED'`. I have not written that migration, because whether any such rows exist is an environment fact I cannot check from here.
- Rollback plan: revert the commit. Nothing else to undo.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, no capability workflow for this fix
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, same reason
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — N/A; this moves behaviour *onto* the documented contract
- [x] Required CI checks passing — pending CI on this PR; locally 361/361 green with the full gated build

Related: #1573 covers the three remaining gaps that still block `CAP_139.130` (no list endpoint, no `workOrderId`, no `submittedAt`). This PR fixes only the status mismatch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DtLBaYrAY9HHBJ2L6sxMGA)_