### PR TITLE
Deploy pos-supplier and pos-marketing to alpha; close the Prometheus scrape gap

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-marketing","pos-mcp-server","pos-order","pos-people","pos-people-contact","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-warranty","pos-workorder"]'
+          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-marketing","pos-mcp-server","pos-order","pos-people","pos-people-contact","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-supplier","pos-tax","pos-vehicle-inventory","pos-warranty","pos-workorder"]'
           echo "all-services=${ALL_SERVICES_JSON}" >> "$GITHUB_OUTPUT"
           FORCE_FULL_REBUILD=false
 
@@ -427,11 +427,17 @@ jobs:
       - name: Deploy backend services on alpha host
         env:
           SECURITY_SEED_ADMIN_PASSWORD_HASH: ${{ secrets.SECURITY_SEED_ADMIN_PASSWORD_HASH }}
+          # pos-supplier refuses to start without its exchange-audit key (ADR-0050 §7).
+          # Optional here: deploy-backend.sh persists it on first use and afterwards accepts
+          # the copy already in the on-box env file, so an unset secret is not a failure once
+          # the key has been provisioned. It rejects a value that differs from the stored one,
+          # because silently rotating it orphans every payload sealed with the old key.
+          SUPPLIER_AUDIT_ENC_KEY: ${{ secrets.SUPPLIER_AUDIT_ENC_KEY }}
         run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "${{ vars.ALPHA_EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
-            --parameters "{\"commands\":[\"SECURITY_SEED_ADMIN_PASSWORD_HASH='${SECURITY_SEED_ADMIN_PASSWORD_HASH}' PROD_OVERRIDE_SHA256='${{ steps.sums.outputs.prod }}' BASE_COMPOSE_SHA256='${{ steps.sums.outputs.base }}' bash /opt/durion/alpha/scripts/deploy-backend.sh '${{ env.BUILD_SHA }}'\"]}" \
+            --parameters "{\"commands\":[\"SECURITY_SEED_ADMIN_PASSWORD_HASH='${SECURITY_SEED_ADMIN_PASSWORD_HASH}' SUPPLIER_AUDIT_ENC_KEY='${SUPPLIER_AUDIT_ENC_KEY}' PROD_OVERRIDE_SHA256='${{ steps.sums.outputs.prod }}' BASE_COMPOSE_SHA256='${{ steps.sums.outputs.base }}' bash /opt/durion/alpha/scripts/deploy-backend.sh '${{ env.BUILD_SHA }}'\"]}" \
             --timeout-seconds 2700 \
             --query "Command.CommandId" --output text)
           echo "SSM Command ID: $COMMAND_ID"

--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -434,6 +434,11 @@ jobs:
           # because silently rotating it orphans every payload sealed with the old key.
           SUPPLIER_AUDIT_ENC_KEY: ${{ secrets.SUPPLIER_AUDIT_ENC_KEY }}
         run: |
+          # base64 carries no whitespace, and `openssl rand -base64 32` ends in a newline that a
+          # careless `gh secret set` keeps. Left in, it is interpolated raw into the --parameters
+          # JSON below, where a literal newline inside a string is invalid and the deploy dies in
+          # the AWS CLI before deploy-backend.sh ever runs.
+          SUPPLIER_AUDIT_ENC_KEY="$(printf '%s' "${SUPPLIER_AUDIT_ENC_KEY}" | tr -d '[:space:]')"
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "${{ vars.ALPHA_EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -75,18 +75,34 @@ require_env_entry() {
 # permanently unreadable, reported as an authentication failure (i.e. as possible tampering).
 # So resolve it up front: a value passed in by the workflow wins and is persisted, otherwise
 # the one already on the box must be there and non-empty.
+# Trim leading/trailing whitespace. AuditPayloadCipher calls .trim() before decoding, so a key
+# with a stray newline — the normal shape of `openssl rand -base64 32` piped straight into a
+# secret — is valid at runtime, and this guard must not reject what the service would accept.
+trim_space() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  printf '%s' "${v}"
+}
+
 require_supplier_audit_key() {
-  local existing
+  local existing supplied
   existing="$(grep -E "^SUPPLIER_AUDIT_ENC_KEY=" "${ENV_FILE}" | head -n1 | cut -d= -f2- || true)"
   existing="${existing%\'}"
   existing="${existing#\'}"
+  existing="$(trim_space "${existing}")"
+  supplied="$(trim_space "${SUPPLIER_AUDIT_ENC_KEY:-}")"
 
-  if [[ -n "${SUPPLIER_AUDIT_ENC_KEY:-}" ]]; then
-    if ! [[ "${SUPPLIER_AUDIT_ENC_KEY}" =~ ^[A-Za-z0-9+/]{43}=$ ]]; then
+  if [[ -n "${supplied}" ]]; then
+    # Padding is optional: Base64.getDecoder() accepts an unpadded 43-char key, so requiring the
+    # '=' would reject a key the service decodes fine.
+    if ! [[ "${supplied}" =~ ^[A-Za-z0-9+/]{43}=?$ ]]; then
       echo "ERROR: SUPPLIER_AUDIT_ENC_KEY must be 32 bytes of base64 (openssl rand -base64 32)." >&2
       exit 1
     fi
-    if [[ -n "${existing}" && "${existing}" != "${SUPPLIER_AUDIT_ENC_KEY}" ]]; then
+    # Compare unpadded: a 32-byte key takes exactly one '=', so the padded and unpadded
+    # spellings are the same key and must not read as a rotation.
+    if [[ -n "${existing}" && "${existing%=}" != "${supplied%=}" ]]; then
       echo "ERROR: SUPPLIER_AUDIT_ENC_KEY differs from the key already on this box." >&2
       echo "Rotating it here would orphan every exchange-audit payload sealed with the old" >&2
       echo "key. Rotate deliberately instead: move the current key into" >&2
@@ -95,7 +111,7 @@ require_supplier_audit_key() {
       exit 1
     fi
     local quoted
-    quoted="$(env_single_quote "${SUPPLIER_AUDIT_ENC_KEY}")"
+    quoted="$(env_single_quote "${supplied}")"
     if grep -q "^SUPPLIER_AUDIT_ENC_KEY=" "${ENV_FILE}"; then
       sed -i "s|^SUPPLIER_AUDIT_ENC_KEY=.*|SUPPLIER_AUDIT_ENC_KEY=${quoted}|" "${ENV_FILE}"
     else

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -68,6 +68,52 @@ require_env_entry() {
   fi
 }
 
+# pos-supplier seals its exchange-audit payloads with SUPPLIER_AUDIT_ENC_KEY (ADR-0050 §7)
+# and refuses to start without one outside the dev/test profiles. Deploying it with the key
+# absent would fail late, in the tier --wait, after every image had already been pulled — and
+# a key that changes between deploys makes every payload written under the old one
+# permanently unreadable, reported as an authentication failure (i.e. as possible tampering).
+# So resolve it up front: a value passed in by the workflow wins and is persisted, otherwise
+# the one already on the box must be there and non-empty.
+require_supplier_audit_key() {
+  local existing
+  existing="$(grep -E "^SUPPLIER_AUDIT_ENC_KEY=" "${ENV_FILE}" | head -n1 | cut -d= -f2- || true)"
+  existing="${existing%\'}"
+  existing="${existing#\'}"
+
+  if [[ -n "${SUPPLIER_AUDIT_ENC_KEY:-}" ]]; then
+    if ! [[ "${SUPPLIER_AUDIT_ENC_KEY}" =~ ^[A-Za-z0-9+/]{43}=$ ]]; then
+      echo "ERROR: SUPPLIER_AUDIT_ENC_KEY must be 32 bytes of base64 (openssl rand -base64 32)." >&2
+      exit 1
+    fi
+    if [[ -n "${existing}" && "${existing}" != "${SUPPLIER_AUDIT_ENC_KEY}" ]]; then
+      echo "ERROR: SUPPLIER_AUDIT_ENC_KEY differs from the key already on this box." >&2
+      echo "Rotating it here would orphan every exchange-audit payload sealed with the old" >&2
+      echo "key. Rotate deliberately instead: move the current key into" >&2
+      echo "SUPPLIER_AUDIT_ENC_PREVIOUS_KEYS as '<keyId>:<base64>' and bump" >&2
+      echo "SUPPLIER_AUDIT_ENC_KEY_ID before changing this value." >&2
+      exit 1
+    fi
+    local quoted
+    quoted="$(env_single_quote "${SUPPLIER_AUDIT_ENC_KEY}")"
+    if grep -q "^SUPPLIER_AUDIT_ENC_KEY=" "${ENV_FILE}"; then
+      sed -i "s|^SUPPLIER_AUDIT_ENC_KEY=.*|SUPPLIER_AUDIT_ENC_KEY=${quoted}|" "${ENV_FILE}"
+    else
+      printf 'SUPPLIER_AUDIT_ENC_KEY=%s\n' "${quoted}" >> "${ENV_FILE}"
+    fi
+    return 0
+  fi
+
+  if [[ -z "${existing}" ]]; then
+    echo "ERROR: SUPPLIER_AUDIT_ENC_KEY is empty or missing in ${ENV_FILE} and none was" >&2
+    echo "supplied by the deploy. pos-supplier will not start without it. Generate one with" >&2
+    echo "  openssl rand -base64 32" >&2
+    echo "and set it as the SUPPLIER_AUDIT_ENC_KEY repository secret (or add it to the" >&2
+    echo "on-box env file) before deploying." >&2
+    exit 1
+  fi
+}
+
 should_run_docker_prune() {
   if ! [[ "${DOCKER_PRUNE_INTERVAL_HOURS}" =~ ^[0-9]+$ ]]; then
     echo "Skipping Docker prune: DOCKER_PRUNE_INTERVAL_HOURS must be an integer, got '${DOCKER_PRUNE_INTERVAL_HOURS}'." >&2
@@ -244,6 +290,7 @@ DOMAIN_SERVICES=(
   pos-people-contact
   pos-price
   pos-shop-manager
+  pos-supplier
   pos-tax
   pos-warranty
   pos-workorder
@@ -270,6 +317,7 @@ if [[ "${MODE}" == "config-only" ]]; then
   require_env_entry BACKEND_TAG
   require_env_entry ECR_REGISTRY
   require_env_entry SECURITY_SEED_ADMIN_PASSWORD_HASH
+  require_supplier_audit_key
 else
   if grep -q '^BACKEND_TAG=' "${ENV_FILE}"; then
     sed -i "s/^BACKEND_TAG=.*/BACKEND_TAG=${IMAGE_TAG}/" "${ENV_FILE}"
@@ -299,6 +347,8 @@ else
   else
     printf 'ECR_REGISTRY=%s\n' "${ECR_REGISTRY}" >> "${ENV_FILE}"
   fi
+
+  require_supplier_audit_key
 
   aws ecr get-login-password --region us-east-1 \
     | docker login --username AWS --password-stdin "${ECR_REGISTRY}"

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -284,6 +284,7 @@ DOMAIN_SERVICES=(
   pos-inventory
   pos-invoice
   pos-location
+  pos-marketing
   pos-mcp-server
   pos-order
   pos-people

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -159,6 +159,14 @@ services:
     environment:
       POS_LOCATION_KAFKA_ENABLED: "true"
 
+  pos-marketing:
+    image: ${ECR_REGISTRY}/durion/pos-marketing:${BACKEND_TAG}
+    restart: unless-stopped
+    logging: *logging
+    # No POS_MARKETING_KAFKA_ENABLED override: unlike the services above, the base
+    # compose already defaults this flag on, so the campaign/redemption publisher and
+    # the customer.events.v1 suppression replica are live as committed.
+
   pos-mcp-server:
     image: ${ECR_REGISTRY}/durion/pos-mcp-server:${BACKEND_TAG}
     restart: unless-stopped

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -217,6 +217,11 @@ services:
     environment:
       POS_SHOP_MANAGER_KAFKA_ENABLED: "true"
 
+  pos-supplier:
+    image: ${ECR_REGISTRY}/durion/pos-supplier:${BACKEND_TAG}
+    restart: unless-stopped
+    logging: *logging
+
   pos-tax:
     image: ${ECR_REGISTRY}/durion/pos-tax:${BACKEND_TAG}
     restart: unless-stopped

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -67,6 +67,17 @@ scrape_configs:
           service: 'pos-accounting'
           application: 'pos-accounting'
 
+  - job_name: 'pos-bulk-loader'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-bulk-loader:8080']
+        labels:
+          service: 'pos-bulk-loader'
+          application: 'pos-bulk-loader'
+
   - job_name: 'pos-catalog'
     metrics_path: '/actuator/prometheus'
     basic_auth:
@@ -88,6 +99,17 @@ scrape_configs:
         labels:
           service: 'pos-customer'
           application: 'pos-customer'
+
+  - job_name: 'pos-documents'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-documents:8092']
+        labels:
+          service: 'pos-documents'
+          application: 'pos-documents'
 
   - job_name: 'pos-event-receiver'
     metrics_path: '/actuator/prometheus'
@@ -151,6 +173,17 @@ scrape_configs:
   # SecurityConfiguration @Imports GatewaySecurityConfig, whose @Order(1) chain requires
   # httpBasic + hasRole('ACTUATOR_METRICS') on /actuator/prometheus, and the service
   # inherits *pos-security-client-env so the credentials below are the ones it expects.
+  - job_name: 'pos-marketing'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-marketing:8080']
+        labels:
+          service: 'pos-marketing'
+          application: 'pos-marketing'
+
   - job_name: 'pos-mcp-server'
     metrics_path: '/actuator/prometheus'
     basic_auth:
@@ -162,6 +195,17 @@ scrape_configs:
           service: 'pos-mcp-server'
           application: 'pos-mcp-server'
 
+  - job_name: 'pos-order'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-order:8080']
+        labels:
+          service: 'pos-order'
+          application: 'pos-order'
+
   - job_name: 'pos-people'
     metrics_path: '/actuator/prometheus'
     basic_auth:
@@ -172,6 +216,17 @@ scrape_configs:
         labels:
           service: 'pos-people'
           application: 'pos-people'
+
+  - job_name: 'pos-people-contact'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-people-contact:8080']
+        labels:
+          service: 'pos-people-contact'
+          application: 'pos-people-contact'
 
   - job_name: 'pos-price'
     metrics_path: '/actuator/prometheus'
@@ -206,6 +261,28 @@ scrape_configs:
           service: 'pos-shop-manager'
           application: 'pos-shop-manager'
 
+  - job_name: 'pos-supplier'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-supplier:8080']
+        labels:
+          service: 'pos-supplier'
+          application: 'pos-supplier'
+
+  - job_name: 'pos-tax'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-tax:8091']
+        labels:
+          service: 'pos-tax'
+          application: 'pos-tax'
+
   - job_name: 'pos-vehicle-inventory'
     metrics_path: '/actuator/prometheus'
     basic_auth:
@@ -216,6 +293,17 @@ scrape_configs:
         labels:
           service: 'pos-vehicle-inventory'
           application: 'pos-vehicle-inventory'
+
+  - job_name: 'pos-warranty'
+    metrics_path: '/actuator/prometheus'
+    basic_auth:
+      username: 'prometheus_scraper'
+      password: 'durion-local-prom-scrape-password'
+    static_configs:
+      - targets: ['pos-warranty:8080']
+        labels:
+          service: 'pos-warranty'
+          application: 'pos-warranty'
 
   - job_name: 'pos-workorder'
     metrics_path: '/actuator/prometheus'


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — deployment/infrastructure fix, no capability surface
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:platform` (deployment + observability config)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — no API or event behavior changes. This PR touches only
`.github/workflows/build-push-ecr.yml`, `deployment/alpha/*`, and
`observability/prometheus.yml`; no controllers, DTOs, events, OpenAPI specs, or
validation/error models. Contract Sync Enforcement reports no contract-relevant
changes for these paths.

## Contract Chain (when a Controller changed)
No controller changed, so none of these apply.

- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

**What changed**

Three services had drifted out of the lists that actually deploy and observe
them. A service reaches `main`, gets its `docker-compose.yml` entry, and is then
silently absent from the alpha deployment path.

*pos-supplier — never deployed at all.* Missing from all three lists:

| File | Gap | Consequence |
|---|---|---|
| `build-push-ecr.yml` `ALL_SERVICES_JSON` | not listed | no image at the whole-stack `BACKEND_TAG` |
| `deployment/alpha/docker-compose.prod.yml` | no `image:` override | keeps the base `build:` context, unusable on the box |
| `deployment/alpha/deploy-backend.sh` `DOMAIN_SERVICES` | not listed | never pulled or started, in either deploy mode |

Note the changed-path branch of `detect-services` *did* select pos-supplier — it
filters on the module having a `Dockerfile` — so per-module pushes worked. The
gap only shows on whole-stack deploys, which is what `AUTO_DEPLOY_ALPHA` forces
and what alpha actually uses.

*pos-marketing — half wired.* It is in `ALL_SERVICES_JSON`, so its image has been
published under every whole-stack tag all along, but it had no `image:` override
and no `DOMAIN_SERVICES` entry, so nothing ever named it in a `compose up` and it
has never run on alpha. It needs no `KAFKA_ENABLED` override in the prod file:
unlike its neighbours there, the base compose already defaults
`POS_MARKETING_KAFKA_ENABLED` on.

*Prometheus scrape config.* Eight deployed services had no scrape job at all —
`pos-bulk-loader`, `pos-documents`, `pos-marketing`, `pos-order`,
`pos-people-contact`, `pos-supplier`, `pos-tax`, `pos-warranty` — so their JVM,
HTTP and Micrometer metrics were absent from the alpha dashboards and from
anything alerting off them. All eight expose `health,info,metrics,prometheus`
and inherit scrape credentials from the shared `x-pos-security-client-env`
anchor, so each needs only the standard job block. Targets follow the
**container** port, not the host mapping: `pos-tax` listens on 8091 and
`pos-documents` on 8092 (both move `SERVER_PORT`/`MANAGEMENT_SERVER_PORT` off
the default and neither publishes a host port); the other six are on 8080.

*Exchange-audit key gate.* pos-supplier seals its stored exchange payloads with
`SUPPLIER_AUDIT_ENC_KEY` (ADR-0050 §7) and refuses to start without one outside
the dev/test profiles. Simply adding it to the start order would have turned a
missing key into a late failure in the tier `--wait`, after every image had been
pulled. `require_supplier_audit_key` resolves the key before any pulls, in both
full and config-only mode: a value supplied by the workflow is validated as 32
bytes of base64 and persisted to the on-box env file, and afterwards the stored
copy suffices — so the repository secret is only needed once. A supplied key
that *differs* from the stored one is rejected rather than applied, because
silently rotating it makes every payload sealed with the old key permanently
unreadable, and that surfaces later as an authentication failure — i.e. as
apparent tampering — for data the deployment itself destroyed.

**Why**

`AUTO_DEPLOY_ALPHA` forces a full rebuild precisely so every image exists at the
single `BACKEND_TAG` the alpha stack deploys. A service absent from that list has
no image at the tag, so it cannot be deployed as part of the stack no matter how
often it is built. After this PR the four lists agree: every `pos-*` module with a
`build:` context has an image override, is started by the deploy script, and is
scraped.

## ⚠️ Operator prerequisite before merge

`SUPPLIER_AUDIT_ENC_KEY` must exist as a repository secret **or** in
`/opt/durion/alpha/.env` before the next alpha deploy or config sync. Generate
with `openssl rand -base64 32`. Without it, both paths now stop early with
instructions rather than deploying a service that cannot start. Note this
affects `sync-alpha-config` too, which fires on merge because this PR changes
`docker-compose.prod.yml` and `deploy-backend.sh`.

## Tests

No unit or integration tests — the change is entirely CI/deployment config, with
no production Java touched.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated

**How it was verified**

- `require_supplier_audit_key` exercised against a scratch env file across all
  seven paths: missing key, key provided and written, same key re-supplied
  (idempotent), stored-only with no env var, mismatched key (rejected),
  malformed non-base64 (rejected), and present-but-empty entry (rejected).
- `bash -n deployment/alpha/deploy-backend.sh` — parses clean.
- Both compose files and `prometheus.yml` parse as YAML; the workflow YAML
  parses after the `--parameters` JSON edit.
- Cross-checked the four lists programmatically: no buildable `pos-*` service
  lacks an image override, none is overridden but never started, and none is
  deployed but unscraped. All three sets are now empty.
- Confirmed each of the eight new scrape targets exposes
  `/actuator/prometheus` and carries the scrape credentials.

## Risk & Rollback

- **Risk level: Medium.** Two services start on alpha for the first time, so the
  deploy's tier `--wait` now gates on two more healthchecks. `DOMAIN_SERVICES`
  goes from 19 to 21, still 4 batches of 6. The new fail-fast key check can stop
  a deploy that previously ran — deliberately, since pos-supplier cannot start
  without the key regardless; the check just makes it fail in seconds rather
  than after a full image pull.
- **Rollback:** revert the two commits. Nothing is stateful — no migrations, no
  data writes. The env-file line the script may add is inert once pos-supplier
  is no longer started.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/pos-supplier-push-deployment-30pcvp`; no cap id was assigned for this fix
- [ ] PR title starts with `[CAP:<cap-id>]` — same reason
- [ ] Links to parent + child issues are present — no tracking issue exists for this
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending first run

## Follow-up not included here

`kafka-topic-init` in `docker-compose.yml` provisions only the `workorder`,
`customer`, `people-contact` and `invoice` topic families. `marketing.events.v1`
is not among them, so it will be broker-auto-created on first publish
(`KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"`) without the explicit
retention/cleanup tuning the listed topics get. This is pre-existing and already
true of `warranty.events.v1` and `vehicle.events.v1`, both deployed with Kafka
on today, so pos-marketing is no worse off than its peers — but the topic-init
list is worth reconciling separately.

Given this drift has now appeared three times, a
`scripts/ci/check-deploy-service-drift.sh` asserting that every `pos-*` module
with a `Dockerfile` and a compose service appears in all four lists would stop it
recurring; it fits the existing `check-*-drift.sh` pattern in `pr-checks.yml`.
Left out here as scope beyond the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4XwB3DomvpAQrHN9iiy5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4XwB3DomvpAQrHN9iiy5R)_